### PR TITLE
refactor [#270] 프로필 조회 API 응답에 소셜 로그인 정보 추가 

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UserInfoResponse.java
@@ -8,15 +8,15 @@ import org.sopt.confeti.global.util.S3FileHandler;
 public record UserInfoResponse (
         Long userId,
         String profileUrl,
-        String username,
-        OAuthProvider OAuthProvider
+        String name,
+        OAuthProvider provider
 ) {
     public static UserInfoResponse of(final UserInfoDTO userInfoDTO, final S3FileHandler s3FileHandler) {
         return new UserInfoResponse(
                 userInfoDTO.userId(),
                 s3FileHandler.getFileUrl(FolderPath.USER.getSingle(), userInfoDTO.profilePath()).toString(),
-                userInfoDTO.username(),
-                userInfoDTO.oAuthProvider()
+                userInfoDTO.name(),
+                userInfoDTO.provider()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UserInfoResponse.java
@@ -1,19 +1,22 @@
 package org.sopt.confeti.api.user.dto.response;
 
 import org.sopt.confeti.api.user.facade.dto.response.UserInfoDTO;
+import org.sopt.confeti.domain.user.OAuthProvider;
 import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.util.S3FileHandler;
 
 public record UserInfoResponse (
         Long userId,
         String profileUrl,
-        String username
+        String username,
+        OAuthProvider OAuthProvider
 ) {
     public static UserInfoResponse of(final UserInfoDTO userInfoDTO, final S3FileHandler s3FileHandler) {
         return new UserInfoResponse(
                 userInfoDTO.userId(),
                 s3FileHandler.getFileUrl(FolderPath.USER.getSingle(), userInfoDTO.profilePath()).toString(),
-                userInfoDTO.username()
+                userInfoDTO.username(),
+                userInfoDTO.oAuthProvider()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserInfoDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserInfoDTO.java
@@ -6,8 +6,8 @@ import org.sopt.confeti.domain.user.User;
 public record UserInfoDTO (
         long userId,
         String profilePath,
-        String username,
-        OAuthProvider oAuthProvider
+        String name,
+        OAuthProvider provider
 ){
     public static UserInfoDTO from (final User user) {
         return new UserInfoDTO(

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserInfoDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserInfoDTO.java
@@ -1,17 +1,20 @@
 package org.sopt.confeti.api.user.facade.dto.response;
 
+import org.sopt.confeti.domain.user.OAuthProvider;
 import org.sopt.confeti.domain.user.User;
 
 public record UserInfoDTO (
         long userId,
         String profilePath,
-        String username
+        String username,
+        OAuthProvider oAuthProvider
 ){
     public static UserInfoDTO from (final User user) {
         return new UserInfoDTO(
                 user.getId(),
                 user.getProfilePath(),
-                user.getName()
+                user.getName(),
+                user.getProvider()
         );
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #270

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 프로필 조회 API 응답에 provider 추가


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->

사용자의 프로필 조회 시 소셜 로그인 가입 정보를 필요로 하는 뷰가 추가되어 provider값을 응답으로 추가합니다! 
![image](https://github.com/user-attachments/assets/9f5ded50-0eb9-44de-8d02-4a4a9a994039)
