### PR TITLE
refactor [#87] 콘서트 정보 조회 API 변경에 따른 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -28,6 +28,10 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
+    // psy
+    implementation 'p6spy:p6spy:3.9.1'
+    implementation 'com.github.gavlyukovskiy:datasource-decorator-spring-boot-autoconfigure:1.9.0'
+
     // spotify api
     implementation 'se.michaelthelin.spotify:spotify-web-api-java:8.4.1'
 

--- a/src/main/java/org/sopt/confeti/api/artist/controller/ArtistController.java
+++ b/src/main/java/org/sopt/confeti/api/artist/controller/ArtistController.java
@@ -1,0 +1,33 @@
+package org.sopt.confeti.api.artist.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.artist.dto.response.SearchArtistResponse;
+import org.sopt.confeti.api.artist.facade.ArtistFacade;
+import org.sopt.confeti.api.artist.facade.dto.response.SearchArtistDTO;
+import org.sopt.confeti.api.user.facade.UserInfoFacade;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/artists")
+public class ArtistController {
+
+    private final ArtistFacade artistFacade;
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<?>> search(
+            @RequestHeader(name = "Authorization", required = false) Long userId,
+            @RequestParam(name = "search") String keyword
+    ) {
+        SearchArtistDTO artist = artistFacade.searchByKeyword(userId, keyword);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, SearchArtistResponse.from(artist));
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/artist/dto/response/SearchArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/api/artist/dto/response/SearchArtistResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.api.artist.dto.response;
+
+import org.sopt.confeti.api.artist.facade.dto.response.SearchArtistDTO;
+
+public record SearchArtistResponse(
+        SearchArtistSingleResponse artist
+) {
+    public static SearchArtistResponse from(final SearchArtistDTO searchArtistDTO) {
+        return new SearchArtistResponse(
+                SearchArtistSingleResponse.from(searchArtistDTO)
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/artist/dto/response/SearchArtistSingleResponse.java
+++ b/src/main/java/org/sopt/confeti/api/artist/dto/response/SearchArtistSingleResponse.java
@@ -1,0 +1,24 @@
+package org.sopt.confeti.api.artist.dto.response;
+
+import java.time.LocalDate;
+import org.sopt.confeti.api.artist.facade.dto.response.SearchArtistDTO;
+
+public record SearchArtistSingleResponse(
+        String artistId,
+        String name,
+        String profileUrl,
+        LocalDate latestReleaseAt,
+        boolean isFavorite,
+        boolean isMultipleArtists
+) {
+    public static SearchArtistSingleResponse from(final SearchArtistDTO searchArtistDTO) {
+        return new SearchArtistSingleResponse(
+                searchArtistDTO.artistId(),
+                searchArtistDTO.name(),
+                searchArtistDTO.profileUrl(),
+                searchArtistDTO.latestReleaseAt(),
+                searchArtistDTO.isFavorite(),
+                searchArtistDTO.isMultipleArtists()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
@@ -1,0 +1,34 @@
+package org.sopt.confeti.api.artist.facade;
+
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.annotation.Facade;
+import org.sopt.confeti.api.artist.facade.dto.response.SearchArtistDTO;
+import org.sopt.confeti.domain.artistfavorite.application.ArtistFavoriteService;
+import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+import org.sopt.confeti.global.util.artistsearcher.SpotifyAPIHandler;
+import org.springframework.transaction.annotation.Transactional;
+
+@Facade
+@RequiredArgsConstructor
+public class ArtistFacade {
+
+    private final ArtistFavoriteService artistFavoriteService;
+    private final SpotifyAPIHandler spotifyAPIHandler;
+
+    @Transactional(readOnly = true)
+    public SearchArtistDTO searchByKeyword(final Long userId, final String keyword) {
+        Optional<ConfetiArtist> confetiArtist = spotifyAPIHandler.findArtistsByKeyword(keyword);
+
+        boolean isFavorite = false;
+
+        if (confetiArtist.isPresent() && userId != null) {
+            isFavorite = artistFavoriteService.isFavorite(userId, confetiArtist.get().getArtistId());
+        }
+
+        return SearchArtistDTO.from(
+                confetiArtist.orElse(ConfetiArtist.empty()),
+                isFavorite
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/artist/facade/dto/response/SearchArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/artist/facade/dto/response/SearchArtistDTO.java
@@ -1,0 +1,26 @@
+package org.sopt.confeti.api.artist.facade.dto.response;
+
+import java.time.LocalDate;
+import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+
+public record SearchArtistDTO(
+        String artistId,
+        String name,
+        String profileUrl,
+        LocalDate latestReleaseAt,
+        boolean isFavorite,
+        boolean isMultipleArtists
+) {
+    private static final boolean fixedIsMultipleArtists = false;
+
+    public static SearchArtistDTO from(final ConfetiArtist confetiArtist, final boolean isFavorite) {
+        return new SearchArtistDTO(
+                confetiArtist.getArtistId(),
+                confetiArtist.getName(),
+                confetiArtist.getProfileUrl(),
+                confetiArtist.getLatestReleaseAt(),
+                isFavorite,
+                fixedIsMultipleArtists
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -12,6 +12,7 @@ import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -29,12 +30,15 @@ import org.springframework.web.bind.annotation.RestController;
 public class PerformanceController {
 
     private final PerformanceFacade performanceFacade;
+    private final S3FileHandler s3FileHandler;
 
     @GetMapping("/concerts/{concertId}")
-    public ResponseEntity<BaseResponse<?>> getConcertInfo(@RequestHeader("Authorization") Long userId,
-                                                          @PathVariable("concertId") @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long concertId) {
+    public ResponseEntity<BaseResponse<?>> getConcertInfo(
+            @RequestHeader(name = "Authorization", required = false) Long userId,
+            @PathVariable("concertId") @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long concertId
+    ) {
         ConcertDetailDTO concertDetailDTO = performanceFacade.getConcertDetailInfo(concertId);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, ConcertDetailResponse.from(concertDetailDTO));
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, ConcertDetailResponse.of(concertDetailDTO, s3FileHandler));
     }
 
     @GetMapping("/festivals/{festivalId}")

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -4,9 +4,11 @@ import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.dto.request.CreateFestivalRequest;
 import org.sopt.confeti.api.performance.dto.response.ConcertDetailResponse;
+import org.sopt.confeti.api.performance.dto.response.FestivalDetailResponse;
 import org.sopt.confeti.api.performance.facade.PerformanceFacade;
 import org.sopt.confeti.api.performance.facade.dto.request.CreateFestivalDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ConcertDetailDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
@@ -33,6 +35,13 @@ public class PerformanceController {
                                                           @PathVariable("concertId") @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long concertId) {
         ConcertDetailDTO concertDetailDTO = performanceFacade.getConcertDetailInfo(concertId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, ConcertDetailResponse.from(concertDetailDTO));
+    }
+
+    @GetMapping("/festivals/{festivalId}")
+    public ResponseEntity<BaseResponse<?>> getFestivalInfo(@RequestHeader(name = "Authorization", required = false) Long userId,
+                                                           @PathVariable("festivalId") @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long festivalId) {
+        FestivalDetailDTO festivalDetailDTO = performanceFacade.getFestivalDetailInfo(userId, festivalId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, FestivalDetailResponse.from(festivalDetailDTO));
     }
 
     @PostMapping("/festivals")

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/ConcertDetailInfoResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/ConcertDetailInfoResponse.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.api.performance.dto.response;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import org.sopt.confeti.api.performance.facade.dto.response.ConcertDetailDTO;
+import org.sopt.confeti.global.util.S3FileHandler;
 
 public record ConcertDetailInfoResponse(
         long concertId,
@@ -21,11 +22,11 @@ public record ConcertDetailInfoResponse(
         String price,
         String infoImgUrl
 ) {
-    public static ConcertDetailInfoResponse from(final ConcertDetailDTO concertDetailDTO) {
+    public static ConcertDetailInfoResponse of(final ConcertDetailDTO concertDetailDTO, final S3FileHandler s3FileHandler) {
         return new ConcertDetailInfoResponse(
                 concertDetailDTO.concertId(),
-                concertDetailDTO.posterUrl(),
-                concertDetailDTO.posterBgUrl(),
+                s3FileHandler.getFileUrl(concertDetailDTO.posterPath()),
+                s3FileHandler.getFileUrl(concertDetailDTO.posterBgPath()),
                 concertDetailDTO.title(),
                 concertDetailDTO.subtitle(),
                 concertDetailDTO.startAt(),
@@ -37,7 +38,7 @@ public record ConcertDetailInfoResponse(
                 concertDetailDTO.ageRating(),
                 concertDetailDTO.reservationOffice(),
                 concertDetailDTO.price(),
-                concertDetailDTO.infoImgUrl()
+                s3FileHandler.getFileUrl(concertDetailDTO.infoImgPath())
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/ConcertDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/ConcertDetailResponse.java
@@ -2,17 +2,24 @@ package org.sopt.confeti.api.performance.dto.response;
 
 import java.util.List;
 import org.sopt.confeti.api.performance.facade.dto.response.ConcertDetailDTO;
+import org.sopt.confeti.global.util.S3FileHandler;
 
 public record ConcertDetailResponse(
         ConcertDetailInfoResponse concert,
+        boolean isOpen,
         List<ConcertDetailArtistResponse> concertArtists
 ) {
-    public static ConcertDetailResponse from(final ConcertDetailDTO concertDetailDTO) {
+    private static final int OPEN_CRITERIA = 4;
+
+    public static ConcertDetailResponse of(final ConcertDetailDTO concertDetailDTO, final S3FileHandler s3FileHandler) {
+        List<ConcertDetailArtistResponse> concertArtists = concertDetailDTO.artists().stream()
+                .map(ConcertDetailArtistResponse::from)
+                .toList();
+
         return new ConcertDetailResponse(
-                ConcertDetailInfoResponse.from(concertDetailDTO),
-                concertDetailDTO.artists().stream()
-                        .map(ConcertDetailArtistResponse::from)
-                        .toList()
+                ConcertDetailInfoResponse.of(concertDetailDTO, s3FileHandler),
+                concertArtists.size() > OPEN_CRITERIA,
+                concertArtists
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailArtistResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailArtistDTO;
+
+public record FestivalDetailArtistResponse(
+        String artistId,
+        String name,
+        String profileUrl
+) {
+    public static FestivalDetailArtistResponse from(final FestivalDetailArtistDTO artist) {
+        return new FestivalDetailArtistResponse(
+                artist.artistId(),
+                artist.name(),
+                artist.profileUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailDateResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailDateResponse.java
@@ -1,0 +1,29 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDateDTO;
+
+public record FestivalDetailDateResponse(
+        long festivalDateId,
+        String festivalAt,
+        boolean isOpen,
+        List<FestivalDetailArtistResponse> artists
+) {
+    private static final int OPEN_CRITERIA = 4;
+    private static final String FESTIVAL_AT_PREFIX = "Day ";
+
+    public static FestivalDetailDateResponse of(final FestivalDetailDateDTO festivalDate, final int order) {
+        List<FestivalDetailArtistResponse> artists = festivalDate.stages().stream()
+                .flatMap(date -> date.times().stream())
+                .flatMap(time -> time.artists().stream())
+                .map(FestivalDetailArtistResponse::from)
+                .toList();
+
+        return new FestivalDetailDateResponse(
+                festivalDate.festivalDateId(),
+                FESTIVAL_AT_PREFIX + order,
+                artists.size() > OPEN_CRITERIA,
+                artists
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailInfoResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailInfoResponse.java
@@ -1,0 +1,45 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
+
+public record FestivalDetailInfoResponse(
+        long festivalId,
+        String posterUrl,
+        String posterBgUrl,
+        String title,
+        String subtitle,
+        LocalDate startAt,
+        LocalDate endAt,
+        String area,
+        LocalDate reserveAt,
+        String reservationUrl,
+        String time,
+        String ageRating,
+        String reservationOffice,
+        String price,
+        String infoImgUrl,
+        boolean isFavorite
+) {
+    public static FestivalDetailInfoResponse from(final FestivalDetailDTO festival) {
+        return new FestivalDetailInfoResponse(
+                festival.festivalId(),
+                festival.festivalPosterUrl(),
+                festival.festivalPosterBgUrl(),
+                festival.festivalTitle(),
+                festival.festivalSubtitle(),
+                festival.festivalStartAt(),
+                festival.festivalEndAt(),
+                festival.festivalArea(),
+                festival.reserveAt(),
+                festival.reservationUrl(),
+                festival.time(),
+                festival.ageRating(),
+                festival.reservationOffice(),
+                festival.price(),
+                festival.festivalInfoImgUrl(),
+                festival.isFavorite()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailResponse.java
@@ -1,0 +1,23 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import java.util.List;
+import java.util.stream.IntStream;
+import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
+
+public record FestivalDetailResponse(
+        FestivalDetailInfoResponse festival,
+        List<FestivalDetailDateResponse> festivalDates
+) {
+    private static final int SPACE_BETWEEN_DATE_AND_IDX = 1;
+    public static FestivalDetailResponse from(final FestivalDetailDTO festival) {
+        return new FestivalDetailResponse(
+                FestivalDetailInfoResponse.from(festival),
+                IntStream.range(0, festival.dates().size())
+                        .mapToObj(idx ->
+                                FestivalDetailDateResponse.of(
+                                        festival.dates().get(idx), idx + SPACE_BETWEEN_DATE_AND_IDX)
+                        )
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -4,9 +4,12 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.annotation.Facade;
 import org.sopt.confeti.api.performance.facade.dto.request.CreateFestivalDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ConcertDetailDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
 import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.application.ConcertService;
+import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.festivalfavorite.application.FestivalFavoriteService;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -16,9 +19,10 @@ public class PerformanceFacade {
 
     private final ConcertService concertService;
     private final FestivalService festivalService;
+    private final FestivalFavoriteService festivalFavoriteService;
     private final S3FileHandler s3FileHandler;
 
-    @Transactional
+    @Transactional(readOnly = true)
     public ConcertDetailDTO getConcertDetailInfo(final long concertId) {
         Concert concert = concertService.getConcertDetailByConcertId(concertId);
         return ConcertDetailDTO.of(concert, s3FileHandler);
@@ -27,5 +31,17 @@ public class PerformanceFacade {
     @Transactional
     public void createFestival(final CreateFestivalDTO createFestivalDTO) {
         festivalService.create(createFestivalDTO);
+    }
+
+    @Transactional(readOnly = true)
+    public FestivalDetailDTO getFestivalDetailInfo(final Long userId, final long festivalId) {
+        boolean isFavorite = false;
+
+        if (userId != null) {
+            isFavorite = festivalFavoriteService.isFavorite(userId, festivalId);
+        }
+
+        Festival festival = festivalService.getFestivalDetailByFestivalId(festivalId);
+        return FestivalDetailDTO.of(festival, isFavorite, s3FileHandler);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -25,7 +25,7 @@ public class PerformanceFacade {
     @Transactional(readOnly = true)
     public ConcertDetailDTO getConcertDetailInfo(final long concertId) {
         Concert concert = concertService.getConcertDetailByConcertId(concertId);
-        return ConcertDetailDTO.of(concert, s3FileHandler);
+        return ConcertDetailDTO.from(concert);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ConcertDetailDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ConcertDetailDTO.java
@@ -4,7 +4,6 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.sopt.confeti.domain.concert.Concert;
-import org.sopt.confeti.global.util.S3FileHandler;
 
 public record ConcertDetailDTO(
         long concertId,
@@ -13,10 +12,10 @@ public record ConcertDetailDTO(
         LocalDate startAt,
         LocalDate endAt,
         String area,
-        String posterUrl,
-        String posterBgUrl,
-        String infoImgUrl,
-        String concertReservationBgUrl,
+        String posterPath,
+        String posterBgPath,
+        String infoImgPath,
+        String concertReservationBgPath,
         LocalDateTime reserveAt,
         String reservationUrl,
         String reservationOffice,
@@ -25,7 +24,7 @@ public record ConcertDetailDTO(
         String price,
         List<ConcertArtistDTO> artists
 ) {
-    public static ConcertDetailDTO of(final Concert concert, final S3FileHandler s3FileHandler) {
+    public static ConcertDetailDTO from(final Concert concert) {
         return new ConcertDetailDTO(
                 concert.getId(),
                 concert.getConcertTitle(),
@@ -33,10 +32,10 @@ public record ConcertDetailDTO(
                 concert.getConcertStartAt(),
                 concert.getConcertEndAt(),
                 concert.getConcertArea(),
-                s3FileHandler.getFileUrl(concert.getConcertPosterPath()),
-                s3FileHandler.getFileUrl(concert.getConcertPosterBgPath()),
-                s3FileHandler.getFileUrl(concert.getConcertInfoImgPath()),
-                s3FileHandler.getFileUrl(concert.getConcertReservationBgPath()),
+                concert.getConcertPosterPath(),
+                concert.getConcertPosterBgPath(),
+                concert.getConcertInfoImgPath(),
+                concert.getConcertReservationBgPath(),
                 concert.getReserveAt(),
                 concert.getReservationUrl(),
                 concert.getReservationOffice(),

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailArtistDTO.java
@@ -1,0 +1,22 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import java.time.LocalDate;
+import org.sopt.confeti.domain.festivalartist.FestivalArtist;
+import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+
+public record FestivalDetailArtistDTO(
+        String artistId,
+        String name,
+        String profileUrl,
+        LocalDate latestReleaseAt
+) {
+    public static FestivalDetailArtistDTO from(final FestivalArtist festivalArtist) {
+        ConfetiArtist confetiArtist = festivalArtist.getArtist();
+        return new FestivalDetailArtistDTO(
+                confetiArtist.getArtistId(),
+                confetiArtist.getName(),
+                confetiArtist.getProfileUrl(),
+                confetiArtist.getLatestReleaseAt()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailDTO.java
@@ -1,0 +1,55 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record FestivalDetailDTO(
+        long festivalId,
+        String festivalTitle,
+        String festivalSubtitle,
+        LocalDate festivalStartAt,
+        LocalDate festivalEndAt,
+        String festivalArea,
+        String festivalPosterUrl,
+        String festivalPosterBgUrl,
+        String festivalInfoImgUrl,
+        String festivalReservationBgUrl,
+        String festivalLogoUrl,
+        LocalDate reserveAt,
+        String reservationUrl,
+        String reservationOffice,
+        String ageRating,
+        String time,
+        String price,
+        boolean isFavorite,
+        List<FestivalDetailDateDTO> dates
+) {
+    public static FestivalDetailDTO of(final Festival festival, boolean isFavorite, final S3FileHandler s3FileHandler) {
+        return new FestivalDetailDTO(
+                festival.getId(),
+                festival.getFestivalTitle(),
+                festival.getFestivalSubtitle(),
+                festival.getFestivalStartAt(),
+                festival.getFestivalEndAt(),
+                festival.getFestivalArea(),
+                s3FileHandler.getFileUrl(festival.getFestivalPosterPath()),
+                s3FileHandler.getFileUrl(festival.getFestivalPosterBgPath()),
+                s3FileHandler.getFileUrl(festival.getFestivalInfoImgPath()),
+                s3FileHandler.getFileUrl(festival.getFestivalReservationBgPath()),
+                s3FileHandler.getFileUrl(festival.getFestivalLogoPath()),
+                festival.getReserveAt(),
+                festival.getReservationUrl(),
+                festival.getReservationOffice(),
+                festival.getAgeRating(),
+                festival.getTime(),
+                festival.getPrice(),
+                isFavorite,
+                festival.getDates().stream()
+                        .map(FestivalDetailDateDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailDateDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailDateDTO.java
@@ -1,0 +1,24 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.List;
+import org.sopt.confeti.domain.festivaldate.FestivalDate;
+
+public record FestivalDetailDateDTO(
+        long festivalDateId,
+        LocalDate festivalAt,
+        LocalTime openAt,
+        List<FestivalDetailStageDTO> stages
+) {
+    public static FestivalDetailDateDTO from(final FestivalDate festivalDate) {
+        return new FestivalDetailDateDTO(
+                festivalDate.getId(),
+                festivalDate.getFestivalAt(),
+                festivalDate.getOpenAt(),
+                festivalDate.getStages().stream()
+                        .map(FestivalDetailStageDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailStageDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailStageDTO.java
@@ -1,0 +1,22 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.domain.festivalstage.FestivalStage;
+
+public record FestivalDetailStageDTO(
+        long festivalStageId,
+        String name,
+        int order,
+        List<FestivalDetailTimeDTO> times
+) {
+    public static FestivalDetailStageDTO from(final FestivalStage festivalStage) {
+        return new FestivalDetailStageDTO(
+                festivalStage.getId(),
+                festivalStage.getName(),
+                festivalStage.getOrder(),
+                festivalStage.getTimes().stream()
+                        .map(FestivalDetailTimeDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailTimeDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailTimeDTO.java
@@ -1,0 +1,24 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.sopt.confeti.domain.festivaltime.FestivalTime;
+
+public record FestivalDetailTimeDTO(
+        long festivalTimeId,
+        LocalTime startAt,
+        LocalTime endAt,
+        List<FestivalDetailArtistDTO> artists
+) {
+    public static FestivalDetailTimeDTO from(final FestivalTime festivalTime) {
+        return new FestivalDetailTimeDTO(
+                festivalTime.getId(),
+                festivalTime.getStartAt(),
+                festivalTime.getEndAt(),
+                festivalTime.getArtists().stream()
+                        .map(FestivalDetailArtistDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
@@ -23,4 +23,9 @@ public class ArtistFavoriteService {
 
         return artistList;
     }
+
+    @Transactional(readOnly = true)
+    public boolean isFavorite(final long userId, final String artistId) {
+        return artistFavoriteRepository.existsByUserIdAndArtist_ArtistId(userId, artistId);
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/infra/repository/ArtistFavoriteRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/infra/repository/ArtistFavoriteRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface ArtistFavoriteRepository extends JpaRepository<ArtistFavorite, Long> {
     @Query(value = "select * from artist_favorites where user_id = :userId order by rand() limit 3", nativeQuery = true)
     List<ArtistFavorite> findTop3ByUserIdOrderByRand(@Param("userId") Long userId);
+
+    boolean existsByUserIdAndArtist_ArtistId(long userId, String artistId);
 }

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -6,16 +6,27 @@ import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
+import org.sopt.confeti.global.util.artistsearcher.ArtistResolver;
 import org.springframework.stereotype.Service;
 
 @Service
 @RequiredArgsConstructor
 public class FestivalService {
+
     private final FestivalRepository festivalRepository;
+    private  final ArtistResolver artistResolver;
 
     public Festival findById(Long festivalId) {
         Festival festival = festivalRepository.findById(festivalId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+        return festival;
+    }
+
+    public Festival getFestivalDetailByFestivalId(final long festivalId) {
+        Festival festival = festivalRepository.findById(festivalId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+        artistResolver.load(festival);
+
         return festival;
     }
 

--- a/src/main/java/org/sopt/confeti/domain/festivalartist/FestivalArtist.java
+++ b/src/main/java/org/sopt/confeti/domain/festivalartist/FestivalArtist.java
@@ -17,7 +17,7 @@ import java.util.List;
 import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
 
 @Entity
-@Table(name="festival_artist")
+@Table(name="festival_artists")
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FestivalArtist {

--- a/src/main/java/org/sopt/confeti/domain/festivalfavorite/application/FestivalFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/festivalfavorite/application/FestivalFavoriteService.java
@@ -31,4 +31,8 @@ public class FestivalFavoriteService {
 
         festivalFavoriteRepository.delete(festivalFavorite);
     }
+
+    public boolean isFavorite(final long userId, final long festivalId) {
+        return festivalFavoriteRepository.existsByUserIdAndFestivalId(userId, festivalId);
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/festivalfavorite/infra/repository/FestivalFavoriteRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/festivalfavorite/infra/repository/FestivalFavoriteRepository.java
@@ -9,4 +9,6 @@ import java.util.Optional;
 
 public interface FestivalFavoriteRepository extends JpaRepository<FestivalFavorite, Long> {
     Optional<FestivalFavorite> findByUserIdAndFestivalId(long userId, long festivalId);
+
+    boolean existsByUserIdAndFestivalId(long userId, long festivalId);
 }

--- a/src/main/java/org/sopt/confeti/global/message/ErrorMessage.java
+++ b/src/main/java/org/sopt/confeti/global/message/ErrorMessage.java
@@ -28,7 +28,7 @@ public enum ErrorMessage {
     private final HttpStatus httpStatus;
     private final String message;
 
-    private ErrorMessage(HttpStatus httpStatus, String message) {
+    ErrorMessage(HttpStatus httpStatus, String message) {
         this.httpStatus = httpStatus;
         this.message = message;
     }

--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
@@ -82,7 +82,6 @@ public class ArtistResolver {
 
             return;
         }
-
         // Mapper에 등록된 클래스 타입인 경우
         if (collectByTypeMapper.containsKey(target.getClass())) {
             collectByTypeMapper.get(target.getClass()).apply(target);
@@ -118,7 +117,7 @@ public class ArtistResolver {
                 .flatMap(stage -> stage.getTimes().stream())
                 .flatMap(time -> time.getArtists().stream())
                 .forEach(artist -> {
-                    artistIds.add(artist.getArtist().getName());
+                    artistIds.add(artist.getArtist().getArtistId());
                     artistMapper.put(artist.getArtist().getArtistId(), artist.getArtist());
                 });
     }
@@ -129,7 +128,7 @@ public class ArtistResolver {
                 .flatMap(stage -> stage.getTimes().stream())
                 .flatMap(time -> time.getArtists().stream())
                 .forEach(artist -> {
-                    artistIds.add(artist.getArtist().getName());
+                    artistIds.add(artist.getArtist().getArtistId());
                     artistMapper.put(artist.getArtist().getArtistId(), artist.getArtist());
                 });
     }

--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/ConfetiArtist.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/ConfetiArtist.java
@@ -64,4 +64,8 @@ public class ConfetiArtist {
     public static ConfetiArtist from(final String artistId) {
         return new ConfetiArtist(artistId);
     }
+
+    public static ConfetiArtist empty() {
+        return new ConfetiArtist();
+    }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #87

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] isOpen 변수 추가
- [x] Authorization 헤더 Optional로 변경
- [x] 파사드와 S3FileHandler 분리


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
S3 파일 경로를 URL로 변환하는 작업은 클라이언트 응답 값을 위한 것이라고 생각해 책임을 컨트롤러에 위임했습니다.
API 변경에 따라 "isOpen" 변수를 추가했습니다.