### PR TITLE
feat [#107] 타임테이블 페스티벌 삭제 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.api.user.controller;
 
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.dto.response.UserTimetableDetailResponse;
 import org.sopt.confeti.api.user.facade.UserTimetableFacade;
@@ -9,12 +10,16 @@ import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
+@Validated
 @RequiredArgsConstructor
 @RequestMapping("/user/timetables/festivals")
 public class UserTimetableController {
@@ -25,5 +30,14 @@ public class UserTimetableController {
     public ResponseEntity<BaseResponse<?>> getTimetablesListAndDate(@RequestHeader("Authorization") long userId) {
         UserTimetableDTO userTimetableDTO =  userTimetableFacade.getTimetablesListAndDate(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserTimetableDetailResponse.of(userTimetableDTO, s3FileHandler));
+    }
+
+    @DeleteMapping("/{festivalId}")
+    public ResponseEntity<BaseResponse<?>> removeTimetableFestival(
+            @RequestHeader("Authorization") long userId,
+            @PathVariable(name = "festivalId") @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") long festivalId
+    ) {
+        userTimetableFacade.removeTimetableFestival(userId, festivalId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -49,7 +49,10 @@ public class UserFavoriteFacade {
 
     @Transactional(readOnly = true)
     public UserFavoriteArtistDTO getArtistList(long userId) {
-        userService.existsById(userId);
+        if (!userService.existsById(userId)) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+
         List<ArtistFavorite> artists = artistFavoriteService.getArtistList(userId);
         return UserFavoriteArtistDTO.from(artists);
     }
@@ -67,9 +70,9 @@ public class UserFavoriteFacade {
 
     @Transactional
     public void removeArtistFavorite(final long userId, final String artistId) {
-        userService.existsById(userId);
-
-        if (!artistFavoriteService.isFavorite(userId, artistId)) {
+        if (
+                !userService.existsById(userId) || !artistFavoriteService.isFavorite(userId, artistId)
+        ) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
 
@@ -90,10 +93,9 @@ public class UserFavoriteFacade {
 
     @Transactional
     public void removeConcertFavorite(final long userId, final long concertId) {
-        userService.existsById(userId);
-        concertService.existsById(concertId);
-
-        if (!concertFavoriteService.isFavorite(userId, concertId)) {
+        if (
+                !userService.existsById(userId) || !concertService.existsById(concertId) || !concertFavoriteService.isFavorite(userId, concertId)
+        ) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -1,6 +1,5 @@
 package org.sopt.confeti.api.user.facade;
 
-import lombok.AllArgsConstructor;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.annotation.Facade;
 import org.sopt.confeti.api.user.facade.dto.response.UserTimetableDTO;
@@ -8,10 +7,10 @@ import org.sopt.confeti.domain.festival.application.FestivalService;
 import org.sopt.confeti.domain.timetablefestival.TimetableFestival;
 import org.sopt.confeti.domain.timetablefestival.application.TimetableFestivalService;
 import org.sopt.confeti.domain.user.application.UserService;
-import org.sopt.confeti.global.util.S3FileHandler;
+import org.sopt.confeti.global.exception.NotFoundException;
+import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.HashMap;
 import java.util.List;
 
 @Facade
@@ -20,12 +19,29 @@ public class UserTimetableFacade {
 
     private final UserService userService;
     private final TimetableFestivalService timetableFestivalService;
+    private final FestivalService festivalService;
 
     @Transactional(readOnly = true)
     public UserTimetableDTO getTimetablesListAndDate(long userId) {
-        userService.existsById(userId);
+        if (!userService.existsById(userId)) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+
         List<TimetableFestival> festivalList =  timetableFestivalService.getFetivalList(userId);
         return UserTimetableDTO.from(festivalList);
+    }
+
+    @Transactional
+    public void removeTimetableFestival(final long userId, final long festivalId) {
+        if (
+                !userService.existsById(userId) ||
+                        !festivalService.existsById(festivalId) ||
+                        !timetableFestivalService.existsByUserIdAndFestivalId(userId, festivalId)
+        ) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+
+        timetableFestivalService.removeTimetableFestival(userId, festivalId);
     }
 }
 

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
@@ -29,10 +29,8 @@ public class ConcertService {
     }
 
     @Transactional(readOnly = true)
-    public void existsById(long concertId) {
-        if (!concertRepository.existsById(concertId)) {
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
-        }
+    public boolean existsById(long concertId) {
+        return concertRepository.existsById(concertId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -35,4 +35,8 @@ public class FestivalService {
                 Festival.create(createFestivalDTO)
         );
     }
+
+    public boolean existsById(final long festivalId) {
+        return festivalRepository.existsById(festivalId);
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/timetablefestival/application/TimetableFestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/timetablefestival/application/TimetableFestivalService.java
@@ -6,13 +6,25 @@ import org.sopt.confeti.domain.timetablefestival.infra.repository.TimetableFesti
 import org.springframework.stereotype.Service;
 
 import java.util.List;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
 public class TimetableFestivalService {
     private final TimetableFestivalRepository timetableFestivalRepository;
 
+    @Transactional(readOnly = true)
     public List<TimetableFestival> getFetivalList(long userId){
         return timetableFestivalRepository.findByUserId(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean existsByUserIdAndFestivalId(final long userId, final long festivalId) {
+        return timetableFestivalRepository.existsByUserIdAndFestivalId(userId, festivalId);
+    }
+
+    @Transactional
+    public void removeTimetableFestival(final long userId, final long festivalId) {
+        timetableFestivalRepository.deleteByUserIdAndFestivalId(userId, festivalId);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/timetablefestival/infra/repository/TimetableFestivalRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/timetablefestival/infra/repository/TimetableFestivalRepository.java
@@ -7,4 +7,8 @@ import java.util.List;
 
 public interface TimetableFestivalRepository extends JpaRepository<TimetableFestival, Long> {
     List<TimetableFestival> findByUserId(Long userId);
+
+    boolean existsByUserIdAndFestivalId(final long userId, final long festivalId);
+
+    void deleteByUserIdAndFestivalId(final long userId, final long festivalId);
 }

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
@@ -24,10 +24,7 @@ public class UserService {
     }
 
     @Transactional(readOnly = true)
-    public void existsById(Long userId) {
-        final boolean isExistUser = userRepository.existsById(userId);
-        if(!isExistUser) {
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
-        }
+    public boolean existsById(Long userId) {
+        return userRepository.existsById(userId);
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #107 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] existsById 반환 값 boolean으로 변경
- [x] 타임테이블 페스티벌 삭제 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1061" alt="image" src="https://github.com/user-attachments/assets/5b2faff2-84a1-449a-9952-b078c630b8df" />

파사드 계층에서 값의 존재 여부에 따라 로직을 구성하기 위해 서비스 계층에서 existsById 반환 값을 boolean으로 수정했습니다. (확장성 고려)
타임테이블 페스티벌 삭제 API를 구현했습니다.