### PR TITLE
hotfix [#69] ArtistResolver에서 같은 객체를 계속 탐색하는 것을 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -26,7 +26,7 @@ public class PerformanceController {
 
     @GetMapping("/concerts/{concertId}")
     public ResponseEntity<BaseResponse<?>> getConcertInfo(@RequestHeader("Authorization") Long userId,
-                                                          @PathVariable @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long concertId) {
+                                                          @PathVariable("concertId") @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long concertId) {
         ConcertDetailDTO concertDetailDTO = performanceFacade.getConcertDetailInfo(concertId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, ConcertDetailResponse.from(concertDetailDTO));
     }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #69

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] ArtistResolver에서 같은 객체를 계속 탐색하는 것을 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
스택오버플로우 발생으로 인해 수정합니다.
HashMap 타입의 objectTrack변수를 ArtistResolver 클래스에 추가해 기존 객체를 탐색하는 것을 방지합니다.