### PR TITLE
fix [#76] ArtistResolver의 load 함수에서 target이 리스트 타입인 경우 탐색 가능하도록 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
@@ -99,9 +99,6 @@ public class ArtistResolver {
     // 리플렉션을 사용해 타겟 오브젝트를 재귀적으로 순회하며 아티스트 아이디를 수집하는 함수
     // TODO: 추후에 메소드 분리 리펙토링 예정
     private void collect(final Object target) {
-        if (target !=null) {
-            System.out.println(target);
-        }
         // 이미 탐색한 객체인 경우
         if (target == null || objectTrack.containsKey(target)) {
             return;

--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/SpotifyAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/SpotifyAPIHandler.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.global.util.artistsearcher;
 import com.neovisionaries.i18n.CountryCode;
 import java.io.IOException;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.List;
@@ -62,6 +63,10 @@ public class SpotifyAPIHandler {
     }
 
     public List<ConfetiArtist> findArtistsByArtistIds(final List<String> artistIds) {
+        if (artistIds.isEmpty()) {
+            return new ArrayList<>();
+        }
+
         try {
             Artist[] artists = spotifyApi.getSeveralArtists(
                             artistIds.toArray(new String[0])


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #76 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] ArtistResolver에 리스트 타입 타겟도 탐색 가능하도록 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="340" alt="image" src="https://github.com/user-attachments/assets/ebdcf200-de29-4bb9-b83e-a127ede3e496" />

load 함수의 target 변수가 리스트 타입인 경우 target.getClass()의 결과가 ArrayList 클래스입니다.
반대로 load 함수에서 리플렉션을 사용해 필드 값을 순회하다 Field 변수가 리스트 타입인 경우 field.getType()의 결과가 List.class 입니다.

부모 인터페이스를 찾아보는 방법으로 해결할 수 있을 것 같지만, 성능 최적화, 구현 난이도가 높다고 생각해 스프린트에 구현하기로 결정했습니다.
현재는 ArrayList.class, List.class 모두 mapper에 등록했습니다.

<img width="476" alt="image" src="https://github.com/user-attachments/assets/288a4a64-1d7b-475b-be95-60e79ec00f59" />

load 함수에 현재 타입이 리스트인 경우 처리하도록 구현했습니다.
