### PR TITLE
fix [#258] 사용자 관심 아티스트가 없을 경우 빈 배열 반환하도록 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
@@ -4,6 +4,8 @@ import lombok.AllArgsConstructor;
 import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;
 import org.sopt.confeti.domain.artistfavorite.infra.repository.ArtistFavoriteRepository;
 import org.sopt.confeti.domain.user.User;
+import org.sopt.confeti.global.exception.NotFoundException;
+import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.artist.ArtistResolver;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -19,7 +21,10 @@ public class ArtistFavoriteService {
     @Transactional(readOnly = true)
     public List<ArtistFavorite> getArtistList(Long userId) {
         List<ArtistFavorite> artistList = artistFavoriteRepository.findTop6ByUserIdOrderByRand(userId);
-        artistResolver.load(artistList);
+
+        if (!artistList.isEmpty()) {
+            artistResolver.load(artistList);
+        }
 
         return artistList;
     }

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
@@ -4,8 +4,6 @@ import lombok.AllArgsConstructor;
 import org.sopt.confeti.domain.artistfavorite.ArtistFavorite;
 import org.sopt.confeti.domain.artistfavorite.infra.repository.ArtistFavoriteRepository;
 import org.sopt.confeti.domain.user.User;
-import org.sopt.confeti.global.exception.NotFoundException;
-import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.artist.ArtistResolver;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #258

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 사용자 관심 아티스트가 없을 경우 빈 배열 반환하도록 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
관심 아티스트 목록을 조회 시 artistList를 가져와 artistResolver로 아티스트 정보를 매핑시키고 있었는데, artistList이 빈배열일 경우 400이 반환되는 문제가 있었습니다. 아래와 같이 if문을 추가해 artistList가 비어있지 않을 때만 artistResolver를 호출하도록 수정했습니다. 

<img width="936" alt="image" src="https://github.com/user-attachments/assets/3dfb203c-5c74-4f15-94b6-85b3c9f55494" />
