### PR TITLE
hotfix [#81] ArtistResolver 수동으로 매핑하는 방법으로 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/domain/festival/Festival.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/Festival.java
@@ -72,7 +72,7 @@ public class Festival {
     private String price;
 
     @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL, orphanRemoval = true)
-    private List<FestivalDate> dates= new ArrayList<>();
+    private List<FestivalDate> dates = new ArrayList<>();
 
     @OneToMany(mappedBy = "festival", cascade = CascadeType.REMOVE)
     private List<FestivalFavorite> festivalFavorites = new ArrayList<>();

--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
@@ -17,6 +17,7 @@ import org.sopt.confeti.global.util.IntegrateFunction;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArtistResolver {
 
+    // 기존에 조회할 클래스를 매핑
     private final ConcurrentHashMap<Class<?>, IntegrateFunction> collectByTypeMapper = new ConcurrentHashMap<Class<?>, IntegrateFunction>() {{
         put(ArtistFavorite.class, args -> {
             collectArtistFavorite(args[0]);
@@ -67,10 +68,12 @@ public class ArtistResolver {
             return;
         }
 
+        // 주어진 타겟이 리스트일 경우
         if (isListType(target)) {
             List<Object> objects = (List<Object>) target;
 
             objects.forEach(object -> {
+                // Mapper에 등록된 클래스 타입인 경우
                 if (collectByTypeMapper.containsKey(object.getClass())) {
                     collectByTypeMapper.get(object.getClass())
                             .apply(object);
@@ -80,6 +83,7 @@ public class ArtistResolver {
             return;
         }
 
+        // Mapper에 등록된 클래스 타입인 경우
         if (collectByTypeMapper.containsKey(target.getClass())) {
             collectByTypeMapper.get(target.getClass()).apply(target);
         }

--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
@@ -1,76 +1,54 @@
 package org.sopt.confeti.global.util.artistsearcher;
 
-import java.lang.reflect.Field;
-import java.lang.reflect.Modifier;
-import java.time.LocalDate;
-import java.time.LocalDateTime;
-import java.time.LocalTime;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
-import java.util.LinkedHashSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.annotation.Resolver;
+import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;
+import org.sopt.confeti.domain.concert.Concert;
+import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festivaldate.FestivalDate;
 import org.sopt.confeti.global.util.IntegrateFunction;
-import org.springframework.aop.support.AopUtils;
 
 @Resolver
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArtistResolver {
 
-    private static final boolean ACCESS_ALLOW = true;
-
-    private final Set<Class<?>> noCustomReferenceTypes = new LinkedHashSet<Class<?>>(
-            Arrays.asList(
-                Integer.class, Long.class, Float.class, Double.class,
-                LocalDate.class, LocalDateTime.class, LocalTime.class,
-                String.class
-            )
-    );
-
     private final ConcurrentHashMap<Class<?>, IntegrateFunction> collectByTypeMapper = new ConcurrentHashMap<Class<?>, IntegrateFunction>() {{
-        put(ArrayList.class, args -> {
-            if (!(args[0] instanceof List)) {
-                // TODO:
-                // 예외 처리 추가
-                throw new RuntimeException();
-            }
-
-            collectByListType((List<?>) args[0]);
+        put(ArtistFavorite.class, args -> {
+            collectArtistFavorite(args[0]);
             return null;
         });
-        put(List.class, args -> {
-            if (!(args[0] instanceof List)) {
-                // TODO:
-                // 예외 처리 추가
-                throw new RuntimeException();
-            }
-
-            collectByListType((List<?>) args[0]);
+        put(Concert.class, args -> {
+            collectConcert(args[0]);
+            return null;
+        });
+        put(Festival.class, args -> {
+            collectFestival(args[0]);
+            return null;
+        });
+        put(FestivalDate.class, args -> {
+            collectFestivalDate(args[0]);
             return null;
         });
     }};
 
     private List<String> artistIds;
     private HashMap<String, ConfetiArtist> artistMapper;
-    private HashMap<Object, Boolean> objectTrack;
 
     private final SpotifyAPIHandler spotifyAPIHandler;
 
     private void prologue() {
         artistIds = new ArrayList<>();
         artistMapper = new HashMap<>();
-        objectTrack = new HashMap<>();
     }
 
     private void epilogue() {
         artistIds.clear();
         artistMapper.clear();
-        objectTrack.clear();
     }
 
     // Spotify API를 사용해 아티스트를 로드하는 엔트리 포인트
@@ -84,6 +62,74 @@ public class ArtistResolver {
         epilogue();
     }
 
+    private void collect(final Object target) {
+        if (target == null) {
+            return;
+        }
+
+        if (isListType(target)) {
+            List<Object> objects = (List<Object>) target;
+
+            objects.forEach(object -> {
+                if (collectByTypeMapper.containsKey(object.getClass())) {
+                    collectByTypeMapper.get(object.getClass())
+                            .apply(object);
+                }
+            });
+
+            return;
+        }
+
+        if (collectByTypeMapper.containsKey(target.getClass())) {
+            collectByTypeMapper.get(target.getClass()).apply(target);
+        }
+    }
+
+    private boolean isListType(final Object target) {
+        return target.getClass() == ArrayList.class;
+    }
+
+    private void collectArtistFavorite(final Object target) {
+        ArtistFavorite artistFavorite = (ArtistFavorite) target;
+        ConfetiArtist confetiArtist = artistFavorite.getArtist();
+        artistIds.add(confetiArtist.getArtistId());
+        artistMapper.put(confetiArtist.getArtistId(), artistFavorite.getArtist());
+    }
+
+    private void collectConcert(final Object target) {
+        Concert concert = (Concert) target;
+        concert.getArtists().forEach(artist -> {
+                    artistIds.add(artist.getArtist().getArtistId());
+                    artistMapper.put(
+                            artist.getArtist().getArtistId(),
+                            artist.getArtist()
+                    );
+                });
+    }
+
+    private void collectFestival(final Object target) {
+        Festival festival = (Festival) target;
+        festival.getDates().stream()
+                .flatMap(date -> date.getStages().stream())
+                .flatMap(stage -> stage.getTimes().stream())
+                .flatMap(time -> time.getArtists().stream())
+                .forEach(artist -> {
+                    artistIds.add(artist.getArtist().getName());
+                    artistMapper.put(artist.getArtist().getArtistId(), artist.getArtist());
+                });
+    }
+
+    private void collectFestivalDate(final Object target) {
+        FestivalDate festivalDate = (FestivalDate) target;
+        festivalDate.getStages().stream()
+                .flatMap(stage -> stage.getTimes().stream())
+                .flatMap(time -> time.getArtists().stream())
+                .forEach(artist -> {
+                    artistIds.add(artist.getArtist().getName());
+                    artistMapper.put(artist.getArtist().getArtistId(), artist.getArtist());
+                });
+    }
+
     private void injection(final List<ConfetiArtist> confetiArtists) {
         confetiArtists.forEach((confetiArtist -> {
             ConfetiArtist mappedConfetiArtist = artistMapper.get(confetiArtist.getArtistId());
@@ -94,101 +140,5 @@ public class ArtistResolver {
 
     private List<ConfetiArtist> searchByArtistIds(final List<String> artistIds) {
         return spotifyAPIHandler.findArtistsByArtistIds(artistIds);
-    }
-
-    // 리플렉션을 사용해 타겟 오브젝트를 재귀적으로 순회하며 아티스트 아이디를 수집하는 함수
-    // TODO: 추후에 메소드 분리 리펙토링 예정
-    private void collect(final Object target) {
-        // 이미 탐색한 객체인 경우
-        if (target == null || objectTrack.containsKey(target)) {
-            return;
-        }
-
-        // 오브젝트 트랙에 현재 탐색 대상 객체를 추가
-        objectTrack.put(target, true);
-
-        // 현재 오브젝트가 ConfetiArtist 타입인 경우
-        if (isConfetiArtistClass(target)) {
-            ConfetiArtist artist = (ConfetiArtist) target;
-
-            artistIds.add(artist.getArtistId());
-            artistMapper.put(artist.getArtistId(), artist);
-            return;
-        } else if (collectByTypeMapper.containsKey(target.getClass())) {
-            // 현재 오브젝트가 정해진 처리 방법이 필요한 타입인 경우 (현재는 List)
-            collectByTypeMapper.get(target.getClass()).apply(
-                    target
-            );
-            return;
-        }
-
-        // 필드에 있는 객체 목록 확인
-        Class<?> targetClass = target.getClass();
-        Arrays.stream(targetClass.getDeclaredFields()).forEach((Field field) -> {
-            if (isReferenceType(field) && isNoCustomReferenceType(field)) {
-                if (isConfetiArtistClass(field)) {
-                    ConfetiArtist artist = extractConfetiArtist(target, field);
-
-                    artistIds.add(artist.getArtistId());
-                    artistMapper.put(artist.getArtistId(), artist);
-                    return;
-                }
-
-                setAccessibleIfPrivateOrProtected(field);
-
-                try {
-                    if (collectByTypeMapper.containsKey(field.getType())) {
-                        collectByTypeMapper.get(field.getType()).apply(
-                                field.get(target)
-                        );
-
-                        return;
-                    }
-
-                    collect(field.get(target));
-                } catch (IllegalAccessException e) {
-                    throw new RuntimeException(e);
-                }
-            }
-        });
-    }
-
-    private void collectByListType(final List<?> objects) {
-        objects.forEach(this::collect);
-    }
-
-    private void setAccessibleIfPrivateOrProtected(final Field field) {
-        if (
-                Modifier.isPrivate(field.getModifiers()) || Modifier.isProtected(field.getModifiers())
-        ) {
-            field.setAccessible(ACCESS_ALLOW);
-        }
-    }
-
-    private boolean isNoCustomReferenceType(final Field field) {
-        return !noCustomReferenceTypes.contains(field.getType());
-    }
-
-    private boolean isReferenceType(final Field field) {
-        return !field.getType().isPrimitive();
-    }
-
-    private boolean isConfetiArtistClass(final Field field) {
-        return field.getType().isAssignableFrom(ConfetiArtist.class);
-    }
-
-    private boolean isConfetiArtistClass(final Object object) {
-        return object.getClass().isAssignableFrom(ConfetiArtist.class);
-    }
-
-    private ConfetiArtist extractConfetiArtist(final Object target, final Field field)
-            throws RuntimeException {
-        try {
-            setAccessibleIfPrivateOrProtected(field);
-            return (ConfetiArtist) field.get(target);
-        } catch (IllegalAccessException e) {
-            throw new RuntimeException();
-        }
-
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #81 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] ArtistResolver 수동으로 매핑하는 방법으로 변경


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
기존 리플렉션을 사용하는 방법은 확장성을 고려해서 선택했지만 구현에 실패했습니다.
따라서 조회 대상 클래스에 따라 조회하는 방법을 지정한 함수를 연결하는 방법으로 바꿨습니다.

<img width="518" alt="image" src="https://github.com/user-attachments/assets/5a305567-921b-44d8-b2a9-9bbca93a429f" />

타겟이 리스트일 경우 순회하며 탐색하고, 아닐 경우 기존에 등록된 클래스인지 확인합니다.
이후 기존에 등록된 클래스일 경우 지정된 함수를 실행해 아티스트 아이디를 모으고, 아티스트 아이디와 객체를 매퍼에 등록해 SpotifyAPIHandler에서 정보를 조회한 후 주입될 수 있도록 합니다.