### PR TITLE
refactor [#261] My artist 미리보기 목록 조회 API 반환 개수 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
@@ -50,7 +50,7 @@ public class UserFavoriteController {
     public ResponseEntity<BaseResponse<?>> getFavoriteArtists(
             @UserId Long userId
     ) {
-        UserFavoriteArtistDTO userFavoriteArtistDTO = userFavoriteFacade.getArtistList(userId);
+        UserFavoriteArtistDTO userFavoriteArtistDTO = userFavoriteFacade.getArtistListPreview(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserFavoriteResponse.from(userFavoriteArtistDTO.artists()));
     }
 

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
@@ -46,7 +46,7 @@ public class UserFavoriteController {
     }
 
     @Permission(role = {Role.GENERAL})
-    @GetMapping("/artists")
+    @GetMapping("/artists/preview")
     public ResponseEntity<BaseResponse<?>> getFavoriteArtists(
             @UserId Long userId
     ) {

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -73,10 +73,10 @@ public class UserFavoriteFacade {
     }
 
     @Transactional(readOnly = true)
-    public UserFavoriteArtistDTO getArtistList(long userId) {
+    public UserFavoriteArtistDTO getArtistListPreview(long userId) {
         validateExistUser(userId);
 
-        List<ArtistFavorite> artists = artistFavoriteService.getArtistList(userId);
+        List<ArtistFavorite> artists = artistFavoriteService.getArtistListPreview(userId);
         return UserFavoriteArtistDTO.from(artists);
     }
 

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
@@ -17,7 +17,7 @@ public class ArtistFavoriteService {
     private final ArtistResolver artistResolver;
 
     @Transactional(readOnly = true)
-    public List<ArtistFavorite> getArtistList(Long userId) {
+    public List<ArtistFavorite> getArtistListPreview(Long userId) {
         List<ArtistFavorite> artistList = artistFavoriteRepository.findTop3ByUserIdOrderByRand(userId);
         artistResolver.load(artistList);
 

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/application/ArtistFavoriteService.java
@@ -18,7 +18,7 @@ public class ArtistFavoriteService {
 
     @Transactional(readOnly = true)
     public List<ArtistFavorite> getArtistList(Long userId) {
-        List<ArtistFavorite> artistList = artistFavoriteRepository.findTop6ByUserIdOrderByRand(userId);
+        List<ArtistFavorite> artistList = artistFavoriteRepository.findTop3ByUserIdOrderByRand(userId);
         artistResolver.load(artistList);
 
         return artistList;

--- a/src/main/java/org/sopt/confeti/domain/artistfavorite/infra/repository/ArtistFavoriteRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/artistfavorite/infra/repository/ArtistFavoriteRepository.java
@@ -8,8 +8,8 @@ import org.springframework.data.repository.query.Param;
 import java.util.List;
 
 public interface ArtistFavoriteRepository extends JpaRepository<ArtistFavorite, Long> {
-    @Query(value = "select * from artist_favorites where user_id = :userId order by rand() limit 6", nativeQuery = true)
-    List<ArtistFavorite> findTop6ByUserIdOrderByRand(@Param("userId") Long userId);
+    @Query(value = "select * from artist_favorites where user_id = :userId order by rand() limit 3", nativeQuery = true)
+    List<ArtistFavorite> findTop3ByUserIdOrderByRand(@Param("userId") Long userId);
 
     boolean existsByUserIdAndArtist_ArtistId(long userId, String artistId);
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #261

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] My artist 미리보기 목록 조회 API에서의 반환되는 값을 6개 -> 3개로 수정
- [x] My artist 미리보기 목록 조회 API uri, 관련 메서드 네이밍 수정 


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
My artist 전체 목록 조회 추가에 따라 My artist 미리보기 목록 조회 api를 수정하였습니다. 
아티스트 조회 개수를 6개가 아닌 3개로 수정하였고, uri와 관련 메서드 네이밍을 변경하였습니다.
![image](https://github.com/user-attachments/assets/071a98b3-2212-4117-9e95-dbbbb13863f0)
