### PR TITLE
fix [#127] SpotifyAPIHandler 리프레시 토큰 재발급 로직 재구성 및 마지막 발매 일자 가져오는 방법 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/SpotifyAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/SpotifyAPIHandler.java
@@ -37,8 +37,6 @@ public class SpotifyAPIHandler {
     private static final int REFRESH_TRIAL = 5;
     private static final int REFRESH_INIT_VALUE = 0;
 
-    private static final String TOKEN_EXPIRED_MESSAGE = "The access token expired";
-
     @Value("${spotify.credentials.client-id}")
     private String clientId;
 

--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/SpotifyAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/SpotifyAPIHandler.java
@@ -1,7 +1,6 @@
 package org.sopt.confeti.global.util.artistsearcher;
 
 import com.neovisionaries.i18n.CountryCode;
-import java.io.IOException;
 import java.time.LocalDate;
 import java.util.Arrays;
 import java.util.Collections;
@@ -9,9 +8,9 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.concurrent.Callable;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.apache.hc.core5.http.ParseException;
 import org.sopt.confeti.annotation.Handler;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
@@ -22,13 +21,10 @@ import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.exceptions.detailed.BadRequestException;
 import se.michaelthelin.spotify.exceptions.detailed.NotFoundException;
 import se.michaelthelin.spotify.exceptions.detailed.UnauthorizedException;
-import se.michaelthelin.spotify.model_objects.credentials.AuthorizationCodeCredentials;
 import se.michaelthelin.spotify.model_objects.credentials.ClientCredentials;
 import se.michaelthelin.spotify.model_objects.specification.AlbumSimplified;
 import se.michaelthelin.spotify.model_objects.specification.Artist;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
-import se.michaelthelin.spotify.requests.authorization.authorization_code.AuthorizationCodeRefreshRequest;
-import se.michaelthelin.spotify.requests.authorization.client_credentials.ClientCredentialsRequest;
 
 @Handler
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
@@ -36,8 +32,12 @@ public class SpotifyAPIHandler {
 
     private static final int ARTIST_LIMIT = 1;
     private static final int ARTIST_OFFSET = 0;
-    private static final int ALBUM_LIMIT = 10;
+    private static final int ALBUM_LIMIT = 1;
     private static final int ALBUM_OFFSET = 0;
+    private static final int REFRESH_TRIAL = 5;
+    private static final int REFRESH_INIT_VALUE = 0;
+
+    private static final String TOKEN_EXPIRED_MESSAGE = "The access token expired";
 
     @Value("${spotify.credentials.client-id}")
     private String clientId;
@@ -47,9 +47,13 @@ public class SpotifyAPIHandler {
 
     private SpotifyApi spotifyApi;
 
+    private int refreshCount;
+
     public void init() {
         createSpotifyApi();
         generateAccessToken();
+
+        refreshCount = REFRESH_INIT_VALUE;
     }
 
     public Optional<ConfetiArtist> findArtistsByKeyword(final String keyword) {
@@ -62,7 +66,7 @@ public class SpotifyAPIHandler {
         Artist artist = searchedArtist.get();
 
         return Optional.of(
-                ConfetiArtist.toConfetiArtist(artist, findLatestReleaseAt(keyword, artist))
+                ConfetiArtist.toConfetiArtist(artist, findLatestReleaseAt(artist.getId()))
         );
     }
 
@@ -72,20 +76,23 @@ public class SpotifyAPIHandler {
         }
 
         try {
-            Artist artist = spotifyApi.getArtist(artistId)
-                    .build()
-                    .execute();
+            generateAccessTokenIfExpired();
 
-            return Optional.of(
-                    ConfetiArtist.toConfetiArtist(artist)
-            );
-        } catch (UnauthorizedException e) {
-            refreshToken();
-            return findArtistByArtistId(artistId);
-        } catch (NotFoundException | BadRequestException e) {
+            return executeWithTokenRefresh(() -> {
+                Artist artist = spotifyApi.getArtist(artistId)
+                        .build()
+                        .execute();
+
+                return Optional.of(
+                        ConfetiArtist.toConfetiArtist(artist)
+                );
+            });
+        } catch (NotFoundException e) {
             return Optional.empty();
-        } catch (IOException | ParseException | SpotifyWebApiException e) {
-            throw new RuntimeException(e);
+        } catch (BadRequestException e) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        } catch (Exception e) {
+            throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -95,81 +102,79 @@ public class SpotifyAPIHandler {
         }
 
         try {
-            Artist[] artists = spotifyApi.getSeveralArtists(
-                        artistIds.stream()
-                                .filter(Objects::nonNull)
-                                .toArray(String[]::new)
-                    )
-                    .build()
-                    .execute();
+            generateAccessTokenIfExpired();
 
-            return Arrays.stream(artists)
-                    .filter(Objects::nonNull)
-                    .map(ConfetiArtist::toConfetiArtist)
-                    .toList();
-        } catch (UnauthorizedException e) {
-            refreshToken();
-            return findArtistsByArtistIds(artistIds);
+            return executeWithTokenRefresh(() -> {
+                Artist[] artists = spotifyApi.getSeveralArtists(
+                                artistIds.stream()
+                                        .filter(Objects::nonNull)
+                                        .toArray(String[]::new)
+                        )
+                        .build()
+                        .execute();
+
+                return Arrays.stream(artists)
+                        .filter(Objects::nonNull)
+                        .map(ConfetiArtist::toConfetiArtist)
+                        .toList();
+            });
         } catch (BadRequestException e) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
-        } catch (IOException | ParseException | SpotifyWebApiException e) {
-            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
     private Optional<Artist> searchArtistByKeyword(final String keyword) {
         try {
-            Paging<Artist> artists = spotifyApi.searchArtists(keyword)
-                    .market(CountryCode.KR)
-                    .limit(ARTIST_LIMIT)
-                    .offset(ARTIST_OFFSET)
-                    .build()
-                    .execute();
+            generateAccessTokenIfExpired();
 
-            return Arrays.stream(artists.getItems())
-                    .findFirst();
-        } catch (UnauthorizedException e) {
-            refreshToken();
-            return searchArtistByKeyword(keyword);
-        } catch (IOException | ParseException | SpotifyWebApiException e) {
-            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+            return executeWithTokenRefresh(() -> {
+                Paging<Artist> artists = spotifyApi.searchArtists(keyword)
+                        .market(CountryCode.KR)
+                        .limit(ARTIST_LIMIT)
+                        .offset(ARTIST_OFFSET)
+                        .build()
+                        .execute();
+
+                return Arrays.stream(artists.getItems())
+                        .findFirst();
+            });
+        } catch (Exception e) {
+            throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
-    private LocalDate findLatestReleaseAt(final String keyword, final Artist artist) {
-        Optional<Paging<AlbumSimplified>> albums = searchAlbumByKeyword(keyword);
+    private LocalDate findLatestReleaseAt(final String artistId) {
+        Optional<Paging<AlbumSimplified>> searchedAlbums = searchAlbumByArtistId(artistId);
 
-        return albums.map(albumSimplifiedPaging -> Arrays.stream(albumSimplifiedPaging.getItems())
-                .filter((searchedAlbum) ->
-                        Arrays.stream(searchedAlbum.getArtists())
-                                .anyMatch((searchedArtist) ->
-                                        searchedArtist.getId().equals(artist.getId())
-                                )
-                )
-                .max(Comparator.comparing(AlbumSimplified::getReleaseDate))
-                .map(
-                        albumSimplified -> DateConvertor.convertToSpotifyLocalDate(albumSimplified.getReleaseDate())
-                )
-                .get())
-                .orElse(null);
+        if (searchedAlbums.isEmpty()) {
+            return null;
+        }
 
+        Paging<AlbumSimplified> albums = searchedAlbums.get();
+
+        return Arrays.stream(albums.getItems())
+                .map(albumItem -> DateConvertor.convertToSpotifyLocalDate(albumItem.getReleaseDate()))
+                .findFirst()
+                .orElseGet(null);
     }
 
-    private Optional<Paging<AlbumSimplified>> searchAlbumByKeyword(final String keyword) {
+    private Optional<Paging<AlbumSimplified>> searchAlbumByArtistId(final String artistId) {
         try {
-            return Optional.of(spotifyApi.searchAlbums(keyword)
+            generateAccessTokenIfExpired();
+
+            return executeWithTokenRefresh(() ->
+                    Optional.of(spotifyApi.getArtistsAlbums(artistId)
                     .market(CountryCode.KR)
                     .limit(ALBUM_LIMIT)
                     .offset(ALBUM_OFFSET)
                     .build()
-                    .execute());
-        } catch (UnauthorizedException e) {
-            refreshToken();
-            return searchAlbumByKeyword(keyword);
+                    .execute()));
         } catch (NotFoundException | BadRequestException e) {
             return Optional.empty();
-        } catch (IOException | ParseException | SpotifyWebApiException e) {
-            throw new RuntimeException(e);
+        } catch (Exception e) {
+            throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
@@ -181,27 +186,42 @@ public class SpotifyAPIHandler {
     }
 
     private void generateAccessToken() {
-        ClientCredentialsRequest clientCredentialsRequest = spotifyApi.clientCredentials().build();
-
         try {
-            final ClientCredentials clientCredentials = clientCredentialsRequest.execute();
+            final ClientCredentials clientCredentials = spotifyApi.clientCredentials()
+                    .build()
+                    .execute();
 
             spotifyApi.setAccessToken(clientCredentials.getAccessToken());
-        } catch (IOException | ParseException | SpotifyWebApiException e) {
-            throw new RuntimeException(e);
-        }
-    }
+            refreshCount = REFRESH_INIT_VALUE;
 
-    public void refreshToken() {
-        try {
-            AuthorizationCodeRefreshRequest refreshRequest = spotifyApi.authorizationCodeRefresh().build();
-            AuthorizationCodeCredentials credentials = refreshRequest.execute();
-
-            spotifyApi.setAccessToken(credentials.getAccessToken());
-
-        } catch (IOException | SpotifyWebApiException | ParseException e) {
+        } catch (Exception e) {
             throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
     }
 
+    private void generateAccessTokenIfExpired() {
+        if (spotifyApi.getAccessToken() == null) {
+            generateAccessToken();
+        }
+    }
+
+    // 토큰 재발급을 위한 실행 메서드
+    private <T> T executeWithTokenRefresh(Callable<T> action) throws Exception {
+        try {
+            T retVal = action.call();
+            refreshCount = REFRESH_INIT_VALUE;
+            return retVal;
+        } catch (UnauthorizedException e) {
+            if (isTokenExpired(e) && refreshCount < REFRESH_TRIAL) {
+                generateAccessToken();
+                return action.call();  // 새 토큰으로 재시도
+            }
+            throw e;
+        }
+    }
+
+    // 토큰 만료 여부 확인
+    private boolean isTokenExpired(SpotifyWebApiException e) {
+        return e instanceof UnauthorizedException;
+    }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #127 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] SpotifyAPIHandler 리프레시 토큰 재발급 로직 재구성 및 마지막 발매 일자 가져오는 방법 변경


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
토큰 만료 시 재발급 받는 로직을 추가했습니다.
이때, 무한 재귀에 빠질 수 있으므로 최대 값을 5로 설정했습니다.

추가로 아티스트 아이디로 간단하게 마지막 발매 일자를 가져올 수 있어 로직을 수정헀습니다.
