### PR TITLE
fix [#265] ERD 반영되지 않은 엔티티 파일 부분 수정 및 최신 등록 순 공연 정보 조회 API 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -4,6 +4,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.performance.facade.dto.request.CreateConcertFileDTO;
 import org.sopt.confeti.api.performance.facade.dto.request.CreateFestivalFileDTO;
 import org.sopt.confeti.domain.concert.application.dto.request.ConcertFileNamesDTO;
@@ -37,6 +38,7 @@ import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Facade
 @RequiredArgsConstructor
 public class PerformanceFacade {
@@ -190,7 +192,7 @@ public class PerformanceFacade {
         // 최신 페스티벌 조회
         List<Festival> festivals = festivalService.getRecentFestivals(RECENT_PERFORMANCES_SIZE);
 
-        return RecentPerformancesDTO.of(concerts, festivals);
+        return RecentPerformancesDTO.of(concerts, festivals, RECENT_PERFORMANCES_SIZE);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecentPerformancesDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecentPerformancesDTO.java
@@ -12,16 +12,21 @@ public record RecentPerformancesDTO(
 ) {
     public static RecentPerformancesDTO of(
             List<Concert> concerts,
-            List<Festival> festivals
+            List<Festival> festivals,
+            int recentPerformanceSize
     ) {
-        return new RecentPerformancesDTO(
-                Stream.concat(
-                        IntStream.range(0, concerts.size())
-                                .mapToObj(i -> RecentPerformanceDTO.of(concerts.get(i), i)),
-                        IntStream.range(concerts.size(), festivals.size())
-                                .mapToObj(i -> RecentPerformanceDTO.of(festivals.get(i), i))
-                ).toList()
-        );
+        List<RecentPerformanceDTO> performances = Stream.concat(
+                IntStream.range(0, concerts.size())
+                        .mapToObj(i -> RecentPerformanceDTO.of(concerts.get(i), i)),
+                        IntStream.range(0, festivals.size())
+                                .mapToObj(i -> RecentPerformanceDTO.of(festivals.get(i), i + concerts.size()))
+                ).toList();
+
+        if (performances.size() >= recentPerformanceSize) {
+            performances = performances.subList(0, recentPerformanceSize);
+        }
+
+        return new RecentPerformancesDTO(performances);
     }
 
     public static RecentPerformancesDTO from(final List<Performance> performances) {

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
@@ -22,7 +22,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class ConcertService {
 
     private static final int INIT_PAGE = 0;
-    private static final String START_AT_COLUMN = "concertStartAt";
+    private static final String START_AT_COLUMN = "startAt";
 
     private final ConcertRepository concertRepository;
     private final ArtistResolver artistResolver;

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -22,13 +22,13 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class FestivalService {
 
-    private static final String START_AT_COLUMN = "festivalStartAt";
+    private static final String START_AT_COLUMN = "startAt";
 
     private final FestivalRepository festivalRepository;
     private final ArtistResolver artistResolver;
 
     private static final int INIT_PAGE = 0;
-    private static final String FESTIVAL_TITLE_COLUMN_NAME = "festivalTitle";
+    private static final String TITLE_COLUMN = "title";
 
     @Transactional(readOnly = true)
     public Festival findById(Long festivalId) {
@@ -78,7 +78,7 @@ public class FestivalService {
 
     private Sort getFestivalSort() {
         return Sort.by(
-                Order.asc(FESTIVAL_TITLE_COLUMN_NAME)
+                Order.asc(TITLE_COLUMN)
         );
     }
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #265 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] Concert의 START_AT_COLUMN 변수 수정
- [x] Festival의 START_AT_COLUMN, FESTIVAL_TITLE_COLUMN_NAME 변수 수정
- [x] 최신 등록 순 공연 정보 조회 API에서 정해진 개수를 가져오지 못하는 오류 해결

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
기존에 `Concert`, `Festival`에서 데이터베이스 정렬 기준 설정을 위해 상수로 두었던 `startAt` 컬럼명을 수정된 ERD의 컬럼명으로 적용하지 않아 오류가 발생헀었습니다. 수정된 컬럼명으로 수정해두었습니다.

추가로 확인하면서 최신 등록 순 공연 정보 조회 API에서 정해진 개수를 가져오지 못하는 오류가 있었습니다. 잘못된 계산으로 발생한 문제였고 아래와 같이 수정했습니다.

<img width="873" alt="image" src="https://github.com/user-attachments/assets/7906b1c7-835d-4ecb-abf8-89f476f6d098" />

