### PR TITLE
fix [#252] 폴더 경로 생성 시 구분자("/")가 한 번 들어가도록 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
@@ -19,7 +19,8 @@ public enum FolderPath {
     public static String combine(FolderPath... folderPaths) {
         return String.join(
                 PATH_DELIMITER,
-                Arrays.stream(folderPaths).map(FolderPath::getSingle).toList()
+                Arrays.stream(folderPaths)
+                        .map(folderPath -> folderPath.path).toList()
         ) + PATH_DELIMITER;
     }
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #252

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 폴더 경로 생성 시 구분자가 한 번 들어가도록 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
> #### 원인
`FolderPath` 클래스의 `getSingle` 함수가 단독으로 쓰일 때 반환 시 경로 구분자를 마지막에 추가했었습니다.<br>
그런데 기존에 `combine` 함수는 `getSingle` 함수를 사용해 경로명을 가져오고 있었고, `String.join` 함수로 경로 구분자를 사이에 넣어 하나의 문자열로 만들었기 때문에 경로 구분자가 두 번 들어갔어요.<br>
이로 인해 S3에서 파일 조회를 위한 URL 생성 시 잘못된 Key 설정을 했고 조회 요청이 거부되었어요.<br>

> #### 결과
![image](https://github.com/user-attachments/assets/a2384264-2471-44bd-8768-588708c4f7bb)
위와 같이 필드 변수를 사용하도록 변경했습니다!<br>

<img width="1065" alt="image" src="https://github.com/user-attachments/assets/d5c5fd38-5151-457a-a89a-b1c891ba7bf2" />

![image](https://github.com/user-attachments/assets/cfdcb4f7-0b3f-4099-a8b3-7deae3d0949a)
