### PR TITLE
fix [#256] 타임테이블 수정 시 존재하지 않는 timetableId 요청될 경우 404 반환하도록 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -1,9 +1,11 @@
 package org.sopt.confeti.api.user.facade;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableListDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalArtiestDTO;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
@@ -160,7 +162,8 @@ public class UserTimetableFacade {
                 .toList();
         validateExistFestivalTimeIds(festivalTimeIds);
 
-        List<UserTimetable> userTimetables = userTimetableService.getUserTimetables(userId, festivalTimeIds);
+        List<UserTimetable> userTimetables = userTimetableService.getUserTimetablesByFestivalTimeId(userId, festivalTimeIds);
+        validateExistUserTimetables(userTimetables);
 
         Map<Long, UserTimetable> userTimetableMapper = createUserTimetableMapper(userTimetables);
         validateExistUserTimetableMapper(userTimetableMapper);
@@ -186,7 +189,12 @@ public class UserTimetableFacade {
     @Transactional
     public void patchTimetableFestivals(final long userId, final PatchTimetableDTO timetableDTO) {
         validateUserExists(userId);
-        userTimetableService.patchTimetableFestival(userId, timetableDTO);
+
+        List<UserTimetable> userTimetables= userTimetableService.getUserTimeTables(userId);
+        validateExistUserTimetables(userTimetables);
+        validateTimetableIds(userTimetables, timetableDTO);
+
+        userTimetableService.patchTimetableFestival(userTimetables, timetableDTO);
     }
 
     @Transactional(readOnly = true)
@@ -208,6 +216,26 @@ public class UserTimetableFacade {
     public void validateExistUserTimetableMapper( Map<Long, UserTimetable> userTimetables) {
         if (userTimetables.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    protected void validateExistUserTimetables(List<UserTimetable> userTimetables) {
+        if (userTimetables.isEmpty()) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    protected void validateTimetableIds(List<UserTimetable> userTimetables, PatchTimetableDTO timetableDTO) {
+        Set<Long> existingIds = userTimetables.stream()
+                .map(UserTimetable::getId)
+                .collect(Collectors.toSet());
+
+        for (PatchTimetableListDTO timetableListDTO : timetableDTO.userTimetables()) {
+            if (!existingIds.contains(timetableListDTO.userTimetableId())) {
+                throw new NotFoundException(ErrorMessage.NOT_FOUND);
+            }
         }
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -1,11 +1,9 @@
 package org.sopt.confeti.api.user.facade;
 
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableListDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalArtiestDTO;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
@@ -162,9 +160,7 @@ public class UserTimetableFacade {
                 .toList();
         validateExistFestivalTimeIds(festivalTimeIds);
 
-
-        List<UserTimetable> userTimetables = userTimetableService.getUserTimetablesByFestivalTimeId(userId, festivalTimeIds);
-        validateExistUserTimetables(userTimetables);
+        List<UserTimetable> userTimetables = userTimetableService.getUserTimetables(userId, festivalTimeIds);
 
         Map<Long, UserTimetable> userTimetableMapper = createUserTimetableMapper(userTimetables);
         validateExistUserTimetableMapper(userTimetableMapper);
@@ -190,22 +186,18 @@ public class UserTimetableFacade {
     @Transactional
     public void patchTimetableFestivals(final long userId, final PatchTimetableDTO timetableDTO) {
         validateUserExists(userId);
-
-        List<UserTimetable> userTimetables= userTimetableService.getUserTimeTables(userId);
-        validateExistUserTimetables(userTimetables);
-        validateExistTimetableIds(userTimetables, timetableDTO);
-
-        userTimetableService.patchTimetableFestival(userTimetables, timetableDTO);
+        userTimetableService.patchTimetableFestival(userId, timetableDTO);
     }
 
     @Transactional(readOnly = true)
-    protected void validateExistFestivalTimeIds(final List<Long> festivalTimeIds){
+    public void validateExistFestivalTimeIds(final List<Long> festivalTimeIds){
         if (festivalTimeIds == null || festivalTimeIds.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
     }
 
-    private Map<Long, UserTimetable> createUserTimetableMapper(List<UserTimetable> userTimetables) {
+    @Transactional(readOnly = true)
+    public Map<Long, UserTimetable> createUserTimetableMapper(List<UserTimetable> userTimetables) {
         return userTimetables.stream()
                 .collect(Collectors.toMap(userTimetable ->
                         userTimetable.getFestivalTime().getId(), Function.identity())
@@ -213,31 +205,10 @@ public class UserTimetableFacade {
     }
 
     @Transactional(readOnly = true)
-    protected void validateExistUserTimetableMapper( Map<Long, UserTimetable> userTimetables) {
+    public void validateExistUserTimetableMapper( Map<Long, UserTimetable> userTimetables) {
         if (userTimetables.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
     }
-
-    @Transactional(readOnly = true)
-    protected void validateExistUserTimetables(List<UserTimetable> userTimetables) {
-        if (userTimetables.isEmpty()) {
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
-        }
-    }
-
-    @Transactional(readOnly = true)
-    protected void validateExistTimetableIds(List<UserTimetable> userTimetables, PatchTimetableDTO timetableDTO) {
-        Set<Long> existingIds = userTimetables.stream()
-                .map(UserTimetable::getId)
-                .collect(Collectors.toSet());
-
-        for (PatchTimetableListDTO timetableListDTO : timetableDTO.userTimetables()) {
-            if (!existingIds.contains(timetableListDTO.userTimetableId())) {
-                throw new NotFoundException(ErrorMessage.NOT_FOUND);
-            }
-        }
-    }
-
 }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -160,7 +160,8 @@ public class UserTimetableFacade {
                 .flatMap(festivalStage -> festivalStage.getTimes().stream())
                 .map(FestivalTime::getId)
                 .toList();
-          validateExistFestivalTimeIds(festivalTimeIds);
+        validateExistFestivalTimeIds(festivalTimeIds);
+
 
         List<UserTimetable> userTimetables = userTimetableService.getUserTimetablesByFestivalTimeId(userId, festivalTimeIds);
         validateExistUserTimetables(userTimetables);
@@ -237,5 +238,6 @@ public class UserTimetableFacade {
             }
         }
     }
+
 }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -1,9 +1,11 @@
 package org.sopt.confeti.api.user.facade;
 
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableListDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalArtiestDTO;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
@@ -160,7 +162,8 @@ public class UserTimetableFacade {
                 .toList();
         validateExistFestivalTimeIds(festivalTimeIds);
 
-        List<UserTimetable> userTimetables = userTimetableService.getUserTimetables(userId, festivalTimeIds);
+        List<UserTimetable> userTimetables = userTimetableService.getUserTimetablesByFestivalTimeId(userId, festivalTimeIds);
+        validateExistUserTimetables(userTimetables);
 
         Map<Long, UserTimetable> userTimetableMapper = createUserTimetableMapper(userTimetables);
         validateExistUserTimetableMapper(userTimetableMapper);
@@ -186,18 +189,22 @@ public class UserTimetableFacade {
     @Transactional
     public void patchTimetableFestivals(final long userId, final PatchTimetableDTO timetableDTO) {
         validateUserExists(userId);
-        userTimetableService.patchTimetableFestival(userId, timetableDTO);
+
+        List<UserTimetable> userTimetables= userTimetableService.getUserTimeTables(userId);
+        validateExistUserTimetables(userTimetables);
+        validateExistTimetableIds(userTimetables, timetableDTO);
+
+        userTimetableService.patchTimetableFestival(userTimetables, timetableDTO);
     }
 
     @Transactional(readOnly = true)
-    public void validateExistFestivalTimeIds(final List<Long> festivalTimeIds){
+    protected void validateExistFestivalTimeIds(final List<Long> festivalTimeIds){
         if (festivalTimeIds == null || festivalTimeIds.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
     }
 
-    @Transactional(readOnly = true)
-    public Map<Long, UserTimetable> createUserTimetableMapper(List<UserTimetable> userTimetables) {
+    private Map<Long, UserTimetable> createUserTimetableMapper(List<UserTimetable> userTimetables) {
         return userTimetables.stream()
                 .collect(Collectors.toMap(userTimetable ->
                         userTimetable.getFestivalTime().getId(), Function.identity())
@@ -205,9 +212,29 @@ public class UserTimetableFacade {
     }
 
     @Transactional(readOnly = true)
-    public void validateExistUserTimetableMapper( Map<Long, UserTimetable> userTimetables) {
+    protected void validateExistUserTimetableMapper( Map<Long, UserTimetable> userTimetables) {
         if (userTimetables.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    protected void validateExistUserTimetables(List<UserTimetable> userTimetables) {
+        if (userTimetables.isEmpty()) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    protected void validateExistTimetableIds(List<UserTimetable> userTimetables, PatchTimetableDTO timetableDTO) {
+        Set<Long> existingIds = userTimetables.stream()
+                .map(UserTimetable::getId)
+                .collect(Collectors.toSet());
+
+        for (PatchTimetableListDTO timetableListDTO : timetableDTO.userTimetables()) {
+            if (!existingIds.contains(timetableListDTO.userTimetableId())) {
+                throw new NotFoundException(ErrorMessage.NOT_FOUND);
+            }
         }
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -160,7 +160,7 @@ public class UserTimetableFacade {
                 .flatMap(festivalStage -> festivalStage.getTimes().stream())
                 .map(FestivalTime::getId)
                 .toList();
-        validateExistFestivalTimeIds(festivalTimeIds);
+          validateExistFestivalTimeIds(festivalTimeIds);
 
         List<UserTimetable> userTimetables = userTimetableService.getUserTimetablesByFestivalTimeId(userId, festivalTimeIds);
         validateExistUserTimetables(userTimetables);
@@ -192,20 +192,19 @@ public class UserTimetableFacade {
 
         List<UserTimetable> userTimetables= userTimetableService.getUserTimeTables(userId);
         validateExistUserTimetables(userTimetables);
-        validateTimetableIds(userTimetables, timetableDTO);
+        validateExistTimetableIds(userTimetables, timetableDTO);
 
         userTimetableService.patchTimetableFestival(userTimetables, timetableDTO);
     }
 
     @Transactional(readOnly = true)
-    public void validateExistFestivalTimeIds(final List<Long> festivalTimeIds){
+    protected void validateExistFestivalTimeIds(final List<Long> festivalTimeIds){
         if (festivalTimeIds == null || festivalTimeIds.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
     }
 
-    @Transactional(readOnly = true)
-    public Map<Long, UserTimetable> createUserTimetableMapper(List<UserTimetable> userTimetables) {
+    private Map<Long, UserTimetable> createUserTimetableMapper(List<UserTimetable> userTimetables) {
         return userTimetables.stream()
                 .collect(Collectors.toMap(userTimetable ->
                         userTimetable.getFestivalTime().getId(), Function.identity())
@@ -213,7 +212,7 @@ public class UserTimetableFacade {
     }
 
     @Transactional(readOnly = true)
-    public void validateExistUserTimetableMapper( Map<Long, UserTimetable> userTimetables) {
+    protected void validateExistUserTimetableMapper( Map<Long, UserTimetable> userTimetables) {
         if (userTimetables.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
@@ -227,7 +226,7 @@ public class UserTimetableFacade {
     }
 
     @Transactional(readOnly = true)
-    protected void validateTimetableIds(List<UserTimetable> userTimetables, PatchTimetableDTO timetableDTO) {
+    protected void validateExistTimetableIds(List<UserTimetable> userTimetables, PatchTimetableDTO timetableDTO) {
         Set<Long> existingIds = userTimetables.stream()
                 .map(UserTimetable::getId)
                 .collect(Collectors.toSet());

--- a/src/main/java/org/sopt/confeti/domain/usertimetable/application/UserTimetableService.java
+++ b/src/main/java/org/sopt/confeti/domain/usertimetable/application/UserTimetableService.java
@@ -21,24 +21,13 @@ public class UserTimetableService {
 
     private final UserTimetableRepository userTimetableRepository;
 
+    @Transactional(readOnly = true)
+    public List<UserTimetable> getUserTimeTables(long userId) {
+        return userTimetableRepository.findByUserId(userId);
+    }
+
     @Transactional
-    public void patchTimetableFestival(long userId, PatchTimetableDTO timetableDTO) {
-        List<UserTimetable> userTimetables = userTimetableRepository.findByUserId(userId);
-
-        if (userTimetables.isEmpty()) {
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
-        }
-
-        Set<Long> existingIds = userTimetables.stream()
-                .map(UserTimetable::getId)
-                .collect(Collectors.toSet());
-
-        for (PatchTimetableListDTO timetableListDTO : timetableDTO.userTimetables()) {
-            if (!existingIds.contains(timetableListDTO.userTimetableId())) {
-                throw new NotFoundException(ErrorMessage.NOT_FOUND);
-            }
-        }
-
+    public void patchTimetableFestival(List<UserTimetable> userTimetables, PatchTimetableDTO timetableDTO) {
         Map<Long, Boolean> updateMap = timetableDTO.userTimetables()
                 .stream()
                 .collect(Collectors.toMap(PatchTimetableListDTO::userTimetableId, PatchTimetableListDTO::isSelected));
@@ -52,13 +41,7 @@ public class UserTimetableService {
     }
 
     @Transactional(readOnly = true)
-    public List<UserTimetable> getUserTimetables(final long userId, final List<Long> festivalTimeIds) {
-        List<UserTimetable> userTimetables = userTimetableRepository.findByUserIdAndFestivalTimeIds(userId, festivalTimeIds);
-
-        if (userTimetables.isEmpty()) {
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
-        }
-
-        return userTimetables;
+    public List<UserTimetable> getUserTimetablesByFestivalTimeId(final long userId, final List<Long> festivalTimeIds) {
+        return userTimetableRepository.findByUserIdAndFestivalTimeIds(userId, festivalTimeIds);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/usertimetable/application/UserTimetableService.java
+++ b/src/main/java/org/sopt/confeti/domain/usertimetable/application/UserTimetableService.java
@@ -5,14 +5,11 @@ import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableDTO;
 import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableListDTO;
 import org.sopt.confeti.domain.usertimetable.UserTimetable;
 import org.sopt.confeti.domain.usertimetable.infra.repository.UserTimetableRepository;
-import org.sopt.confeti.global.exception.NotFoundException;
-import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service

--- a/src/main/java/org/sopt/confeti/domain/usertimetable/application/UserTimetableService.java
+++ b/src/main/java/org/sopt/confeti/domain/usertimetable/application/UserTimetableService.java
@@ -12,6 +12,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 
 @Service
@@ -26,6 +27,16 @@ public class UserTimetableService {
 
         if (userTimetables.isEmpty()) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+
+        Set<Long> existingIds = userTimetables.stream()
+                .map(UserTimetable::getId)
+                .collect(Collectors.toSet());
+
+        for (PatchTimetableListDTO timetableListDTO : timetableDTO.userTimetables()) {
+            if (!existingIds.contains(timetableListDTO.userTimetableId())) {
+                throw new NotFoundException(ErrorMessage.NOT_FOUND);
+            }
         }
 
         Map<Long, Boolean> updateMap = timetableDTO.userTimetables()


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #256

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 존재하지 않는 timetableId 요청될 경우 404 반환하도록 변경


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
타임테이블 수정 api에서 timetableDTO에 존재하지 않는 timetableId가 포함된 상태로 요청이 오더라도 200을 반환하는 문제가 있었습니다. 

이를 해결하기 위해 1) 실제 존재하는  타임테이블에 userTimetableId 수집 2) timetableDTO에 담긴 id 값이 앞서 수집된 id에 포함되는지 확인 후, 그렇지 않다면 404를 반환하도록 수정했습니다.

1) 실제 존재하는 userTimetableId를 Set으로 수집
```java
        Set<Long> existingIds = userTimetables.stream()
                .map(UserTimetable::getId)
                .collect(Collectors.toSet());
```

2) timetableDTO에 포함된 ID들이 모두 existingIds에 존재하는지 확인
```java
        for (PatchTimetableListDTO timetableListDTO : timetableDTO.userTimetables()) {
            if (!existingIds.contains(timetableListDTO.userTimetableId())) {
                throw new NotFoundException(ErrorMessage.NOT_FOUND);
            }
        }
```
