### PR TITLE
fix [#229] ArtistResolver의 load 함수의 인자가 리스트 타입일 때 아티스트 정보를 주입하지 못하는 문제 해결

### DIFF
--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
@@ -1,6 +1,5 @@
 package org.sopt.confeti.global.resolver.artist;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Queue;
@@ -20,42 +19,56 @@ public class ArtistResolver {
     private final ArtistStrategyRegistry artistStrategyRegistry;
 
     // Spotify API를 사용해 아티스트를 로드하는 엔트리 포인트
-    public void load(final Object target) {
+    public <T> void load(final T target) {
         final HashMap<String, Queue<ConfetiArtist>> artistMapper = new HashMap<>();
 
-        collect(artistMapper, target, artistStrategyRegistry.getArtistStrategyByClass(target.getClass()));
+        collect(artistMapper, target);
 
         List<ConfetiArtist> confetiArtists =  searchByArtistIds(artistMapper.keySet());
 
         injection(artistMapper, confetiArtists);
     }
 
-    private void collect(
+    private <T> void collect(
             final HashMap<String, Queue<ConfetiArtist>> artistMapper,
-            final Object target,
-            final ArtistStrategy artistStrategy
+            final T target
+    ) {
+        if (isListType(target)) {
+            collectList(artistMapper, (List<?>) target);
+            return;
+        }
+
+        collectSingle(artistMapper, target);
+    }
+
+    private <T> void collectList(
+            final HashMap<String, Queue<ConfetiArtist>> artistMapper,
+            final List<T> targets
+    ) {
+        if (targets.isEmpty()) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
+
+        ArtistStrategy artistStrategy = artistStrategyRegistry.getArtistStrategyByClass(targets.getFirst().getClass());
+        targets.forEach(target -> {
+            artistStrategy.collect(artistMapper, target);
+        });
+    }
+
+    private <T> void collectSingle(
+            final HashMap<String, Queue<ConfetiArtist>> artistMapper,
+            final T target
     ) {
         if (target == null) {
-            return;
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
 
-        // 주어진 타겟이 리스트일 경우
-        if (isListType(target)) {
-            List<Object> targets = (List<Object>) target;
-
-            targets.forEach(loadTarget -> {
-                // Mapper에 등록된 클래스 타입인 경우
-                artistStrategy.collect(artistMapper, loadTarget);
-            });
-
-            return;
-        }
-        // Mapper에 등록된 클래스 타입인 경우
+        ArtistStrategy artistStrategy = artistStrategyRegistry.getArtistStrategyByClass(target.getClass());
         artistStrategy.collect(artistMapper, target);
     }
 
-    private boolean isListType(final Object target) {
-        return target.getClass() == ArrayList.class;
+    private <T> boolean isListType(final T target) {
+        return target instanceof List<?>;
     }
 
     private void injection(


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #229 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 리스트 타입 여부 판단, 아티스트 전략 조회 로직을 collect 함수 내부로 이동
- [x] load, collect 및 연계 함수에서 타겟의 클래스를 Object가 아닌 제네릭 타입으로 변경

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="477" alt="image" src="https://github.com/user-attachments/assets/9adbda41-68be-47a9-a36c-6cd1994a3e9a" />

collect 함수 진입 시 리스트 타입인지 검사하고, 리스트 타입일 경우 `collectList` 함수로, 그 외의 타입일 경우 `collectSingle` 함수로 처리를 요청합니다.

<img width="841" alt="image" src="https://github.com/user-attachments/assets/f0d4e026-4f75-4cb1-a44e-2f1654547f00" />

`collectList` 함수는 리스트가 비어있지 않아야 하고, 타겟의 클래스 정보를 가지고 아티스트 전략을 요청한 뒤 리스트를 순회하며 처리를 요청합니다.

<img width="754" alt="image" src="https://github.com/user-attachments/assets/e5457827-8897-42b8-a388-f590bd945c9a" />

`collectSingle` 함수는 타겟이 null이 아니어야 하고, 타겟의 클래스 정보를 가지고 아티스트 전략을 요청한 뒤 처리를 요청합니다.
