### PR TITLE
feat [#126] 예정된 페스티벌 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
@@ -25,15 +25,17 @@ public class UserFavoriteController {
     private final S3FileHandler s3FileHandler;
 
     @PostMapping("/festivals/{festivalId}")
-    public ResponseEntity<BaseResponse<?>> postFavoriteFestival(@RequestHeader("Authorization") Long userId, @PathVariable
-                                                                @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long festivalId) {
+    public ResponseEntity<BaseResponse<?>> postFavoriteFestival(
+            @RequestHeader("Authorization") Long userId,
+            @PathVariable(name = "festivalId") @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long festivalId) {
         userFavoriteFacade.addFestivalFavorite(userId, festivalId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
     @DeleteMapping("/festivals/{festivalId}")
-    public ResponseEntity<BaseResponse<?>> deleteFavoriteFestival(@RequestHeader("Authorization") Long userId, @PathVariable
-                                                                  @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long festivalId) {
+    public ResponseEntity<BaseResponse<?>> deleteFavoriteFestival(
+            @RequestHeader("Authorization") Long userId,
+            @PathVariable(name = "festivalId") @Min(value = 0, message = "요청 형식이 올바르지 않습니다.") Long festivalId) {
         userFavoriteFacade.removeFestivalFavorite(userId, festivalId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
@@ -3,11 +3,14 @@ package org.sopt.confeti.api.user.controller;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.dto.request.AddTimetableFestivalRequest;
+import org.sopt.confeti.api.user.dto.response.TimetablesToAddResponse;
 import org.sopt.confeti.api.user.dto.response.UserTimetableDetailResponse;
 import org.sopt.confeti.api.user.facade.UserTimetableFacade;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
+import org.sopt.confeti.api.user.facade.dto.response.TimetableToAddDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserTimetableDTO;
 import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.common.CursorPage;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.sopt.confeti.global.util.S3FileHandler;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -27,6 +31,9 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/user/timetables/festivals")
 public class UserTimetableController {
+    private static final String DEFAULT_PAGING_SIZE = "3";
+    private static final int NEXT_CURSOR_SIZE = 1;
+
     private final UserTimetableFacade userTimetableFacade;
     private final S3FileHandler s3FileHandler;
 
@@ -34,6 +41,16 @@ public class UserTimetableController {
     public ResponseEntity<BaseResponse<?>> getTimetablesListAndDate(@RequestHeader("Authorization") long userId) {
         UserTimetableDTO userTimetableDTO =  userTimetableFacade.getTimetablesListAndDate(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserTimetableDetailResponse.of(userTimetableDTO, s3FileHandler));
+    }
+
+    @GetMapping("/add")
+    public ResponseEntity<BaseResponse<?>> getTimetablesToAdd(
+            @RequestHeader("Authorization") long userId,
+            @RequestParam(name = "cursor", required = false) Long cursor,
+            @RequestParam(name = "size", required = false, defaultValue = DEFAULT_PAGING_SIZE) int size
+    ) {
+        CursorPage<TimetableToAddDTO> timetablesToAdd = userTimetableFacade.getTimetablesToAdd(userId, cursor, size + NEXT_CURSOR_SIZE);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, TimetablesToAddResponse.of(timetablesToAdd, s3FileHandler));
     }
 
     @PostMapping

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
@@ -31,8 +31,6 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @RequestMapping("/user/timetables/festivals")
 public class UserTimetableController {
-    private static final String DEFAULT_PAGING_SIZE = "3";
-    private static final int NEXT_CURSOR_SIZE = 1;
 
     private final UserTimetableFacade userTimetableFacade;
     private final S3FileHandler s3FileHandler;
@@ -46,10 +44,9 @@ public class UserTimetableController {
     @GetMapping("/add")
     public ResponseEntity<BaseResponse<?>> getTimetablesToAdd(
             @RequestHeader("Authorization") long userId,
-            @RequestParam(name = "cursor", required = false) Long cursor,
-            @RequestParam(name = "size", required = false, defaultValue = DEFAULT_PAGING_SIZE) int size
+            @RequestParam(name = "cursor", required = false) Long cursor
     ) {
-        CursorPage<TimetableToAddDTO> timetablesToAdd = userTimetableFacade.getTimetablesToAdd(userId, cursor, size + NEXT_CURSOR_SIZE);
+        CursorPage<TimetableToAddDTO> timetablesToAdd = userTimetableFacade.getTimetablesToAdd(userId, cursor);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, TimetablesToAddResponse.of(timetablesToAdd, s3FileHandler));
     }
 

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/TimetablesToAddFestivalResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/TimetablesToAddFestivalResponse.java
@@ -1,8 +1,18 @@
 package org.sopt.confeti.api.user.dto.response;
 
+import org.sopt.confeti.api.user.facade.dto.response.TimetableToAddDTO;
+import org.sopt.confeti.global.util.S3FileHandler;
+
 public record TimetablesToAddFestivalResponse(
         long festivalId,
         String posterUrl,
         String title
 ) {
+    public static TimetablesToAddFestivalResponse of(final TimetableToAddDTO timetableToAddDTO, final S3FileHandler s3FileHandler) {
+        return new TimetablesToAddFestivalResponse (
+                timetableToAddDTO.festivalId(),
+                s3FileHandler.getFileUrl(timetableToAddDTO.posterPath()),
+                timetableToAddDTO.title()
+        );
+    }
 }

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/TimetablesToAddFestivalResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/TimetablesToAddFestivalResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.confeti.api.user.dto.response;
+
+public record TimetablesToAddFestivalResponse(
+        long festivalId,
+        String posterUrl,
+        String title
+) {
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/TimetablesToAddResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/TimetablesToAddResponse.java
@@ -1,9 +1,28 @@
 package org.sopt.confeti.api.user.dto.response;
 
 import java.util.List;
+import org.sopt.confeti.api.user.facade.dto.response.TimetableToAddDTO;
+import org.sopt.confeti.global.common.CursorPage;
+import org.sopt.confeti.global.util.S3FileHandler;
 
 public record TimetablesToAddResponse(
         long nextCursor,
         List<TimetablesToAddFestivalResponse> festivals
 ) {
+    private static final long DEFAULT_NEXT_CURSOR = -1L;
+
+    public static TimetablesToAddResponse of(final CursorPage<TimetableToAddDTO> cursorPage, final S3FileHandler s3FileHandler) {
+        Long nextCursor = DEFAULT_NEXT_CURSOR;
+
+        if (!cursorPage.isLast()) {
+            nextCursor = cursorPage.getNextCursor().festivalId();
+        }
+
+        return new TimetablesToAddResponse(
+                nextCursor,
+                cursorPage.getItems().stream()
+                        .map(timetableToAddDTO -> TimetablesToAddFestivalResponse.of(timetableToAddDTO, s3FileHandler))
+                        .toList()
+        );
+    }
 }

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/TimetablesToAddResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/TimetablesToAddResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.api.user.dto.response;
+
+import java.util.List;
+
+public record TimetablesToAddResponse(
+        long nextCursor,
+        List<TimetablesToAddFestivalResponse> festivals
+) {
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -125,10 +125,7 @@ public class UserTimetableFacade {
         }
 
         // 커서 값 조회
-        FestivalCursorDTO festivalCursorDTO = festivalService.findFestivalCursor(userId, cursor)
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
-                );
+        FestivalCursorDTO festivalCursorDTO = getFestivalCursor(userId, cursor);
 
         List<Festival> festivals = festivalService.findFestivalsUsingCursor(userId, festivalCursorDTO.cursorTitle(), festivalCursorDTO.cursorIsFavorite(), TIMETABLE_FESTIVALS_TO_ADD_SIZE);
         return CursorPage.of(
@@ -137,6 +134,14 @@ public class UserTimetableFacade {
                         .toList(),
                 TIMETABLE_FESTIVALS_TO_ADD_SIZE
         );
+    }
+
+    @Transactional(readOnly = true)
+    public FestivalCursorDTO getFestivalCursor(final long userId, final long cursor) {
+        return festivalService.findFestivalCursor(userId, cursor)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+                );
     }
 }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -1,6 +1,5 @@
 package org.sopt.confeti.api.user.facade;
 
-import java.util.Optional;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.annotation.Facade;
@@ -20,7 +19,6 @@ import org.sopt.confeti.global.exception.ConflictException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -30,6 +28,8 @@ import java.util.List;
 public class UserTimetableFacade {
 
     private static final int TIMETABLE_FESTIVAL_COUNT_MAXIMUM = 3;
+    private static final int NEXT_CURSOR_SIZE = 1;
+    private static final int TIMETABLE_FESTIVALS_TO_ADD_SIZE = 6 + NEXT_CURSOR_SIZE;
 
     private final UserService userService;
     private final TimetableFestivalService timetableFestivalService;
@@ -113,14 +113,14 @@ public class UserTimetableFacade {
     }
 
     @Transactional(readOnly = true)
-    public CursorPage<TimetableToAddDTO> getTimetablesToAdd(final long userId, final Long cursor, final int size) {
+    public CursorPage<TimetableToAddDTO> getTimetablesToAdd(final long userId, final Long cursor) {
         if (cursor == null) {
-            List<Festival> festivals = festivalService.findFestivalsUsingInitCursor(userId, size);
+            List<Festival> festivals = festivalService.findFestivalsUsingInitCursor(userId, TIMETABLE_FESTIVALS_TO_ADD_SIZE);
             return CursorPage.of(
                     festivals.stream()
                             .map(TimetableToAddDTO::from)
                             .toList(),
-                    size
+                    TIMETABLE_FESTIVALS_TO_ADD_SIZE
             );
         }
 
@@ -130,12 +130,12 @@ public class UserTimetableFacade {
                         () -> new NotFoundException(ErrorMessage.NOT_FOUND)
                 );
 
-        List<Festival> festivals = festivalService.findFestivalsUsingCursor(userId, festivalCursorDTO.cursorTitle(), festivalCursorDTO.cursorIsFavorite(), size);
+        List<Festival> festivals = festivalService.findFestivalsUsingCursor(userId, festivalCursorDTO.cursorTitle(), festivalCursorDTO.cursorIsFavorite(), TIMETABLE_FESTIVALS_TO_ADD_SIZE);
         return CursorPage.of(
                 festivals.stream()
                         .map(TimetableToAddDTO::from)
                         .toList(),
-                size
+                TIMETABLE_FESTIVALS_TO_ADD_SIZE
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -1,21 +1,26 @@
 package org.sopt.confeti.api.user.facade;
 
+import java.util.Optional;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.annotation.Facade;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalArtiestDTO;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
+import org.sopt.confeti.api.user.facade.dto.response.TimetableToAddDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserTimetableDTO;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.festival.application.dto.FestivalCursorDTO;
 import org.sopt.confeti.domain.timetablefestival.TimetableFestival;
 import org.sopt.confeti.domain.timetablefestival.application.TimetableFestivalService;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.application.UserService;
+import org.sopt.confeti.global.common.CursorPage;
 import org.sopt.confeti.global.exception.ConflictException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -105,6 +110,33 @@ public class UserTimetableFacade {
         if (!timetableFestivalService.existsByUserIdAndFestivalId(userId, festivalId)) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public CursorPage<TimetableToAddDTO> getTimetablesToAdd(final long userId, final Long cursor, final int size) {
+        if (cursor == null) {
+            List<Festival> festivals = festivalService.findFestivalsUsingInitCursor(userId, size);
+            return CursorPage.of(
+                    festivals.stream()
+                            .map(TimetableToAddDTO::from)
+                            .toList(),
+                    size
+            );
+        }
+
+        // 커서 값 조회
+        FestivalCursorDTO festivalCursorDTO = festivalService.findFestivalCursor(userId, cursor)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+                );
+
+        List<Festival> festivals = festivalService.findFestivalsUsingCursor(userId, festivalCursorDTO.cursorTitle(), festivalCursorDTO.cursorIsFavorite(), size);
+        return CursorPage.of(
+                festivals.stream()
+                        .map(TimetableToAddDTO::from)
+                        .toList(),
+                size
+        );
     }
 }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/TimetableToAddDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/TimetableToAddDTO.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.facade.dto.response;
+
+import org.sopt.confeti.domain.festival.Festival;
+
+public record TimetableToAddDTO(
+        long festivalId,
+        String posterPath,
+        String title
+) {
+    public static TimetableToAddDTO from(final Festival festival) {
+        return new TimetableToAddDTO(
+                festival.getId(),
+                festival.getFestivalPosterPath(),
+                festival.getFestivalTitle()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -1,13 +1,18 @@
 package org.sopt.confeti.domain.festival.application;
 
 import java.util.List;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.facade.dto.request.CreateFestivalDTO;
 import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festival.application.dto.FestivalCursorDTO;
 import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.util.artistsearcher.ArtistResolver;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,6 +22,9 @@ public class FestivalService {
 
     private final FestivalRepository festivalRepository;
     private  final ArtistResolver artistResolver;
+
+    private static final int INIT_PAGE = 0;
+    private static final String FESTIVAL_TITLE_COLUMN_NAME = "festivalTitle";
 
     @Transactional(readOnly = true)
     public Festival findById(Long festivalId) {
@@ -49,5 +57,47 @@ public class FestivalService {
     @Transactional
     public List<Festival> findFestivalsByIdIn(final List<Long> festivalIds) {
         return festivalRepository.findFestivalsByIdIn(festivalIds);
+    }
+
+
+    @Transactional(readOnly = true)
+    public List<Festival> findFestivalsUsingInitCursor(final long userId, final int size) {
+        return festivalRepository.findFestivalsUsingInitCursor(
+                userId,
+                getPageRequestWithSort(size, getFestivalSort())
+        );
+    }
+
+    private PageRequest getPageRequestWithSort(final int size, final Sort sort) {
+        return PageRequest.of(INIT_PAGE, size, sort);
+    }
+
+    private PageRequest getPageRequest(final int size) {
+        return PageRequest.of(INIT_PAGE, size);
+    }
+
+    private Sort getFestivalSort() {
+        return Sort.by(
+                Order.asc(FESTIVAL_TITLE_COLUMN_NAME)
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public List<Festival> findFestivalsUsingCursor(
+            final long userId,
+            final String cursorTitle,
+            final boolean cursorIsFavorite,
+            final int size
+    ) {
+        return festivalRepository.findFestivalsUsingCursor(
+                userId,
+                cursorTitle,
+                cursorIsFavorite,
+                getPageRequestWithSort(size, getFestivalSort())
+        );
+    }
+
+    public Optional<FestivalCursorDTO> findFestivalCursor(final long userId, final long festivalId) {
+        return festivalRepository.findFestivalCursor(userId, festivalId);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -72,10 +72,6 @@ public class FestivalService {
         return PageRequest.of(INIT_PAGE, size, sort);
     }
 
-    private PageRequest getPageRequest(final int size) {
-        return PageRequest.of(INIT_PAGE, size);
-    }
-
     private Sort getFestivalSort() {
         return Sort.by(
                 Order.asc(FESTIVAL_TITLE_COLUMN_NAME)
@@ -97,6 +93,7 @@ public class FestivalService {
         );
     }
 
+    @Transactional(readOnly = true)
     public Optional<FestivalCursorDTO> findFestivalCursor(final long userId, final long festivalId) {
         return festivalRepository.findFestivalCursor(userId, festivalId);
     }

--- a/src/main/java/org/sopt/confeti/domain/festival/application/dto/FestivalCursorDTO.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/dto/FestivalCursorDTO.java
@@ -1,0 +1,7 @@
+package org.sopt.confeti.domain.festival.application.dto;
+
+public record FestivalCursorDTO(
+        String cursorTitle,
+        boolean cursorIsFavorite
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
@@ -1,11 +1,74 @@
 package org.sopt.confeti.domain.festival.infra.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festival.application.dto.FestivalCursorDTO;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface FestivalRepository extends JpaRepository<Festival, Long> {
     List<Festival> findFestivalsByIdIn(final @Param("festivalIds") List<Long> festivalIds);
+
+    @Query(value =
+            "SELECT f" +
+                    " FROM Festival f" +
+                    " LEFT JOIN FestivalFavorite ff" +
+                    " ON f.id = ff.festival.id AND ff.user.id = :userId" +
+                    " WHERE f.festivalEndAt >= CURRENT_DATE AND f.id NOT IN (" +
+                        " SELECT tf.id" +
+                        " FROM TimetableFestival tf" +
+                        " INNER JOIN tf.user u" +
+                        " WHERE u.id = :userId" +
+                    " )" +
+                    " ORDER BY CASE WHEN ff.id IS NULL THEN 0 ELSE 1 END DESC"
+    )
+    List<Festival> findFestivalsUsingInitCursor(
+            final @Param("userId") long userId,
+            final PageRequest page
+    );
+
+    @Query(value =
+            "SELECT f" +
+                    " FROM Festival f" +
+                    " LEFT JOIN FestivalFavorite ff" +
+                    " ON f.id = ff.festival.id AND ff.user.id = :userId" +
+                    " WHERE f.festivalEndAt >= CURRENT_DATE AND f.id NOT IN (" +
+                        " SELECT tf.id" +
+                        " FROM TimetableFestival tf" +
+                        " INNER JOIN tf.user u" +
+                        " WHERE u.id = :userId" +
+                    " ) AND " +
+                    " (" +
+                        " (" +
+                            " ((:cursorIsFavorite = true AND ff.id IS NOT NULL) OR (:cursorIsFavorite = false AND ff.id IS NULL)) AND (:cursorTitle <= f.festivalTitle)" +
+                        " ) OR (" +
+                            " :cursorIsFavorite = true AND ff.id IS NULL" +
+                        " ) " +
+                    " )" +
+                    " ORDER BY CASE WHEN ff.id IS NULL THEN 0 ELSE 1 END DESC"
+    )
+    List<Festival> findFestivalsUsingCursor(
+            final @Param("userId") long userId,
+            final @Param("cursorTitle") String cursorTitle,
+            final @Param("cursorIsFavorite") boolean cursorIsFavorite,
+            final PageRequest page
+    );
+
+    @Query(value =
+        "SELECT new org.sopt.confeti.domain.festival.application.dto.FestivalCursorDTO(" +
+                " f.festivalTitle," +
+                " CASE WHEN ff.id IS NULL THEN false ELSE true END" +
+                " )" +
+                " FROM Festival f" +
+                " LEFT JOIN FestivalFavorite ff" +
+                " ON f.id = ff.festival.id AND ff.user.id = :userId" +
+                " WHERE f.id = :festivalId"
+    )
+    Optional<FestivalCursorDTO> findFestivalCursor(
+            final @Param("userId") long userId,
+            final @Param("festivalId") long festivalId
+    );
 }

--- a/src/main/java/org/sopt/confeti/global/common/CursorPage.java
+++ b/src/main/java/org/sopt/confeti/global/common/CursorPage.java
@@ -15,7 +15,7 @@ public class CursorPage<T> {
     }
 
     public boolean isLast() {
-        return itemsWithNextCursor.size() <= size;
+        return itemsWithNextCursor.size() < size;
     }
 
     public List<T> getItems() {
@@ -23,7 +23,7 @@ public class CursorPage<T> {
             return itemsWithNextCursor;
         }
 
-        return itemsWithNextCursor.subList(0, size);
+        return itemsWithNextCursor.subList(0, size - 1);
     }
 
     public T getNextCursor() {

--- a/src/main/java/org/sopt/confeti/global/common/CursorPage.java
+++ b/src/main/java/org/sopt/confeti/global/common/CursorPage.java
@@ -1,0 +1,32 @@
+package org.sopt.confeti.global.common;
+
+import java.util.List;
+import lombok.AccessLevel;
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor(access = AccessLevel.PRIVATE)
+public class CursorPage<T> {
+
+    private final List<T> itemsWithNextCursor;
+    private final int size;
+
+    public static <T> CursorPage<T> of(final List<T> itemsWithNextCursor, final int size) {
+        return new CursorPage<>(itemsWithNextCursor, size);
+    }
+
+    public boolean isLast() {
+        return itemsWithNextCursor.size() <= size;
+    }
+
+    public List<T> getItems() {
+        if (isLast()) {
+            return itemsWithNextCursor;
+        }
+
+        return itemsWithNextCursor.subList(0, size);
+    }
+
+    public T getNextCursor() {
+        return itemsWithNextCursor.get(size - 1);
+    }
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #126 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 예정된 페스티벌 목록 조회 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="652" alt="image" src="https://github.com/user-attachments/assets/15130ee4-b923-47ca-824c-d1efbbda5196" />

커서 기반 페이징 구현을 위해 데이터베이스 결과 값에서 응답 값으로 쉽게 변환하기 위한 클래스를 작성했습니다.
데이터베이스에서 요청한 값보다 하나 더 조회해 다음 값이 있는지 확인하는 방식으로 구현했습니다.

<img width="564" alt="image" src="https://github.com/user-attachments/assets/f999ecf0-38c7-402e-9b61-2d9937ee1719" />

기존 타임테이블에 등록되지 않은, 끝나지 않은 페스티벌을 대상으로 조회합니다.
정렬은 좋아요가 등록된, 공연 제목이 ㄱㄴㄷ 순으로 했습니다.
위 사진은 커서 값이 주어지지 않았을 때 초기 조회 쿼리입니다.

<img width="1208" alt="image" src="https://github.com/user-attachments/assets/2be7c393-18a8-4246-ae54-915dcf137ce7" />

커서 값이 주어졌을 때 조회 쿼리입니다.
커서 값을 포함해 요청한 크기보다 하나 더 조회합니다.