### PR TITLE
fix [#254] 유저 타임테이블 조회 시 null 값 예외 처리 로직 추가

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -28,7 +28,6 @@ import org.sopt.confeti.global.exception.ConflictException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.resolver.artist.ArtistResolver;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
@@ -46,7 +45,6 @@ public class UserTimetableFacade {
     private final TimetableFestivalService timetableFestivalService;
     private final FestivalService festivalService;
     private final FestivalDateService festivalDateService;
-    private final ArtistResolver artistResolver;
     private final UserTimetableService userTimetableService;
 
     @Transactional(readOnly = true)
@@ -155,7 +153,6 @@ public class UserTimetableFacade {
         validateUserExists(userId);
 
         FestivalDate festivalDate = festivalDateService.findFestivalDateId(festivalDateId);
-        artistResolver.load(festivalDate);
 
         List<Long> festivalTimeIds = festivalDate.getStages().stream()
                 .flatMap(festivalStage -> festivalStage.getTimes().stream())

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -158,18 +158,14 @@ public class UserTimetableFacade {
                 .flatMap(festivalStage -> festivalStage.getTimes().stream())
                 .map(FestivalTime::getId)
                 .toList();
+        validateExistFestivalTimeIds(festivalTimeIds);
 
         List<UserTimetable> userTimetables = userTimetableService.getUserTimetables(userId, festivalTimeIds);
 
-        Map<Long, UserTimetable> userTimetableMapper = userTimetables.stream()
-                .collect(Collectors.toMap(userTimetable ->
-                        userTimetable.getFestivalTime().getId(), Function.identity())
-                );
-        try {
-            return UserTimetableFestivalBasicDTO.of(festivalDate, userTimetableMapper);
-        } catch (NullPointerException e) {
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
-        }
+        Map<Long, UserTimetable> userTimetableMapper = createUserTimetableMapper(userTimetables);
+        validateExistUserTimetableMapper(userTimetableMapper);
+
+        return UserTimetableFestivalBasicDTO.of(festivalDate, userTimetableMapper);
     }
 
     @Transactional(readOnly = true)
@@ -191,6 +187,28 @@ public class UserTimetableFacade {
     public void patchTimetableFestivals(final long userId, final PatchTimetableDTO timetableDTO) {
         validateUserExists(userId);
         userTimetableService.patchTimetableFestival(userId, timetableDTO);
+    }
+
+    @Transactional(readOnly = true)
+    public void validateExistFestivalTimeIds(final List<Long> festivalTimeIds){
+        if (festivalTimeIds == null || festivalTimeIds.isEmpty()) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    public Map<Long, UserTimetable> createUserTimetableMapper(List<UserTimetable> userTimetables) {
+        return userTimetables.stream()
+                .collect(Collectors.toMap(userTimetable ->
+                        userTimetable.getFestivalTime().getId(), Function.identity())
+                );
+    }
+
+    @Transactional(readOnly = true)
+    public void validateExistUserTimetableMapper( Map<Long, UserTimetable> userTimetables) {
+        if (userTimetables.isEmpty()) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
     }
 }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -168,8 +168,11 @@ public class UserTimetableFacade {
                 .collect(Collectors.toMap(userTimetable ->
                         userTimetable.getFestivalTime().getId(), Function.identity())
                 );
-
-        return UserTimetableFestivalBasicDTO.of(festivalDate, userTimetableMapper);
+        try {
+            return UserTimetableFestivalBasicDTO.of(festivalDate, userTimetableMapper);
+        } catch (NullPointerException e) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateService.java
+++ b/src/main/java/org/sopt/confeti/domain/festivaldate/application/FestivalDateService.java
@@ -7,21 +7,21 @@ import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
-
+import org.sopt.confeti.global.resolver.artist.ArtistResolver;
 
 @Service
 @RequiredArgsConstructor
 public class FestivalDateService {
 
     private final FestivalDateRepository festivalDateRepository;
+    private final ArtistResolver artistResolver;
 
     @Transactional(readOnly = true)
     public FestivalDate findFestivalDateId(final long festivalDateId) {
-        return festivalDateRepository.findByFestivalDateId(festivalDateId)
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
-                );
+        FestivalDate festivalDate = festivalDateRepository.findByFestivalDateId(festivalDateId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+        artistResolver.load(festivalDate);
+
+        return festivalDate;
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/usertimetable/application/UserTimetableService.java
+++ b/src/main/java/org/sopt/confeti/domain/usertimetable/application/UserTimetableService.java
@@ -42,6 +42,12 @@ public class UserTimetableService {
 
     @Transactional(readOnly = true)
     public List<UserTimetable> getUserTimetables(final long userId, final List<Long> festivalTimeIds) {
-        return userTimetableRepository.findByUserIdAndFestivalTimeIds(userId, festivalTimeIds);
+        List<UserTimetable> userTimetables = userTimetableRepository.findByUserIdAndFestivalTimeIds(userId, festivalTimeIds);
+
+        if (userTimetables.isEmpty()) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+
+        return userTimetables;
     }
 }

--- a/src/main/java/org/sopt/confeti/global/config/WebMvcConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/WebMvcConfig.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.api.config;
+package org.sopt.confeti.global.config;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.resolver.user.UserIdArgumentResolver;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #254

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 유저 타임테이블 조회 시 null 값 예외 처리 로직 추가


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
타임테이블 등록된 시간표 조회 API에서 존재하지 않는 festivalDateId 조회 시, 유저 타임테이블이 등록되어 있지 않을 경우 404가 아닌 500이 반환되어 해당 부분을 수정했습니다
`NullPointerException`을 추가해 `userTimetableMapper` 에서 `null`값이 반환될 경우 404를 리턴하도록 수정했습니다. 

수정 이전

```java
        Map<Long, UserTimetable> userTimetableMapper = userTimetables.stream()
                .collect(Collectors.toMap(userTimetable ->
                        userTimetable.getFestivalTime().getId(), Function.identity())
                );

        return UserTimetableFestivalBasicDTO.of(festivalDate, userTimetableMapper);
    );
```

수정 이후 (try catch문 추가)

```java
        Map<Long, UserTimetable> userTimetableMapper = userTimetables.stream()
                .collect(Collectors.toMap(userTimetable ->
                        userTimetable.getFestivalTime().getId(), Function.identity())
                );
        try {
            return UserTimetableFestivalBasicDTO.of(festivalDate, userTimetableMapper);
        } catch (NullPointerException e) {
            throw new NotFoundException(ErrorMessage.NOT_FOUND);
        }
```