### PR TITLE
fix [#286] 로그인 API에서 카카오 로그인 시 프로필 이미지를 S3 다운로드

### DIFF
--- a/src/main/java/org/sopt/confeti/api/auth/facade/AuthFacade.java
+++ b/src/main/java/org/sopt/confeti/api/auth/facade/AuthFacade.java
@@ -10,7 +10,9 @@ import org.sopt.confeti.auth.Token;
 import org.sopt.confeti.auth.WithdrawService;
 import org.sopt.confeti.auth.command.LoginCommand;
 import org.sopt.confeti.auth.dto.LoginResult;
+import org.sopt.confeti.auth.dto.OAuthSocialInfoResult;
 import org.sopt.confeti.domain.artist_favorite.application.ArtistFavoriteService;
+import org.sopt.confeti.domain.user.AuthUser;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.application.UserService;
 import org.sopt.confeti.domain.user.constant.Role;
@@ -29,9 +31,17 @@ public class AuthFacade {
     private final OnboardService onboardService;
     private final WithdrawService withdrawService;
 
-    @Transactional
     public LoginResult login(LoginCommand loginCommand) {
-        return loginService.login(loginCommand);
+        OAuthSocialInfoResult socialInfo = loginService.getSocialInfo(loginCommand);
+
+        if (userService.notExist(socialInfo.id(), loginCommand.provider())) {
+            userService.create(loginService.getCreateUserDTO(loginCommand.provider(), socialInfo));
+        }
+
+        AuthUser authUser = userService.getAuthUser(socialInfo.id(), loginCommand.provider());
+        Token token = loginService.createToken(authUser, socialInfo);
+
+        return loginService.getLoginResult(token, authUser.getRole());
     }
 
     @Transactional

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UserInfoResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UserInfoResponse.java
@@ -14,7 +14,8 @@ public record UserInfoResponse(
     public static UserInfoResponse of(final UserInfoDTO userInfoDTO, final S3FileHandler s3FileHandler) {
         return new UserInfoResponse(
                 userInfoDTO.userId(),
-                s3FileHandler.getFileUrl(FolderPath.USER.getSingle(), userInfoDTO.profilePath()).toString(),
+                s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.USER, FolderPath.PROFILE),
+                        userInfoDTO.profilePath()).toString(),
                 userInfoDTO.name(),
                 userInfoDTO.provider()
         );

--- a/src/main/java/org/sopt/confeti/auth/LoginService.java
+++ b/src/main/java/org/sopt/confeti/auth/LoginService.java
@@ -1,7 +1,9 @@
 package org.sopt.confeti.auth;
 
+import java.nio.file.Path;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.auth.command.LoginCommand;
+import org.sopt.confeti.auth.dto.CreateUserDTO;
 import org.sopt.confeti.auth.dto.LoginResult;
 import org.sopt.confeti.auth.dto.OAuthSocialInfoResult;
 import org.sopt.confeti.auth.jwt.JwtTokenGenerator;
@@ -15,8 +17,11 @@ import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.domain.user.infra.repository.AllUserRepository;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
+import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.oauth.OAuthApiClient;
 import org.sopt.confeti.global.oauth.OAuthApiClientRegistry;
+import org.sopt.confeti.global.util.FileDownloader;
+import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -30,12 +35,15 @@ public class LoginService {
     private final JwtTokenGenerator jwtTokenGenerator;
     private final RefreshTokenRepository refreshTokenRepository;
     private final AppleTokenRepository appleTokenRepository;
+    private final FileDownloader fileDownloader;
+    private final S3FileHandler s3FileHandler;
 
 
     @Transactional
     public LoginResult login(LoginCommand command) {
         OAuthApiClient oAuthApiClient = oAuthApiClientRegistry.getOAuthApiClientByProvider(command.provider());
         OAuthSocialInfoResult socialInfo = oAuthApiClient.getSocialInfo(command);
+
         AuthUser authUser = loadOrCreateUser(command, socialInfo);
         Token token = createToken(authUser);
         saveRefreshToken(token.refreshToken(), authUser.getId());
@@ -72,14 +80,33 @@ public class LoginService {
             return retrievedAuthUser;
         }
 
+        CreateUserDTO createUserDTO = getCreateUserDTO(command.provider(), socialInfo);
+
         return allUserRepository.save(
                 AuthUser.create(
                         command.provider(),
-                        socialInfo.id(),
-                        socialInfo.name(),
-                        socialInfo.profileImgUrl()
+                        createUserDTO.id(),
+                        createUserDTO.name(),
+                        createUserDTO.profileImgUrl()
                 )
         );
+    }
+
+    private CreateUserDTO getCreateUserDTO(OAuthProvider provider, OAuthSocialInfoResult socialInfo) {
+        if (provider == OAuthProvider.KAKAO) {
+            String profileImgUrl = downloadProfileImg(socialInfo.profileImgUrl());
+            return CreateUserDTO.of(socialInfo, profileImgUrl);
+        }
+
+        return CreateUserDTO.from(socialInfo);
+    }
+
+    private String downloadProfileImg(String profileImgUrl) {
+        Path profileImg = fileDownloader.downloadFile(profileImgUrl);
+        String s3ProfileImgUrl = s3FileHandler.uploadFile(profileImg.toFile(),
+                FolderPath.combine(FolderPath.USER, FolderPath.PROFILE));
+        fileDownloader.deleteTempFile(profileImg);
+        return s3ProfileImgUrl;
     }
 
     private Token createToken(AuthUser authUser) {

--- a/src/main/java/org/sopt/confeti/auth/LoginService.java
+++ b/src/main/java/org/sopt/confeti/auth/LoginService.java
@@ -53,10 +53,12 @@ public class LoginService {
 
     private String downloadProfileImg(String profileImgUrl) {
         Path profileImg = fileDownloader.downloadFile(profileImgUrl);
-        String s3ProfileImgUrl = s3FileHandler.uploadFile(profileImg.toFile(),
-                FolderPath.combine(FolderPath.USER, FolderPath.PROFILE));
-        fileDownloader.deleteTempFile(profileImg);
-        return s3ProfileImgUrl;
+        try {
+            return s3FileHandler.uploadFile(profileImg.toFile(),
+                    FolderPath.combine(FolderPath.USER, FolderPath.PROFILE));
+        } finally {
+            fileDownloader.deleteTempFile(profileImg);
+        }
     }
 
     @Transactional

--- a/src/main/java/org/sopt/confeti/auth/LoginService.java
+++ b/src/main/java/org/sopt/confeti/auth/LoginService.java
@@ -13,7 +13,6 @@ import org.sopt.confeti.domain.token.infra.AppleTokenRepository;
 import org.sopt.confeti.domain.token.infra.RefreshTokenRepository;
 import org.sopt.confeti.domain.user.AuthUser;
 import org.sopt.confeti.domain.user.OAuthProvider;
-import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.domain.user.infra.repository.AllUserRepository;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
@@ -38,18 +37,41 @@ public class LoginService {
     private final FileDownloader fileDownloader;
     private final S3FileHandler s3FileHandler;
 
+    public OAuthSocialInfoResult getSocialInfo(LoginCommand command) {
+        OAuthApiClient oAuthApiClient = oAuthApiClientRegistry.getOAuthApiClientByProvider(command.provider());
+        return oAuthApiClient.getSocialInfo(command);
+    }
+
+    public CreateUserDTO getCreateUserDTO(OAuthProvider provider, OAuthSocialInfoResult socialInfo) {
+        if (provider == OAuthProvider.KAKAO) {
+            String profileImgUrl = downloadProfileImg(socialInfo.profileImgUrl());
+            return CreateUserDTO.of(provider, socialInfo, profileImgUrl);
+        }
+
+        return CreateUserDTO.of(provider, socialInfo);
+    }
+
+    private String downloadProfileImg(String profileImgUrl) {
+        Path profileImg = fileDownloader.downloadFile(profileImgUrl);
+        String s3ProfileImgUrl = s3FileHandler.uploadFile(profileImg.toFile(),
+                FolderPath.combine(FolderPath.USER, FolderPath.PROFILE));
+        fileDownloader.deleteTempFile(profileImg);
+        return s3ProfileImgUrl;
+    }
 
     @Transactional
-    public LoginResult login(LoginCommand command) {
-        OAuthApiClient oAuthApiClient = oAuthApiClientRegistry.getOAuthApiClientByProvider(command.provider());
-        OAuthSocialInfoResult socialInfo = oAuthApiClient.getSocialInfo(command);
+    public Token createToken(AuthUser authUser, OAuthSocialInfoResult socialInfo) {
+        Token token = new Token(
+                jwtTokenGenerator.createAccessToken(String.valueOf(authUser.getId()), authUser.getRole(),
+                        authUser.getProvider()),
+                jwtTokenGenerator.createRefreshToken(String.valueOf(authUser.getId()), authUser.getRole(),
+                        authUser.getProvider())
+        );
 
-        AuthUser authUser = loadOrCreateUser(command, socialInfo);
-        Token token = createToken(authUser);
         saveRefreshToken(token.refreshToken(), authUser.getId());
-        saveSocialTokenIfAppleLogin(command.provider(), authUser.getId(), socialInfo);
+        saveSocialTokenIfAppleLogin(authUser.getProvider(), authUser.getId(), socialInfo);
 
-        return LoginResult.from(token, isOnboarding(authUser.getRole()));
+        return token;
     }
 
     private void saveRefreshToken(String refreshToken, long userId) {
@@ -68,58 +90,12 @@ public class LoginService {
         }
     }
 
-    private AuthUser loadOrCreateUser(LoginCommand command, OAuthSocialInfoResult socialInfo) {
-        AuthUser retrievedAuthUser = userRepository.findBySocialIdAndProvider(
-                        socialInfo.id(),
-                        command.provider()
-                )
-                .map(User::toAuthUser)
-                .orElse(null);
-
-        if (retrievedAuthUser != null) {
-            return retrievedAuthUser;
-        }
-
-        CreateUserDTO createUserDTO = getCreateUserDTO(command.provider(), socialInfo);
-
-        return allUserRepository.save(
-                AuthUser.create(
-                        command.provider(),
-                        createUserDTO.id(),
-                        createUserDTO.name(),
-                        createUserDTO.profileImgUrl()
-                )
-        );
-    }
-
-    private CreateUserDTO getCreateUserDTO(OAuthProvider provider, OAuthSocialInfoResult socialInfo) {
-        if (provider == OAuthProvider.KAKAO) {
-            String profileImgUrl = downloadProfileImg(socialInfo.profileImgUrl());
-            return CreateUserDTO.of(socialInfo, profileImgUrl);
-        }
-
-        return CreateUserDTO.from(socialInfo);
-    }
-
-    private String downloadProfileImg(String profileImgUrl) {
-        Path profileImg = fileDownloader.downloadFile(profileImgUrl);
-        String s3ProfileImgUrl = s3FileHandler.uploadFile(profileImg.toFile(),
-                FolderPath.combine(FolderPath.USER, FolderPath.PROFILE));
-        fileDownloader.deleteTempFile(profileImg);
-        return s3ProfileImgUrl;
-    }
-
-    private Token createToken(AuthUser authUser) {
-        return new Token(
-                jwtTokenGenerator.createAccessToken(String.valueOf(authUser.getId()), authUser.getRole(),
-                        authUser.getProvider()),
-                jwtTokenGenerator.createRefreshToken(String.valueOf(authUser.getId()), authUser.getRole(),
-                        authUser.getProvider())
-        );
-    }
-
     private boolean isAppleLogin(OAuthProvider provider) {
         return provider.equals(OAuthProvider.APPLE);
+    }
+
+    public LoginResult getLoginResult(Token token, Role role) {
+        return LoginResult.of(token, isOnboarding(role));
     }
 
     private boolean isOnboarding(Role role) {

--- a/src/main/java/org/sopt/confeti/auth/dto/CreateUserDTO.java
+++ b/src/main/java/org/sopt/confeti/auth/dto/CreateUserDTO.java
@@ -1,0 +1,26 @@
+package org.sopt.confeti.auth.dto;
+
+public record CreateUserDTO(
+        String id,
+        String name,
+        String profileImgUrl,
+        OAuthTokenInfoResult token
+) {
+    public static CreateUserDTO from(OAuthSocialInfoResult socialInfo) {
+        return new CreateUserDTO(
+                socialInfo.id(),
+                socialInfo.name(),
+                socialInfo.profileImgUrl(),
+                socialInfo.token()
+        );
+    }
+
+    public static CreateUserDTO of(OAuthSocialInfoResult socialInfo, String profileImgUrl) {
+        return new CreateUserDTO(
+                socialInfo.id(),
+                socialInfo.name(),
+                profileImgUrl,
+                socialInfo.token()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/auth/dto/CreateUserDTO.java
+++ b/src/main/java/org/sopt/confeti/auth/dto/CreateUserDTO.java
@@ -1,23 +1,28 @@
 package org.sopt.confeti.auth.dto;
 
+import org.sopt.confeti.domain.user.OAuthProvider;
+
 public record CreateUserDTO(
         String id,
+        OAuthProvider provider,
         String name,
         String profileImgUrl,
         OAuthTokenInfoResult token
 ) {
-    public static CreateUserDTO from(OAuthSocialInfoResult socialInfo) {
+    public static CreateUserDTO of(OAuthProvider provider, OAuthSocialInfoResult socialInfo) {
         return new CreateUserDTO(
                 socialInfo.id(),
+                provider,
                 socialInfo.name(),
                 socialInfo.profileImgUrl(),
                 socialInfo.token()
         );
     }
 
-    public static CreateUserDTO of(OAuthSocialInfoResult socialInfo, String profileImgUrl) {
+    public static CreateUserDTO of(OAuthProvider provider, OAuthSocialInfoResult socialInfo, String profileImgUrl) {
         return new CreateUserDTO(
                 socialInfo.id(),
+                provider,
                 socialInfo.name(),
                 profileImgUrl,
                 socialInfo.token()

--- a/src/main/java/org/sopt/confeti/auth/dto/LoginResult.java
+++ b/src/main/java/org/sopt/confeti/auth/dto/LoginResult.java
@@ -7,7 +7,7 @@ public record LoginResult(
         String refreshToken,
         boolean isOnboarding
 ) {
-    public static LoginResult from(Token token, boolean isOnboarding) {
+    public static LoginResult of(Token token, boolean isOnboarding) {
         return new LoginResult(token.accessToken(), token.refreshToken(), isOnboarding);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
@@ -1,7 +1,11 @@
 package org.sopt.confeti.domain.user.application;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.auth.dto.CreateUserDTO;
+import org.sopt.confeti.domain.user.AuthUser;
+import org.sopt.confeti.domain.user.OAuthProvider;
 import org.sopt.confeti.domain.user.User;
+import org.sopt.confeti.domain.user.infra.repository.AllUserRepository;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
@@ -12,7 +16,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
     private final UserRepository userRepository;
+    private final AllUserRepository allUserRepository;
 
     @Transactional(readOnly = true)
     public User findById(Long userId) {
@@ -39,5 +45,31 @@ public class UserService {
     @Transactional
     public void deleteUser(User user) {
         userRepository.delete(user);
+    }
+
+    @Transactional(readOnly = true)
+    public boolean notExist(String socialId, OAuthProvider provider) {
+        return !userRepository.existsBySocialIdAndProvider(socialId, provider);
+    }
+
+    @Transactional
+    public void create(CreateUserDTO createUserDTO) {
+        allUserRepository.save(
+                AuthUser.create(
+                        createUserDTO.provider(),
+                        createUserDTO.id(),
+                        createUserDTO.name(),
+                        createUserDTO.profileImgUrl()
+                )
+        );
+    }
+
+    @Transactional(readOnly = true)
+    public AuthUser getAuthUser(String socialId, OAuthProvider provider) {
+        return userRepository.findBySocialIdAndProvider(socialId, provider)
+                .map(AuthUser::toAuthUser)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+                );
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/user/infra/repository/UserRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/user/infra/repository/UserRepository.java
@@ -17,4 +17,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findUserTimetablesById(final @Param("userId") long userId);
 
     Optional<User> findBySocialIdAndProvider(String socialId, OAuthProvider provider);
+
+    boolean existsBySocialIdAndProvider(String socialId, OAuthProvider provider);
 }

--- a/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
@@ -7,7 +7,7 @@ import org.sopt.confeti.global.message.ErrorMessage;
 public enum FolderPath {
     FESTIVAL("festival"), CONCERT("concert"), USER("user"),
     DETAIL("detail"), LOGO("logo"), MAIN_BANNER("main-banner"),
-    POSTER_BG("poster-bg"), POSTER("poster"), RESERVATION("reservation");
+    POSTER_BG("poster-bg"), POSTER("poster"), RESERVATION("reservation"), PROFILE("profile");
 
     private static final String PATH_DELIMITER = "/";
     private final String path;

--- a/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
@@ -6,8 +6,8 @@ import org.sopt.confeti.global.message.ErrorMessage;
 
 public enum FolderPath {
     FESTIVAL("festival"), CONCERT("concert"), USER("user"),
-    DETAIL("detail"), LOGO("logo"), MAIN_BANNER("main-banner"),
-    POSTER_BG("poster-bg"), POSTER("poster"), RESERVATION("reservation"), PROFILE("profile");
+    LOGO("logo"), POSTER_BG("poster-bg"), POSTER("poster"),
+    RESERVATION("reservation"), PROFILE("profile");
 
     private static final String PATH_DELIMITER = "/";
     private final String path;

--- a/src/main/java/org/sopt/confeti/global/util/FileDownloader.java
+++ b/src/main/java/org/sopt/confeti/global/util/FileDownloader.java
@@ -1,0 +1,60 @@
+package org.sopt.confeti.global.util;
+
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
+import org.springframework.http.HttpMethod;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FileDownloader {
+
+    private static final String TEMP_FILE_PREFIX = "temp-profile-";
+    private static final String TEMP_FILE_TYPE = ".png";
+
+    private static final int BUFFER_SIZE = 4096;
+
+    public Path downloadFile(String url) {
+        try {
+            URL downloadUrl = new URL(url);
+            HttpURLConnection connection = (HttpURLConnection) downloadUrl.openConnection();
+            connection.setRequestMethod(HttpMethod.GET.name());
+
+            // 임시 파일로 저장
+            Path tempFile = Files.createTempFile(TEMP_FILE_PREFIX, TEMP_FILE_TYPE);
+            try (InputStream inputStream = connection.getInputStream();
+                 FileOutputStream outputStream = new FileOutputStream(tempFile.toFile())) {
+
+                byte[] buffer = new byte[BUFFER_SIZE];
+                int bytesRead;
+                while ((bytesRead = inputStream.read(buffer)) != -1) {
+                    outputStream.write(buffer, 0, bytesRead);
+                }
+            }
+
+            return tempFile;
+        } catch (IOException e) {
+            log.error("파일 다운로드 실패 : {}", e.getMessage());
+            throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    public void deleteTempFile(Path tempFile) {
+        try {
+            Files.delete(tempFile);
+        } catch (IOException e) {
+            log.error("임시 파일 삭제 실패 : {}", e.getMessage());
+            throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -12,6 +12,7 @@ import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Handler;
 import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.multipart.MultipartFile;
@@ -93,6 +94,8 @@ public class S3FileHandler {
      * 파일 삭제
      */
     public void deleteFile(String folderPath, String key) {
+        checkFileExist(folderPath, key);
+
         s3Operations.deleteObject(bucket, folderPath + key);
     }
 
@@ -100,16 +103,25 @@ public class S3FileHandler {
      * 파일 조회 URL 생성
      */
     public URL getFileUrl(String folderPath, String key) {
+        checkFileExist(folderPath, key);
+
         return s3Operations.createSignedGetURL(bucket, folderPath + key, urlDuration);
+    }
+
+    /**
+     * 파일이 존재하는지 확인
+     */
+    private void checkFileExist(String folderPath, String key) {
+        if (!s3Operations.objectExists(bucket, folderPath + key)) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
     }
 
     /**
      * 파일 수정 (삭제 -> 업로드)
      */
     public void updateFile(MultipartFile file, String folderPath, String key) throws IOException {
-        if (!s3Operations.objectExists(bucket, folderPath + key)) {
-            throw new ConfetiException(ErrorMessage.FORBIDDEN);
-        }
+        checkFileExist(folderPath, key);
 
         deleteFile(folderPath, key);
         upload(folderPath + key, file.getInputStream(), getMetadata(file));

--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -2,9 +2,12 @@ package org.sopt.confeti.global.util;
 
 import io.awspring.cloud.s3.ObjectMetadata;
 import io.awspring.cloud.s3.S3Operations;
+import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URL;
+import java.nio.file.Files;
 import java.time.Duration;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Handler;
@@ -44,10 +47,41 @@ public class S3FileHandler {
         return fileName;
     }
 
+    public String uploadFile(File file, String folderPath) {
+        final String fileName = fileNameGenerator.generate(file.getName());
+        final ObjectMetadata metadata = getMetadata(file);
+
+        try (FileInputStream inputStream = new FileInputStream(file)) {
+            upload(
+                    folderPath + fileName,
+                    inputStream, metadata
+            );
+        } catch (IOException e) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
+
+        return fileName;
+    }
+
     private ObjectMetadata getMetadata(MultipartFile file) {
         return new ObjectMetadata.Builder()
                 .contentLength(file.getSize())
                 .contentType(file.getContentType())
+                .build();
+    }
+
+    private ObjectMetadata getMetadata(File file) {
+        String contentType;
+
+        try {
+            contentType = Files.probeContentType(file.toPath());
+        } catch (IOException e) {
+            contentType = "application/octet-stream";
+        }
+
+        return new ObjectMetadata.Builder()
+                .contentLength(file.length())
+                .contentType(contentType)
                 .build();
     }
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #286 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 로그인 API에 카카오 로그인 시 프로필 이미지를 S3에 다운로드 후 경로 저장하는 로직 추가


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
[ 카카오 로그인 성공 ]
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/8e83c0f4-d699-4c61-a8cb-1cd4e06a723e" />

[ S3에 저장된 카카오 기본 프로필 ]
<img width="1501" alt="image" src="https://github.com/user-attachments/assets/8a74a442-15c8-4890-9ffd-71dcffd18b14" />

[ 프로필 조회 성공 ]
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/60d695b8-745e-459f-b1e5-bd03e94e4c81" />
