### PR TITLE
refactor [#223] ArtistResolver 객체 그래프 탐색 로직을 분리하기 위해 전략(Strategy) 패턴 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
 
     // psy
-    implementation 'p6spy:p6spy:3.9.1'
-    implementation 'com.github.gavlyukovskiy:datasource-decorator-spring-boot-autoconfigure:1.9.0'
+//    implementation 'p6spy:p6spy:3.9.1'
+//    implementation 'com.github.gavlyukovskiy:datasource-decorator-spring-boot-autoconfigure:1.9.0'
 
     // spotify api
     implementation 'se.michaelthelin.spotify:spotify-web-api-java:8.4.1'

--- a/src/main/java/org/sopt/confeti/ConfetiApplication.java
+++ b/src/main/java/org/sopt/confeti/ConfetiApplication.java
@@ -1,7 +1,7 @@
 package org.sopt.confeti;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.global.util.artistsearcher.SpotifyAPIHandler;
+import org.sopt.confeti.global.util.SpotifyAPIHandler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.context.event.ApplicationReadyEvent;

--- a/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
@@ -2,7 +2,7 @@ package org.sopt.confeti.api.artist.facade;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.annotation.Facade;
+import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.artist.facade.dto.response.SearchArtistDTO;
 import org.sopt.confeti.domain.artistfavorite.application.ArtistFavoriteService;
 import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;

--- a/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
@@ -5,8 +5,8 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.artist.facade.dto.response.SearchArtistDTO;
 import org.sopt.confeti.domain.artistfavorite.application.ArtistFavoriteService;
-import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
-import org.sopt.confeti.global.util.artistsearcher.SpotifyAPIHandler;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
+import org.sopt.confeti.global.util.SpotifyAPIHandler;
 import org.springframework.transaction.annotation.Transactional;
 
 @Facade

--- a/src/main/java/org/sopt/confeti/api/artist/facade/dto/response/SearchArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/artist/facade/dto/response/SearchArtistDTO.java
@@ -1,7 +1,7 @@
 package org.sopt.confeti.api.artist.facade.dto.response;
 
 import java.time.LocalDate;
-import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 
 public record SearchArtistDTO(
         String artistId,

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 import java.util.stream.Stream;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.annotation.Facade;
+import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.performance.facade.dto.request.CreateConcertDTO;
 import org.sopt.confeti.api.performance.facade.dto.request.CreateFestivalDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ConcertDetailDTO;

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ConcertArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ConcertArtistDTO.java
@@ -2,7 +2,7 @@ package org.sopt.confeti.api.performance.facade.dto.response;
 
 import java.time.LocalDate;
 import org.sopt.confeti.domain.concertartist.ConcertArtist;
-import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 
 public record ConcertArtistDTO(
         String artistId,

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailArtistDTO.java
@@ -2,7 +2,7 @@ package org.sopt.confeti.api.performance.facade.dto.response;
 
 import java.time.LocalDate;
 import org.sopt.confeti.domain.festivalartist.FestivalArtist;
-import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 
 public record FestivalDetailArtistDTO(
         String artistId,

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -2,7 +2,7 @@ package org.sopt.confeti.api.user.facade;
 
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.annotation.Facade;
+import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoriteArtistDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoritePerformancesDTO;
 import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -20,8 +20,8 @@ import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.global.exception.ConflictException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
-import org.sopt.confeti.global.util.artistsearcher.SpotifyAPIHandler;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
+import org.sopt.confeti.global.util.SpotifyAPIHandler;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
@@ -1,9 +1,8 @@
 package org.sopt.confeti.api.user.facade;
 
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.annotation.Facade;
+import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.user.facade.dto.response.UserInfoDTO;
-import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.application.UserService;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -1,15 +1,13 @@
 package org.sopt.confeti.api.user.facade;
 
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.annotation.Facade;
+import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalArtiestDTO;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
 import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableDTO;
-import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableListDTO;
 import org.sopt.confeti.api.user.facade.dto.response.TimetableToAddDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserTimetableDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserTimetableFestivalBasicDTO;

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -28,7 +28,7 @@ import org.sopt.confeti.global.exception.ConflictException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.util.artistsearcher.ArtistResolver;
+import org.sopt.confeti.global.resolver.artist.ArtistResolver;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/ArtistFavorite.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/ArtistFavorite.java
@@ -6,7 +6,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.confeti.domain.user.User;
-import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 
 @Entity
 @Table(name="artist_favorites")

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteArtistStrategy.java
@@ -1,0 +1,28 @@
+package org.sopt.confeti.domain.artistfavorite.application;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Queue;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;
+import org.sopt.confeti.global.annotation.Strategy;
+import org.sopt.confeti.global.resolver.artist.AbstractArtistStrategy;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
+
+@Strategy
+@RequiredArgsConstructor
+public class ArtistFavoriteArtistStrategy extends AbstractArtistStrategy {
+
+    @Override
+    public void collect(List<String> artistIds, HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
+        ArtistFavorite artistFavorite = (ArtistFavorite) target;
+        ConfetiArtist confetiArtist = artistFavorite.getArtist();
+        artistIds.add(confetiArtist.getArtistId());
+        addArtistToMapper(confetiArtist.getArtistId(), artistMapper, artistFavorite.getArtist());
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return clazz == ArtistFavorite.class;
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteArtistStrategy.java
@@ -15,8 +15,7 @@ public class ArtistFavoriteArtistStrategy extends AbstractArtistStrategy {
     @Override
     public void collect(HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
         ArtistFavorite artistFavorite = (ArtistFavorite) target;
-        ConfetiArtist confetiArtist = artistFavorite.getArtist();
-        addArtistToMapper(confetiArtist.getArtistId(), artistMapper, artistFavorite.getArtist());
+        addArtistToMapper(artistMapper, artistFavorite.getArtist());
     }
 
     @Override

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteArtistStrategy.java
@@ -1,7 +1,6 @@
 package org.sopt.confeti.domain.artistfavorite.application;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Queue;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteArtistStrategy.java
@@ -14,10 +14,9 @@ import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 public class ArtistFavoriteArtistStrategy extends AbstractArtistStrategy {
 
     @Override
-    public void collect(List<String> artistIds, HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
+    public void collect(HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
         ArtistFavorite artistFavorite = (ArtistFavorite) target;
         ConfetiArtist confetiArtist = artistFavorite.getArtist();
-        artistIds.add(confetiArtist.getArtistId());
         addArtistToMapper(confetiArtist.getArtistId(), artistMapper, artistFavorite.getArtist());
     }
 

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
@@ -4,8 +4,7 @@ import lombok.AllArgsConstructor;
 import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;
 import org.sopt.confeti.domain.artistfavorite.infra.repository.ArtistFavoriteRepository;
 import org.sopt.confeti.domain.user.User;
-import org.sopt.confeti.global.util.artistsearcher.ArtistResolver;
-import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+import org.sopt.confeti.global.resolver.artist.ArtistResolver;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertArtistStrategy.java
@@ -1,0 +1,30 @@
+package org.sopt.confeti.domain.concert.application;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Queue;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;
+import org.sopt.confeti.domain.concert.Concert;
+import org.sopt.confeti.global.annotation.Strategy;
+import org.sopt.confeti.global.resolver.artist.AbstractArtistStrategy;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
+
+@Strategy
+@RequiredArgsConstructor
+public class ConcertArtistStrategy extends AbstractArtistStrategy {
+
+    @Override
+    public void collect(List<String> artistIds, HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
+        Concert concert = (Concert) target;
+        concert.getArtists().forEach(artist -> {
+            artistIds.add(artist.getArtist().getArtistId());
+            addArtistToMapper(artist.getArtist().getArtistId(), artistMapper, artist.getArtist());
+        });
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return clazz == Concert.class;
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertArtistStrategy.java
@@ -16,7 +16,7 @@ public class ConcertArtistStrategy extends AbstractArtistStrategy {
     public void collect(HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
         Concert concert = (Concert) target;
         concert.getArtists().forEach(artist -> {
-            addArtistToMapper(artist.getArtist().getArtistId(), artistMapper, artist.getArtist());
+            addArtistToMapper(artistMapper, artist.getArtist());
         });
     }
 

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertArtistStrategy.java
@@ -1,10 +1,8 @@
 package org.sopt.confeti.domain.concert.application;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Queue;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;
 import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.global.annotation.Strategy;
 import org.sopt.confeti.global.resolver.artist.AbstractArtistStrategy;

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertArtistStrategy.java
@@ -15,10 +15,9 @@ import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 public class ConcertArtistStrategy extends AbstractArtistStrategy {
 
     @Override
-    public void collect(List<String> artistIds, HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
+    public void collect(HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
         Concert concert = (Concert) target;
         concert.getArtists().forEach(artist -> {
-            artistIds.add(artist.getArtist().getArtistId());
             addArtistToMapper(artist.getArtist().getArtistId(), artistMapper, artist.getArtist());
         });
     }

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
@@ -8,7 +8,7 @@ import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.infra.repository.ConcertRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.util.artistsearcher.ArtistResolver;
+import org.sopt.confeti.global.resolver.artist.ArtistResolver;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;

--- a/src/main/java/org/sopt/confeti/domain/concertartist/ConcertArtist.java
+++ b/src/main/java/org/sopt/confeti/domain/concertartist/ConcertArtist.java
@@ -7,7 +7,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.sopt.confeti.api.performance.facade.dto.request.CreateConcertArtistDTO;
 import org.sopt.confeti.domain.concert.Concert;
-import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 
 @Entity
 @Table(name="concert_artists")

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalArtistStrategy.java
@@ -15,14 +15,13 @@ import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 public class FestivalArtistStrategy extends AbstractArtistStrategy {
 
     @Override
-    public void collect(List<String> artistIds, HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
+    public void collect(HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
         Festival festival = (Festival) target;
         festival.getDates().stream()
                 .flatMap(date -> date.getStages().stream())
                 .flatMap(stage -> stage.getTimes().stream())
                 .flatMap(time -> time.getArtists().stream())
                 .forEach(artist -> {
-                    artistIds.add(artist.getArtist().getArtistId());
                     addArtistToMapper(artist.getArtist().getArtistId(), artistMapper, artist.getArtist());
                 });
     }

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalArtistStrategy.java
@@ -1,0 +1,34 @@
+package org.sopt.confeti.domain.festival.application;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Queue;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.concert.Concert;
+import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.global.annotation.Strategy;
+import org.sopt.confeti.global.resolver.artist.AbstractArtistStrategy;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
+
+@Strategy
+@RequiredArgsConstructor
+public class FestivalArtistStrategy extends AbstractArtistStrategy {
+
+    @Override
+    public void collect(List<String> artistIds, HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
+        Festival festival = (Festival) target;
+        festival.getDates().stream()
+                .flatMap(date -> date.getStages().stream())
+                .flatMap(stage -> stage.getTimes().stream())
+                .flatMap(time -> time.getArtists().stream())
+                .forEach(artist -> {
+                    artistIds.add(artist.getArtist().getArtistId());
+                    addArtistToMapper(artist.getArtist().getArtistId(), artistMapper, artist.getArtist());
+                });
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return clazz == Festival.class;
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalArtistStrategy.java
@@ -1,10 +1,8 @@
 package org.sopt.confeti.domain.festival.application;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Queue;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.global.annotation.Strategy;
 import org.sopt.confeti.global.resolver.artist.AbstractArtistStrategy;

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalArtistStrategy.java
@@ -20,7 +20,7 @@ public class FestivalArtistStrategy extends AbstractArtistStrategy {
                 .flatMap(stage -> stage.getTimes().stream())
                 .flatMap(time -> time.getArtists().stream())
                 .forEach(artist -> {
-                    addArtistToMapper(artist.getArtist().getArtistId(), artistMapper, artist.getArtist());
+                    addArtistToMapper(artistMapper, artist.getArtist());
                 });
     }
 

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -10,7 +10,7 @@ import org.sopt.confeti.domain.festival.application.dto.FestivalCursorDTO;
 import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.util.artistsearcher.ArtistResolver;
+import org.sopt.confeti.global.resolver.artist.ArtistResolver;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;

--- a/src/main/java/org/sopt/confeti/domain/festivalartist/FestivalArtist.java
+++ b/src/main/java/org/sopt/confeti/domain/festivalartist/FestivalArtist.java
@@ -7,14 +7,9 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
 import org.sopt.confeti.api.performance.facade.dto.request.CreateFestivalArtistDTO;
-import org.sopt.confeti.domain.festivalstage.FestivalStage;
 import org.sopt.confeti.domain.festivaltime.FestivalTime;
-import org.sopt.confeti.domain.usertimetable.UserTimetable;
 
-import java.time.LocalDateTime;
-import java.util.ArrayList;
-import java.util.List;
-import org.sopt.confeti.global.util.artistsearcher.ConfetiArtist;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 
 @Entity
 @Table(name="festival_artists")

--- a/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateArtistStrategy.java
@@ -19,7 +19,7 @@ public class FestivalDateArtistStrategy extends AbstractArtistStrategy {
                 .flatMap(stage -> stage.getTimes().stream())
                 .flatMap(time -> time.getArtists().stream())
                 .forEach(artist -> {
-                    addArtistToMapper(artist.getArtist().getArtistId(), artistMapper, artist.getArtist());
+                    addArtistToMapper(artistMapper, artist.getArtist());
                 });
     }
 

--- a/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateArtistStrategy.java
@@ -1,0 +1,33 @@
+package org.sopt.confeti.domain.festivaldate.application;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Queue;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festivaldate.FestivalDate;
+import org.sopt.confeti.global.annotation.Strategy;
+import org.sopt.confeti.global.resolver.artist.AbstractArtistStrategy;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
+
+@Strategy
+@RequiredArgsConstructor
+public class FestivalDateArtistStrategy extends AbstractArtistStrategy {
+
+    @Override
+    public void collect(List<String> artistIds, HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
+        FestivalDate festivalDate = (FestivalDate) target;
+        festivalDate.getStages().stream()
+                .flatMap(stage -> stage.getTimes().stream())
+                .flatMap(time -> time.getArtists().stream())
+                .forEach(artist -> {
+                    artistIds.add(artist.getArtist().getArtistId());
+                    addArtistToMapper(artist.getArtist().getArtistId(), artistMapper, artist.getArtist());
+                });
+    }
+
+    @Override
+    public boolean supports(Class<?> clazz) {
+        return clazz == FestivalDate.class;
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateArtistStrategy.java
@@ -1,10 +1,8 @@
 package org.sopt.confeti.domain.festivaldate.application;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Queue;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festivaldate.FestivalDate;
 import org.sopt.confeti.global.annotation.Strategy;
 import org.sopt.confeti.global.resolver.artist.AbstractArtistStrategy;

--- a/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateArtistStrategy.java
@@ -15,13 +15,12 @@ import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 public class FestivalDateArtistStrategy extends AbstractArtistStrategy {
 
     @Override
-    public void collect(List<String> artistIds, HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
+    public void collect(HashMap<String, Queue<ConfetiArtist>> artistMapper, Object target) {
         FestivalDate festivalDate = (FestivalDate) target;
         festivalDate.getStages().stream()
                 .flatMap(stage -> stage.getTimes().stream())
                 .flatMap(time -> time.getArtists().stream())
                 .forEach(artist -> {
-                    artistIds.add(artist.getArtist().getArtistId());
                     addArtistToMapper(artist.getArtist().getArtistId(), artistMapper, artist.getArtist());
                 });
     }

--- a/src/main/java/org/sopt/confeti/global/annotation/Facade.java
+++ b/src/main/java/org/sopt/confeti/global/annotation/Facade.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.annotation;
+package org.sopt.confeti.global.annotation;
 
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;

--- a/src/main/java/org/sopt/confeti/global/annotation/Handler.java
+++ b/src/main/java/org/sopt/confeti/global/annotation/Handler.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.annotation;
+package org.sopt.confeti.global.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/org/sopt/confeti/global/annotation/Registry.java
+++ b/src/main/java/org/sopt/confeti/global/annotation/Registry.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.stereotype.Component;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Component
+public @interface Registry {
+}

--- a/src/main/java/org/sopt/confeti/global/annotation/Resolver.java
+++ b/src/main/java/org/sopt/confeti/global/annotation/Resolver.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.annotation;
+package org.sopt.confeti.global.annotation;
 
 import java.lang.annotation.Documented;
 import java.lang.annotation.ElementType;

--- a/src/main/java/org/sopt/confeti/global/annotation/Strategy.java
+++ b/src/main/java/org/sopt/confeti/global/annotation/Strategy.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.global.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import org.springframework.stereotype.Component;
+
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Component
+public @interface Strategy {
+}

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/AbstractArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/AbstractArtistStrategy.java
@@ -2,12 +2,10 @@ package org.sopt.confeti.global.resolver.artist;
 
 import java.util.HashMap;
 import java.util.LinkedList;
-import java.util.List;
 import java.util.Queue;
 
 public abstract class AbstractArtistStrategy implements ArtistStrategy {
     public abstract void collect(
-            List<String> artistIds,
             HashMap<String, Queue<ConfetiArtist>> artistMapper,
             Object target
     );

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/AbstractArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/AbstractArtistStrategy.java
@@ -1,0 +1,35 @@
+package org.sopt.confeti.global.resolver.artist;
+
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Queue;
+
+public abstract class AbstractArtistStrategy implements ArtistStrategy {
+    public abstract void collect(
+            List<String> artistIds,
+            HashMap<String, Queue<ConfetiArtist>> artistMapper,
+            Object target
+    );
+
+    public abstract boolean supports(Class<?> clazz);
+
+    protected void addArtistToMapper(
+            String artistId,
+            HashMap<String, Queue<ConfetiArtist>> artistMapper,
+            ConfetiArtist artist
+    ) {
+        if (!artistMapper.containsKey(artistId)) {
+            createQueueToMapper(artistId, artistMapper);
+        }
+
+        artistMapper.get(artistId).add(artist);
+    }
+
+    private void createQueueToMapper(
+            String artistId,
+            HashMap<String, Queue<ConfetiArtist>> artistMapper
+    ) {
+        artistMapper.put(artistId, new LinkedList<>());
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/AbstractArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/AbstractArtistStrategy.java
@@ -13,15 +13,14 @@ public abstract class AbstractArtistStrategy implements ArtistStrategy {
     public abstract boolean supports(Class<?> clazz);
 
     protected void addArtistToMapper(
-            String artistId,
             HashMap<String, Queue<ConfetiArtist>> artistMapper,
             ConfetiArtist artist
     ) {
-        if (!artistMapper.containsKey(artistId)) {
-            createQueueToMapper(artistId, artistMapper);
+        if (!artistMapper.containsKey(artist.getArtistId())) {
+            createQueueToMapper(artist.getArtistId(), artistMapper);
         }
 
-        artistMapper.get(artistId).add(artist);
+        artistMapper.get(artist.getArtistId()).add(artist);
     }
 
     private void createQueueToMapper(

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Queue;
+import java.util.Set;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Resolver;
@@ -15,34 +16,25 @@ import org.sopt.confeti.global.util.SpotifyAPIHandler;
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArtistResolver {
 
-    private List<String> artistIds;
-    private HashMap<String, Queue<ConfetiArtist>> artistMapper;
-
     private final SpotifyAPIHandler spotifyAPIHandler;
     private final ArtistStrategyRegistry artistStrategyRegistry;
 
-    private void prologue() {
-        artistIds = new ArrayList<>();
-        artistMapper = new HashMap<>();
-    }
-
-    private void epilogue() {
-        artistIds.clear();
-        artistMapper.clear();
-    }
-
     // Spotify API를 사용해 아티스트를 로드하는 엔트리 포인트
     public void load(final Object target) {
-        prologue();
-        collect(target, artistStrategyRegistry.getArtistStrategyByClass(target.getClass()));
+        final HashMap<String, Queue<ConfetiArtist>> artistMapper = new HashMap<>();
 
-        List<ConfetiArtist> confetiArtists =  searchByArtistIds(artistIds);
+        collect(artistMapper, target, artistStrategyRegistry.getArtistStrategyByClass(target.getClass()));
 
-        injection(confetiArtists);
-        epilogue();
+        List<ConfetiArtist> confetiArtists =  searchByArtistIds(artistMapper.keySet());
+
+        injection(artistMapper, confetiArtists);
     }
 
-    private void collect(final Object target, final ArtistStrategy artistStrategy) {
+    private void collect(
+            final HashMap<String, Queue<ConfetiArtist>> artistMapper,
+            final Object target,
+            final ArtistStrategy artistStrategy
+    ) {
         if (target == null) {
             return;
         }
@@ -53,20 +45,23 @@ public class ArtistResolver {
 
             targets.forEach(loadTarget -> {
                 // Mapper에 등록된 클래스 타입인 경우
-                artistStrategy.collect(artistIds, artistMapper, loadTarget);
+                artistStrategy.collect(artistMapper, loadTarget);
             });
 
             return;
         }
         // Mapper에 등록된 클래스 타입인 경우
-        artistStrategy.collect(artistIds, artistMapper, target);
+        artistStrategy.collect(artistMapper, target);
     }
 
     private boolean isListType(final Object target) {
         return target.getClass() == ArrayList.class;
     }
 
-    private void injection(final List<ConfetiArtist> confetiArtists) {
+    private void injection(
+            final HashMap<String, Queue<ConfetiArtist>> artistMapper,
+            final List<ConfetiArtist> confetiArtists
+    ) {
         confetiArtists.forEach((confetiArtist -> {
             ConfetiArtist mappedConfetiArtist = artistMapper.get(confetiArtist.getArtistId()).poll();
 
@@ -79,7 +74,7 @@ public class ArtistResolver {
         }));
     }
 
-    private List<ConfetiArtist> searchByArtistIds(final List<String> artistIds) {
+    private List<ConfetiArtist> searchByArtistIds(final Set<String> artistIds) {
         return spotifyAPIHandler.findArtistsByArtistIdsEntry(artistIds);
     }
 }

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
@@ -63,14 +63,14 @@ public class ArtistResolver {
             final List<ConfetiArtist> confetiArtists
     ) {
         confetiArtists.forEach((confetiArtist -> {
-            ConfetiArtist mappedConfetiArtist = artistMapper.get(confetiArtist.getArtistId()).poll();
+            Queue<ConfetiArtist> mappedConfetiArtists = artistMapper.get(confetiArtist.getArtistId());
 
-            if (mappedConfetiArtist == null) {
-                throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
+            while (!mappedConfetiArtists.isEmpty()) {
+                ConfetiArtist mappedConfetiArtist = mappedConfetiArtists.poll();
+
+                mappedConfetiArtist.setName(confetiArtist.getName());
+                mappedConfetiArtist.setProfileUrl(confetiArtist.getProfileUrl());
             }
-
-            mappedConfetiArtist.setName(confetiArtist.getName());
-            mappedConfetiArtist.setProfileUrl(confetiArtist.getProfileUrl());
         }));
     }
 

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.global.util.artistsearcher;
+package org.sopt.confeti.global.resolver.artist;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -16,6 +16,7 @@ import org.sopt.confeti.domain.festivaldate.FestivalDate;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.util.IntegrateFunction;
+import org.sopt.confeti.global.util.SpotifyAPIHandler;
 
 @Resolver
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
@@ -2,50 +2,24 @@ package org.sopt.confeti.global.resolver.artist;
 
 import java.util.ArrayList;
 import java.util.HashMap;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Queue;
-import java.util.concurrent.ConcurrentHashMap;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Resolver;
-import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;
-import org.sopt.confeti.domain.concert.Concert;
-import org.sopt.confeti.domain.festival.Festival;
-import org.sopt.confeti.domain.festivaldate.FestivalDate;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.util.IntegrateFunction;
 import org.sopt.confeti.global.util.SpotifyAPIHandler;
 
 @Resolver
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArtistResolver {
 
-    // 기존에 조회할 클래스를 매핑
-    private final ConcurrentHashMap<Class<?>, IntegrateFunction> collectByTypeMapper = new ConcurrentHashMap<Class<?>, IntegrateFunction>() {{
-        put(ArtistFavorite.class, args -> {
-            collectArtistFavorite(args[0]);
-            return null;
-        });
-        put(Concert.class, args -> {
-            collectConcert(args[0]);
-            return null;
-        });
-        put(Festival.class, args -> {
-            collectFestival(args[0]);
-            return null;
-        });
-        put(FestivalDate.class, args -> {
-            collectFestivalDate(args[0]);
-            return null;
-        });
-    }};
-
     private List<String> artistIds;
     private HashMap<String, Queue<ConfetiArtist>> artistMapper;
 
     private final SpotifyAPIHandler spotifyAPIHandler;
+    private final ArtistStrategyRegistry artistStrategyRegistry;
 
     private void prologue() {
         artistIds = new ArrayList<>();
@@ -60,7 +34,7 @@ public class ArtistResolver {
     // Spotify API를 사용해 아티스트를 로드하는 엔트리 포인트
     public void load(final Object target) {
         prologue();
-        collect(target);
+        collect(target, artistStrategyRegistry.getArtistStrategyByClass(target.getClass()));
 
         List<ConfetiArtist> confetiArtists =  searchByArtistIds(artistIds);
 
@@ -68,71 +42,28 @@ public class ArtistResolver {
         epilogue();
     }
 
-    private void collect(final Object target) {
+    private void collect(final Object target, final ArtistStrategy artistStrategy) {
         if (target == null) {
             return;
         }
 
         // 주어진 타겟이 리스트일 경우
         if (isListType(target)) {
-            List<Object> objects = (List<Object>) target;
+            List<Object> targets = (List<Object>) target;
 
-            objects.forEach(object -> {
+            targets.forEach(loadTarget -> {
                 // Mapper에 등록된 클래스 타입인 경우
-                if (collectByTypeMapper.containsKey(object.getClass())) {
-                    collectByTypeMapper.get(object.getClass())
-                            .apply(object);
-                }
+                artistStrategy.collect(artistIds, artistMapper, loadTarget);
             });
 
             return;
         }
         // Mapper에 등록된 클래스 타입인 경우
-        if (collectByTypeMapper.containsKey(target.getClass())) {
-            collectByTypeMapper.get(target.getClass()).apply(target);
-        }
+        artistStrategy.collect(artistIds, artistMapper, target);
     }
 
     private boolean isListType(final Object target) {
         return target.getClass() == ArrayList.class;
-    }
-
-    private void collectArtistFavorite(final Object target) {
-        ArtistFavorite artistFavorite = (ArtistFavorite) target;
-        ConfetiArtist confetiArtist = artistFavorite.getArtist();
-        artistIds.add(confetiArtist.getArtistId());
-        addArtistToMapper(confetiArtist.getArtistId(), artistFavorite.getArtist());
-    }
-
-    private void collectConcert(final Object target) {
-        Concert concert = (Concert) target;
-        concert.getArtists().forEach(artist -> {
-                    artistIds.add(artist.getArtist().getArtistId());
-                    addArtistToMapper(artist.getArtist().getArtistId(), artist.getArtist());
-                });
-    }
-
-    private void collectFestival(final Object target) {
-        Festival festival = (Festival) target;
-        festival.getDates().stream()
-                .flatMap(date -> date.getStages().stream())
-                .flatMap(stage -> stage.getTimes().stream())
-                .flatMap(time -> time.getArtists().stream())
-                .forEach(artist -> {
-                    artistIds.add(artist.getArtist().getArtistId());
-                    addArtistToMapper(artist.getArtist().getArtistId(), artist.getArtist());
-                });
-    }
-
-    private void collectFestivalDate(final Object target) {
-        FestivalDate festivalDate = (FestivalDate) target;
-        festivalDate.getStages().stream()
-                .flatMap(stage -> stage.getTimes().stream())
-                .flatMap(time -> time.getArtists().stream())
-                .forEach(artist -> {
-                    artistIds.add(artist.getArtist().getArtistId());
-                    addArtistToMapper(artist.getArtist().getArtistId(), artist.getArtist());
-                });
     }
 
     private void injection(final List<ConfetiArtist> confetiArtists) {
@@ -150,17 +81,5 @@ public class ArtistResolver {
 
     private List<ConfetiArtist> searchByArtistIds(final List<String> artistIds) {
         return spotifyAPIHandler.findArtistsByArtistIdsEntry(artistIds);
-    }
-
-    private void addArtistToMapper(final String artistId, final ConfetiArtist artist) {
-        if (!artistMapper.containsKey(artistId)) {
-            createQueueToMapper(artistId);
-        }
-
-        artistMapper.get(artistId).add(artist);
-    }
-
-    private void createQueueToMapper(final String artistId) {
-        artistMapper.put(artistId, new LinkedList<>());
     }
 }

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistStrategy.java
@@ -1,13 +1,11 @@
 package org.sopt.confeti.global.resolver.artist;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Queue;
 
 public interface ArtistStrategy {
 
     void collect(
-            List<String> artistIds,
             HashMap<String, Queue<ConfetiArtist>> artistMapper,
             Object target
     );

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistStrategy.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.global.resolver.artist;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Queue;
+
+public interface ArtistStrategy {
+
+    void collect(
+            List<String> artistIds,
+            HashMap<String, Queue<ConfetiArtist>> artistMapper,
+            Object target
+    );
+
+    boolean supports(Class<?> clazz);
+}

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistStrategyRegistry.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistStrategyRegistry.java
@@ -1,0 +1,23 @@
+package org.sopt.confeti.global.resolver.artist;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.global.annotation.Registry;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
+
+@Registry
+@RequiredArgsConstructor
+public class ArtistStrategyRegistry {
+
+    private final List<ArtistStrategy> artistStrategies;
+
+    public ArtistStrategy getArtistStrategyByClass(Class<?> clazz) {
+        return artistStrategies.stream()
+                .filter(strategy -> strategy.supports(clazz))
+                .findFirst()
+                .orElseThrow(
+                        () -> new ConfetiException(ErrorMessage.BAD_REQUEST)
+                );
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ConfetiArtist.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ConfetiArtist.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.global.util.artistsearcher;
+package org.sopt.confeti.global.resolver.artist;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;

--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -1,6 +1,6 @@
 package org.sopt.confeti.global.util;
 
-import org.sopt.confeti.annotation.Handler;
+import org.sopt.confeti.global.annotation.Handler;
 import org.springframework.beans.factory.annotation.Value;
 
 @Handler

--- a/src/main/java/org/sopt/confeti/global/util/SpotifyAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/SpotifyAPIHandler.java
@@ -9,8 +9,10 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.stream.IntStream;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Handler;
@@ -97,34 +99,22 @@ public class SpotifyAPIHandler {
         }
     }
 
-    public List<ConfetiArtist> findArtistsByArtistIdsEntry(final List<String> artistIds) {
+    public List<ConfetiArtist> findArtistsByArtistIdsEntry(final Set<String> artistIds) {
         // 아티스트 아이디 개수가 최대를 넘지 않는 경우 단일 호출
         if (artistIds.size() <= GET_SEVERAL_ARTIST_MAXIMUM_SIZE) {
-            return findArtistsByArtistIds(artistIds);
+            return findArtistsByArtistIds(artistIds.stream().toList());
         }
-
-        // 최대를 넘는 경우 최대 개수(50개)씩 나눠서 가져옴
-        int iteration = (artistIds.size() - 1) / GET_SEVERAL_ARTIST_MAXIMUM_SIZE;
-        int remain = artistIds.size() % GET_SEVERAL_ARTIST_MAXIMUM_SIZE;
 
         List<ConfetiArtist> artists = new ArrayList<>();
 
-        IntStream.range(0, iteration)
-                .forEach(i -> {
-                    artists.addAll(
-                            findArtistsByArtistIds(artistIds.subList(
-                                    i * GET_SEVERAL_ARTIST_MAXIMUM_SIZE,
-                                    (i + 1) * GET_SEVERAL_ARTIST_MAXIMUM_SIZE
-                            ))
-                    );
+        AtomicInteger counter = new AtomicInteger();
+        artistIds.stream()
+                .collect(Collectors.groupingBy(artistId -> counter.getAndIncrement() / GET_SEVERAL_ARTIST_MAXIMUM_SIZE))
+                .values()
+                .parallelStream()
+                .forEach(consumeArtistIds -> {
+                    artists.addAll(findArtistsByArtistIds(consumeArtistIds));
                 });
-
-        artists.addAll(
-                findArtistsByArtistIds(artistIds.subList(
-                        iteration * GET_SEVERAL_ARTIST_MAXIMUM_SIZE,
-                        iteration * GET_SEVERAL_ARTIST_MAXIMUM_SIZE + remain
-                ))
-        );
 
         return artists;
     }

--- a/src/main/java/org/sopt/confeti/global/util/SpotifyAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/SpotifyAPIHandler.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.global.util.artistsearcher;
+package org.sopt.confeti.global.util;
 
 import com.neovisionaries.i18n.CountryCode;
 import java.time.LocalDate;
@@ -16,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Handler;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.util.DateConvertor;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
 import org.springframework.beans.factory.annotation.Value;
 import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;

--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/ArtistResolver.java
@@ -8,7 +8,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.annotation.Resolver;
+import org.sopt.confeti.global.annotation.Resolver;
 import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;
 import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.festival.Festival;

--- a/src/main/java/org/sopt/confeti/global/util/artistsearcher/SpotifyAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/artistsearcher/SpotifyAPIHandler.java
@@ -13,7 +13,7 @@ import java.util.concurrent.Callable;
 import java.util.stream.IntStream;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.annotation.Handler;
+import org.sopt.confeti.global.annotation.Handler;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.util.DateConvertor;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #223 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] Artist 정보 수집 Registry 생성
- [x] ArtistResolver에서 Artist 정보 수집 로직 분리
- [x] 탐색 대상 엔티티 Registry 등록

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
### 문제 상황
기존 ArtistResolver 클래스는 탐색 대상 클래스의 Artist 정보를 수집하고, 조회된 정보를 주입하기 위해 단일 파일에 함수를 등록했습니다.
이로 인해 새로운 엔티티가 추가되거나 엔티티 변경사항이 생기면 ArtistResolver 파일도 수정해야하는, 변경지점이 다수 발생하는 문제가 있습니다.

[탐색 대상 클래스 등록]
<img width="999" alt="Image" src="https://github.com/user-attachments/assets/739eb969-38bb-4ece-bc89-a545f54c11ab" />

[객체 그래프 탐색 로직 구현]
<img width="651" alt="Image" src="https://github.com/user-attachments/assets/092885c6-1bce-41bb-a3d2-d0ba5d577dfd" />

이를 해결하기 위해 전략(Strategy) 패턴을 사용해서 엔티티의 변경 사항이 `ArtistResolver`에 영향이 가지않도록 격리시키고 탐색이 필요한 엔티티를 Registry에 등록시켜 유연성과 확장성(OCP 원칙) 향상시키고자 합니다.

### 해결 방법
![image](https://github.com/user-attachments/assets/51242ebe-5d5a-4b63-a3fe-cecf93bfa45d)

아티스트 정보를 주입받기 위해 구현해야 하는 함수를 강제한 인터페이스 입니다.
- collect 함수 : 엔티티 객체 그래프 상의 아티스트 정보를 가지는 객체의 위치를 정의하는 함수입니다. 객체 그래프 상의 탐색 대상을 정의하고 `artistMapper`에 객체를 등록합니다.
- supports 함수 : ArtistResolver에 주어진 엔티티의 클래스에 대응되는 전략을 반환하기 위해 해당 전략이 주어진 클래스를 지원하는지 여부를 반환합니다.

![image](https://github.com/user-attachments/assets/f5b40199-aaa0-4d7e-9f8c-b78003c2960d)

`artistMapper` 변수 관리를 위해 공통적인 함수 작성이 필요했습니다. 그래서 abstract 클래스를 작성했습니다.

![image](https://github.com/user-attachments/assets/d0e9aeae-b194-415b-9d66-a03c40415403)

`ArtistResolver` 가 사용하는 아티스트 전략 빈 클래스입니다.
주어진 타겟의 클래스를 가지고 적절한 전략을 요청합니다.

![image](https://github.com/user-attachments/assets/751e458c-4c72-404e-a913-d543633b76a3)

Festival 엔티티가 구현한 아티스트 전략 클래스입니다.
자신이 가지고 있는 아티스트 객체 위치를 탐색해 `artistMapper` 에 등록합니다.
Festival 클래스 타입일 경우 supports 함수는 true를 반환합니다.

[ArtistResolver load 함수]
|변경 전|변경 후|
|---|---|
|![image](https://github.com/user-attachments/assets/84f2ff17-a13c-44c0-8dfc-e817f89a936b)|![image](https://github.com/user-attachments/assets/2ff40f31-87db-4473-83ba-18f4ed85744f)|

ArtistMapper를 지역변수로 변경한 이유는 싱글톤으로 관리되는 빈은 상태를 가지면 안되기 때문입니다. 상태를 가지면 서로 다른 스레드에서 처리하는 데이터에 서로 영향을 줄 수 있기 때문에 지역 변수로 변경했습니다.

[ArtistResolver collect 함수]
|변경 전|변경 후|
|---|---|
|![image](https://github.com/user-attachments/assets/7b85dff9-6887-4e81-b7ac-7c3b15cc46b4)|![image](https://github.com/user-attachments/assets/76092525-54b1-4554-bec0-e605b9fd1850)|

코드 변경 후에는 아티스트 전략 구현 클래스만 변경하면 Resolver 클래스를 변경하지 않아도 변경사항을 적용할 수 있게 되었습니다.
