### PR TITLE
refactor [#227] 아티스트 정보 조회에 사용하는 Open API 추상화

### DIFF
--- a/src/main/java/org/sopt/confeti/ConfetiApplication.java
+++ b/src/main/java/org/sopt/confeti/ConfetiApplication.java
@@ -1,26 +1,12 @@
 package org.sopt.confeti;
 
-import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.global.util.SpotifyAPIHandler;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
-import org.springframework.boot.context.event.ApplicationReadyEvent;
-import org.springframework.context.ApplicationContext;
-import org.springframework.context.event.EventListener;
 
 @SpringBootApplication
-@RequiredArgsConstructor
 public class ConfetiApplication {
-
-    private final ApplicationContext ac;
 
     public static void main(String[] args) {
         SpringApplication.run(ConfetiApplication.class, args);
-    }
-
-    @EventListener(ApplicationReadyEvent.class)
-    public void init() {
-        SpotifyAPIHandler spotifyAPIHandler = ac.getBean(SpotifyAPIHandler.class);
-        spotifyAPIHandler.init();
     }
 }

--- a/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
@@ -6,7 +6,7 @@ import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.artist.facade.dto.response.SearchArtistDTO;
 import org.sopt.confeti.domain.artistfavorite.application.ArtistFavoriteService;
 import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
-import org.sopt.confeti.global.util.SpotifyAPIHandler;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.transaction.annotation.Transactional;
 
 @Facade
@@ -14,11 +14,11 @@ import org.springframework.transaction.annotation.Transactional;
 public class ArtistFacade {
 
     private final ArtistFavoriteService artistFavoriteService;
-    private final SpotifyAPIHandler spotifyAPIHandler;
+    private final MusicAPIHandler musicAPIHandler;
 
     @Transactional(readOnly = true)
     public SearchArtistDTO searchByKeyword(final Long userId, final String keyword) {
-        Optional<ConfetiArtist> confetiArtist = spotifyAPIHandler.findArtistsByKeyword(keyword);
+        Optional<ConfetiArtist> confetiArtist = musicAPIHandler.findArtistByKeyword(keyword);
 
         boolean isFavorite = false;
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -21,7 +21,7 @@ import org.sopt.confeti.global.exception.ConflictException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
-import org.sopt.confeti.global.util.SpotifyAPIHandler;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -36,7 +36,7 @@ public class UserFavoriteFacade {
     private final ArtistFavoriteService artistFavoriteService;
     private final ConcertFavoriteService concertFavoriteService;
     private final ConcertService concertService;
-    private final SpotifyAPIHandler spotifyAPIHandler;
+    private final MusicAPIHandler musicAPIHandler;
     private final PerformanceService performanceService;
 
     @Transactional
@@ -98,7 +98,7 @@ public class UserFavoriteFacade {
     }
 
     private void validateExistArtist(final String artistId) {
-        Optional<ConfetiArtist> artist = spotifyAPIHandler.findArtistByArtistId(artistId);
+        Optional<ConfetiArtist> artist = musicAPIHandler.findArtistByArtistId(artistId);
         if (artist.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }

--- a/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/artist/ArtistResolver.java
@@ -9,13 +9,13 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Resolver;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.util.SpotifyAPIHandler;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
 
 @Resolver
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArtistResolver {
 
-    private final SpotifyAPIHandler spotifyAPIHandler;
+    private final MusicAPIHandler musicAPIHandler;
     private final ArtistStrategyRegistry artistStrategyRegistry;
 
     // Spotify API를 사용해 아티스트를 로드하는 엔트리 포인트
@@ -88,6 +88,6 @@ public class ArtistResolver {
     }
 
     private List<ConfetiArtist> searchByArtistIds(final Set<String> artistIds) {
-        return spotifyAPIHandler.findArtistsByArtistIdsEntry(artistIds);
+        return musicAPIHandler.findArtistsByArtistIds(artistIds);
     }
 }

--- a/src/main/java/org/sopt/confeti/global/util/SpotifyAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/SpotifyAPIHandler.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.global.util;
 
 import com.neovisionaries.i18n.CountryCode;
+import jakarta.annotation.PostConstruct;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -52,6 +53,7 @@ public class SpotifyAPIHandler {
 
     private int refreshCount;
 
+    @PostConstruct
     public void init() {
         createSpotifyApi();
         generateAccessToken();

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.global.util.music;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
+
+public interface MusicAPIHandler {
+
+    List<ConfetiArtist> findArtistsByArtistIds(final Set<String> artistIds);
+    Optional<ConfetiArtist> findArtistByKeyword(final String keyword);
+    Optional<ConfetiArtist> findArtistByArtistId(final String artistId);
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandlerTemplate.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandlerTemplate.java
@@ -1,0 +1,32 @@
+package org.sopt.confeti.global.util.music;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
+import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
+
+public abstract class MusicAPIHandlerTemplate implements MusicAPIHandler {
+
+    protected abstract List<ConfetiArtist> findArtistsByArtistIds(final List<String> artistIds);
+
+    protected List<ConfetiArtist> findArtistsByArtistIds(final Set<String> artistIds, final int fetchLimit) {
+        if (artistIds.size() <= fetchLimit) {
+            return findArtistsByArtistIds(artistIds.stream().toList());
+        }
+
+        List<ConfetiArtist> artists = new ArrayList<>();
+
+        AtomicInteger counter = new AtomicInteger();
+        artistIds.stream()
+                .collect(Collectors.groupingBy(artistId -> counter.getAndIncrement() / fetchLimit))
+                .values()
+                .parallelStream()
+                .forEach(consumeArtistIds -> {
+                    artists.addAll(findArtistsByArtistIds(consumeArtistIds));
+                });
+
+        return artists;
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/SpotifyAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/SpotifyAPIHandler.java
@@ -1,9 +1,8 @@
-package org.sopt.confeti.global.util;
+package org.sopt.confeti.global.util.music;
 
 import com.neovisionaries.i18n.CountryCode;
 import jakarta.annotation.PostConstruct;
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
@@ -12,15 +11,15 @@ import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.atomic.AtomicInteger;
-import java.util.stream.Collectors;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Handler;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.artist.ConfetiArtist;
+import org.sopt.confeti.global.util.DateConvertor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Primary;
 import se.michaelthelin.spotify.SpotifyApi;
 import se.michaelthelin.spotify.exceptions.SpotifyWebApiException;
 import se.michaelthelin.spotify.exceptions.detailed.BadRequestException;
@@ -32,8 +31,9 @@ import se.michaelthelin.spotify.model_objects.specification.Artist;
 import se.michaelthelin.spotify.model_objects.specification.Paging;
 
 @Handler
+@Primary
 @RequiredArgsConstructor(access = AccessLevel.PROTECTED)
-public class SpotifyAPIHandler {
+public class SpotifyAPIHandler extends MusicAPIHandlerTemplate {
 
     private static final int ARTIST_LIMIT = 1;
     private static final int ARTIST_OFFSET = 0;
@@ -61,7 +61,13 @@ public class SpotifyAPIHandler {
         refreshCount = REFRESH_INIT_VALUE;
     }
 
-    public Optional<ConfetiArtist> findArtistsByKeyword(final String keyword) {
+    @Override
+    public List<ConfetiArtist> findArtistsByArtistIds(final Set<String> artistIds) {
+        return findArtistsByArtistIds(artistIds, GET_SEVERAL_ARTIST_MAXIMUM_SIZE);
+    }
+
+    @Override
+    public Optional<ConfetiArtist> findArtistByKeyword(final String keyword) {
         Optional<Artist> searched = searchArtistByKeyword(keyword);
 
         if (searched.isEmpty()) {
@@ -75,6 +81,7 @@ public class SpotifyAPIHandler {
         );
     }
 
+    @Override
     public Optional<ConfetiArtist> findArtistByArtistId(final String artistId) {
         if (artistId == null || artistId.isBlank()) {
             return Optional.empty();
@@ -101,27 +108,8 @@ public class SpotifyAPIHandler {
         }
     }
 
-    public List<ConfetiArtist> findArtistsByArtistIdsEntry(final Set<String> artistIds) {
-        // 아티스트 아이디 개수가 최대를 넘지 않는 경우 단일 호출
-        if (artistIds.size() <= GET_SEVERAL_ARTIST_MAXIMUM_SIZE) {
-            return findArtistsByArtistIds(artistIds.stream().toList());
-        }
-
-        List<ConfetiArtist> artists = new ArrayList<>();
-
-        AtomicInteger counter = new AtomicInteger();
-        artistIds.stream()
-                .collect(Collectors.groupingBy(artistId -> counter.getAndIncrement() / GET_SEVERAL_ARTIST_MAXIMUM_SIZE))
-                .values()
-                .parallelStream()
-                .forEach(consumeArtistIds -> {
-                    artists.addAll(findArtistsByArtistIds(consumeArtistIds));
-                });
-
-        return artists;
-    }
-
-    public List<ConfetiArtist> findArtistsByArtistIds(final List<String> artistIds) {
+    @Override
+    protected List<ConfetiArtist> findArtistsByArtistIds(final List<String> artistIds) {
         if (artistIds.isEmpty()) {
             return Collections.emptyList();
         }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #227 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 아티스트 정보 조회 Open API 추상화


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
음악 정보를 가져오는 외부 도메인이 Spotify API에서 Apple Music API로 바뀔 예정이고, 해당 변경사항이 API를 사용하는 모든 코드에 영향을 미칠 것을 예상해 의존성을 끊어내려고 합니다!
외부에서 주입되는 객체를 사용하는 방식으로 DI를 만족하도록 구성할거에요.
<br>
아래는 리팩토링 결과 코드의 포스트맨 응답 스크린샷입니다.
<img width="762" alt="image" src="https://github.com/user-attachments/assets/452dacb1-262f-4923-a3e3-197e3f28f6dd" />
<br>
![image](https://github.com/user-attachments/assets/a45be455-6af7-40bc-ac67-0d2868842db2)
`MusicAPIHandler` 인터페이스를 작성해 서비스에서 필요로 하기 때문에 무조건 구현해야할 함수를 모아뒀어요.
<br>
![image](https://github.com/user-attachments/assets/6f78acca-2076-4839-a4f4-c02891b0099c)
"여러 아티스트 아이디로 여러 아티스트 한 번에 조회하기"의 경우 보통 조회할 수 있는 아이디의 개수가 정해져 있기 때문에 나눠서 요청을 해야하는데요, 이 경우 외부 API에 의존적이지 않아 공통 로직으로 구성할 수 있어 `Abstract` 파일로 구현했어요.
<br>
![image](https://github.com/user-attachments/assets/c695a901-3aae-4486-a580-09c52e657559)
마지막으로 `MusicAPIHandlerTemplate`을 상속받아 구현해줬습니다!
`@Primary` 어노테이션을 사용해 여러 개의 `MusicAPIHandler` 빈 객체가 등록되어 있어도 `SpotifyAPIHandler`가 주입되도록 했어요.
<br>
![image](https://github.com/user-attachments/assets/d50bc9bf-a551-46b2-a175-dbcc2e7d43e6)
`ArtistResolver`에서 외부 API를 어떤 것을 사용하는지의 여부와 관계없이 등록된 빈 객체를 주입받아 코드 변경없이 변경사항을 적용할 수 있게 되었습니다.