### PR TITLE
fix [#276] 더미데이터 등록 API에 Performance 생성 로직 추가

### DIFF
--- a/src/main/java/org/sopt/confeti/api/dummy/facade/DummyFacade.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/facade/DummyFacade.java
@@ -6,12 +6,15 @@ import org.sopt.confeti.api.dummy.facade.dto.concert.ConcertFilePathsDTO;
 import org.sopt.confeti.api.dummy.facade.dto.concert.request.CreateConcertDTO;
 import org.sopt.confeti.api.dummy.facade.dto.concert.request.UploadConcertFilesDTO;
 import org.sopt.confeti.api.dummy.facade.dto.festival.FestivalFilePathsDTO;
+import org.sopt.confeti.api.dummy.facade.dto.festival.request.CreateFestivalArtistDTO;
 import org.sopt.confeti.api.dummy.facade.dto.festival.request.CreateFestivalDTO;
 import org.sopt.confeti.api.dummy.facade.dto.festival.request.UploadFestivalFilesDTO;
 import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.application.ConcertService;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.util.S3FileHandler;
@@ -24,6 +27,7 @@ public class DummyFacade {
     private final S3FileHandler s3FileHandler;
     private final FestivalService festivalService;
     private final ConcertService concertService;
+    private final PerformanceService performanceService;
 
     public FestivalFilePathsDTO uploadFestivalFiles(UploadFestivalFilesDTO files) {
         String posterPath = s3FileHandler.uploadFile(files.poster(),
@@ -42,7 +46,23 @@ public class DummyFacade {
 
     @Transactional
     public void createFestival(CreateFestivalDTO festivalDTO) {
-        festivalService.create(Festival.create(festivalDTO));
+        long festivalId = festivalService.create(Festival.create(festivalDTO));
+        performanceService.create(createPerformances(festivalId, festivalDTO));
+    }
+
+    private List<Performance> createPerformances(long festivalId, CreateFestivalDTO festivalDTO) {
+        return getArtistIds(festivalDTO).stream()
+                .map(artistId -> Performance.create(festivalId, festivalDTO, artistId))
+                .toList();
+    }
+
+    private List<String> getArtistIds(CreateFestivalDTO festivalDTO) {
+        return festivalDTO.dates().stream()
+                .flatMap(date -> date.stages().stream())
+                .flatMap(stage -> stage.times().stream())
+                .flatMap(time -> time.artists().stream())
+                .map(CreateFestivalArtistDTO::artistId)
+                .toList();
     }
 
     public ConcertFilePathsDTO uploadConcertFiles(UploadConcertFilesDTO files) {

--- a/src/main/java/org/sopt/confeti/api/dummy/facade/DummyFacade.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/facade/DummyFacade.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.api.dummy.facade;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.dummy.facade.dto.concert.ConcertFilePathsDTO;
+import org.sopt.confeti.api.dummy.facade.dto.concert.request.CreateConcertArtistDTO;
 import org.sopt.confeti.api.dummy.facade.dto.concert.request.CreateConcertDTO;
 import org.sopt.confeti.api.dummy.facade.dto.concert.request.UploadConcertFilesDTO;
 import org.sopt.confeti.api.dummy.facade.dto.festival.FestivalFilePathsDTO;
@@ -80,6 +81,19 @@ public class DummyFacade {
 
     @Transactional
     public void createConcert(CreateConcertDTO concertDTO) {
-        concertService.create(Concert.create(concertDTO));
+        long concertId = concertService.create(Concert.create(concertDTO));
+        performanceService.create(createPerformances(concertId, concertDTO));
+    }
+
+    private List<Performance> createPerformances(long concertId, CreateConcertDTO concertDTO) {
+        return getArtistIds(concertDTO).stream()
+                .map(artistId -> Performance.create(concertId, concertDTO, artistId))
+                .toList();
+    }
+
+    private List<String> getArtistIds(CreateConcertDTO concertDTO) {
+        return concertDTO.artists().stream()
+                .map(CreateConcertArtistDTO::artistId)
+                .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/concert/Concert.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/Concert.java
@@ -21,6 +21,8 @@ import org.sopt.confeti.domain.concert_artist.ConcertArtist;
 import org.sopt.confeti.domain.concert_music.ConcertMusic;
 import org.sopt.confeti.domain.concert_reservation_url.ConcertReservationUrl;
 import org.sopt.confeti.global.common.constant.Default;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 @Entity
 @Table(name = "concerts")
@@ -78,6 +80,13 @@ public class Concert {
 
     @Column(length = 100, nullable = false)
     private String address;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "concert", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<ConcertArtist> artists = new ArrayList<>();

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
@@ -73,7 +73,7 @@ public class ConcertService {
     }
 
     @Transactional
-    public void create(Concert concert) {
-        concertRepository.save(concert);
+    public long create(Concert concert) {
+        return concertRepository.save(concert).getId();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival/Festival.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/Festival.java
@@ -23,6 +23,8 @@ import org.sopt.confeti.domain.festival_music.FestivalMusic;
 import org.sopt.confeti.domain.festival_reservation_url.FestivalReservationUrl;
 import org.sopt.confeti.domain.timetable_festival.TimetableFestival;
 import org.sopt.confeti.global.common.constant.Default;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 @Entity
 @Table(name = "festivals")
@@ -85,6 +87,13 @@ public class Festival {
 
     @Column(length = 100, nullable = false)
     private String address;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
     @OneToMany(mappedBy = "festival", cascade = CascadeType.ALL, orphanRemoval = true)
     private List<FestivalDate> dates = new ArrayList<>();

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -116,7 +116,7 @@ public class FestivalService {
     }
 
     @Transactional
-    public void create(Festival festival) {
-        festivalRepository.save(festival);
+    public long create(Festival festival) {
+        return festivalRepository.save(festival).getId();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
@@ -9,13 +9,11 @@ import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import java.time.LocalDateTime;
-import java.time.LocalTime;
 import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
-import org.sopt.confeti.domain.concert.Concert;
-import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.api.dummy.facade.dto.festival.request.CreateFestivalDTO;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 
 @Entity
@@ -53,15 +51,12 @@ public class Performance {
     @Column(nullable = false)
     private LocalDateTime endAt;
 
-    @Column
-    private LocalTime artistStartAt;
-
     @Column(length = 250, nullable = false)
     private String posterPath;
 
     @Builder
     public Performance(long typeId, PerformanceType type, String artistId, String area, String title,
-                       String subtitle, LocalDateTime startAt, LocalDateTime endAt, LocalTime artistStartAt,
+                       String subtitle, LocalDateTime startAt, LocalDateTime endAt,
                        String posterPath) {
         this.typeId = typeId;
         this.type = type;
@@ -71,37 +66,21 @@ public class Performance {
         this.subtitle = subtitle;
         this.startAt = startAt;
         this.endAt = endAt;
-        this.artistStartAt = artistStartAt;
         this.posterPath = posterPath;
     }
 
-    public static Performance create(final Festival festival, final String artistId, final LocalTime artistStartAt) {
+    public static Performance create(final long festivalId, final CreateFestivalDTO festivalDTO,
+                                     final String artistId) {
         return Performance.builder()
-                .typeId(festival.getId())
+                .typeId(festivalId)
                 .type(PerformanceType.FESTIVAL)
                 .artistId(artistId)
-                .area(festival.getArea())
-                .title(festival.getTitle())
-                .subtitle(festival.getSubtitle())
-                .startAt(festival.getStartAt())
-                .endAt(festival.getEndAt())
-                .artistStartAt(artistStartAt)
-                .posterPath(festival.getPosterPath())
-                .build();
-    }
-
-    public static Performance create(final Concert concert, final String artistId) {
-        return Performance.builder()
-                .typeId(concert.getId())
-                .type(PerformanceType.CONCERT)
-                .artistId(artistId)
-                .area(concert.getArea())
-                .title(concert.getTitle())
-                .subtitle(concert.getSubtitle())
-                .startAt(concert.getStartAt())
-                .endAt(concert.getEndAt())
-                .artistStartAt(null)
-                .posterPath(concert.getPosterPath())
+                .area(festivalDTO.area())
+                .title(festivalDTO.title())
+                .subtitle(festivalDTO.subtitle())
+                .startAt(festivalDTO.startAt())
+                .endAt(festivalDTO.endAt())
+                .posterPath(festivalDTO.posterPath())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
@@ -16,6 +16,8 @@ import lombok.NoArgsConstructor;
 import org.sopt.confeti.api.dummy.facade.dto.concert.request.CreateConcertDTO;
 import org.sopt.confeti.api.dummy.facade.dto.festival.request.CreateFestivalDTO;
 import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
 
 @Entity
 @Table(name = "performances")
@@ -54,6 +56,13 @@ public class Performance {
 
     @Column(length = 250, nullable = false)
     private String posterPath;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
 
     @Builder
     public Performance(long typeId, PerformanceType type, String artistId, String area, String title,

--- a/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
@@ -98,7 +98,7 @@ public class Performance {
                                      final String artistId) {
         return Performance.builder()
                 .typeId(concertId)
-                .type(PerformanceType.FESTIVAL)
+                .type(PerformanceType.CONCERT)
                 .artistId(artistId)
                 .area(concertDTO.area())
                 .title(concertDTO.title())

--- a/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
@@ -13,6 +13,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.confeti.api.dummy.facade.dto.concert.request.CreateConcertDTO;
 import org.sopt.confeti.api.dummy.facade.dto.festival.request.CreateFestivalDTO;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 
@@ -81,6 +82,21 @@ public class Performance {
                 .startAt(festivalDTO.startAt())
                 .endAt(festivalDTO.endAt())
                 .posterPath(festivalDTO.posterPath())
+                .build();
+    }
+
+    public static Performance create(final long concertId, final CreateConcertDTO concertDTO,
+                                     final String artistId) {
+        return Performance.builder()
+                .typeId(concertId)
+                .type(PerformanceType.FESTIVAL)
+                .artistId(artistId)
+                .area(concertDTO.area())
+                .title(concertDTO.title())
+                .subtitle(concertDTO.subtitle())
+                .startAt(concertDTO.startAt())
+                .endAt(concertDTO.endAt())
+                .posterPath(concertDTO.posterPath())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -3,7 +3,6 @@ package org.sopt.confeti.domain.view.performance.application;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.concert.Concert;
-import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
@@ -41,16 +40,8 @@ public class PerformanceService {
     }
 
     @Transactional
-    public void create(final Festival festival) {
-        performanceRepository.saveAll(
-                festival.getDates().stream()
-                        .flatMap(festivalDate -> festivalDate.getStages().stream())
-                        .flatMap(festivalStage -> festivalStage.getTimes().stream())
-                        .flatMap(festivalTime -> festivalTime.getArtists().stream()
-                                .map(festivalArtist -> Performance.create(festival, festivalArtist.getArtist().getId(),
-                                        festivalTime.getStartAt()))
-                        ).toList()
-        );
+    public void create(final List<Performance> performances) {
+        performanceRepository.saveAll(performances);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -2,7 +2,6 @@ package org.sopt.confeti.domain.view.performance.application;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
@@ -42,15 +41,6 @@ public class PerformanceService {
     @Transactional
     public void create(final List<Performance> performances) {
         performanceRepository.saveAll(performances);
-    }
-
-    @Transactional
-    public void create(final Concert concert) {
-        performanceRepository.saveAll(
-                concert.getArtists().stream()
-                        .map(concertArtist -> Performance.create(concert, concertArtist.getArtist().getId()))
-                        .toList()
-        );
     }
 
     @Transactional(readOnly = true)


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #276 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 콘서트 등록 API에 Performance 테이블 등록 로직 추가
- [x] 페스티벌 등록 API에 Performance 테이블 등록 로직 추가

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="777" alt="image" src="https://github.com/user-attachments/assets/a691863f-7650-4a3a-a6db-1543ffdc55b9" />
페스티벌, 콘서트 등록 시 `Performance` 테이블에도 같은 데이터가 등록되도록 수정했습니다!

그리고 공연 등록 기준일을 사용하는 뷰가 추가되어 `Performance`, `Festival`, `Concert` 테이블에 생성 시간과 수정 시간을 추가했어요.