### PR TITLE
feat [#288] 애플 로그인 시 기본 프로필 이미지 지정

### DIFF
--- a/src/main/java/org/sopt/confeti/auth/LoginService.java
+++ b/src/main/java/org/sopt/confeti/auth/LoginService.java
@@ -64,7 +64,7 @@ public class LoginService {
                 FolderPath.combine(FolderPath.USER, FolderPath.DEFAULT),
                 Default.PROFILE_IMG_NAME,
                 FolderPath.combine(FolderPath.USER, FolderPath.PROFILE),
-                socialName
+                socialName + Default.PROFILE_IMG_NAME
         );
     }
 

--- a/src/main/java/org/sopt/confeti/auth/LoginService.java
+++ b/src/main/java/org/sopt/confeti/auth/LoginService.java
@@ -14,8 +14,7 @@ import org.sopt.confeti.domain.token.infra.RefreshTokenRepository;
 import org.sopt.confeti.domain.user.AuthUser;
 import org.sopt.confeti.domain.user.OAuthProvider;
 import org.sopt.confeti.domain.user.constant.Role;
-import org.sopt.confeti.domain.user.infra.repository.AllUserRepository;
-import org.sopt.confeti.domain.user.infra.repository.UserRepository;
+import org.sopt.confeti.global.common.constant.Default;
 import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.oauth.OAuthApiClient;
 import org.sopt.confeti.global.oauth.OAuthApiClientRegistry;
@@ -29,8 +28,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class LoginService {
 
     private final OAuthApiClientRegistry oAuthApiClientRegistry;
-    private final UserRepository userRepository;
-    private final AllUserRepository allUserRepository;
     private final JwtTokenGenerator jwtTokenGenerator;
     private final RefreshTokenRepository refreshTokenRepository;
     private final AppleTokenRepository appleTokenRepository;
@@ -48,7 +45,8 @@ public class LoginService {
             return CreateUserDTO.of(provider, socialInfo, profileImgUrl);
         }
 
-        return CreateUserDTO.of(provider, socialInfo);
+        String defaultProfileImgName = getDefaultProfileImgName(socialInfo.name());
+        return CreateUserDTO.of(provider, socialInfo, defaultProfileImgName);
     }
 
     private String downloadProfileImg(String profileImgUrl) {
@@ -59,6 +57,15 @@ public class LoginService {
         } finally {
             fileDownloader.deleteTempFile(profileImg);
         }
+    }
+
+    private String getDefaultProfileImgName(String socialName) {
+        return s3FileHandler.copyFile(
+                FolderPath.combine(FolderPath.USER, FolderPath.DEFAULT),
+                Default.PROFILE_IMG_NAME,
+                FolderPath.combine(FolderPath.USER, FolderPath.PROFILE),
+                socialName
+        );
     }
 
     @Transactional

--- a/src/main/java/org/sopt/confeti/auth/dto/CreateUserDTO.java
+++ b/src/main/java/org/sopt/confeti/auth/dto/CreateUserDTO.java
@@ -9,15 +9,6 @@ public record CreateUserDTO(
         String profileImgUrl,
         OAuthTokenInfoResult token
 ) {
-    public static CreateUserDTO of(OAuthProvider provider, OAuthSocialInfoResult socialInfo) {
-        return new CreateUserDTO(
-                socialInfo.id(),
-                provider,
-                socialInfo.name(),
-                socialInfo.profileImgUrl(),
-                socialInfo.token()
-        );
-    }
 
     public static CreateUserDTO of(OAuthProvider provider, OAuthSocialInfoResult socialInfo, String profileImgUrl) {
         return new CreateUserDTO(

--- a/src/main/java/org/sopt/confeti/global/common/constant/Default.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/Default.java
@@ -9,4 +9,5 @@ public class Default {
     public static String IMG_PATH = "default/img_logo_3d.svg";
     public static String URL = "https://www.naver.com/";
     public static String TEXT = "CONFETI";
+    public static String PROFILE_IMG_NAME = "user-profile.svg";
 }

--- a/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
@@ -7,7 +7,7 @@ import org.sopt.confeti.global.message.ErrorMessage;
 public enum FolderPath {
     FESTIVAL("festival"), CONCERT("concert"), USER("user"),
     LOGO("logo"), POSTER_BG("poster-bg"), POSTER("poster"),
-    RESERVATION("reservation"), PROFILE("profile");
+    RESERVATION("reservation"), PROFILE("profile"), DEFAULT("default");
 
     private static final String PATH_DELIMITER = "/";
     private final String path;

--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -16,6 +16,8 @@ import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
 
 @Handler
 @RequiredArgsConstructor
@@ -24,6 +26,7 @@ public class S3FileHandler {
     private static final Duration urlDuration = Duration.ofMinutes(10L);
 
     private final S3Operations s3Operations;
+    private final S3Client s3Client;
     private final FileNameGenerator fileNameGenerator;
 
     @Value("${spring.cloud.aws.s3.bucket-name}")
@@ -34,6 +37,8 @@ public class S3FileHandler {
      */
     public String uploadFile(MultipartFile file, String folderPath) {
         final String fileName = fileNameGenerator.generate(file.getOriginalFilename());
+        checkFileNotExist(folderPath, fileName);
+
         final ObjectMetadata metadata = getMetadata(file);
 
         try {
@@ -115,6 +120,36 @@ public class S3FileHandler {
         if (!s3Operations.objectExists(bucket, folderPath + key)) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
+    }
+
+    /**
+     * 파일이 존재하지 않는지 확인
+     */
+    private void checkFileNotExist(String folderPath, String key) {
+        if (s3Operations.objectExists(bucket, folderPath + key)) {
+            throw new ConfetiException(ErrorMessage.CONFLICT);
+        }
+    }
+
+    /**
+     * 파일 복사
+     */
+    public String copyFile(String originFolderPath, String originKey, String targetFolderPath, String targetKey) {
+        checkFileExist(originFolderPath, originKey);
+        checkFileNotExist(targetFolderPath, targetKey);
+
+        String targetFileName = fileNameGenerator.generate(targetKey + originKey);
+
+        CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
+                .sourceBucket(bucket)
+                .sourceKey(originFolderPath + originKey)
+                .destinationBucket(bucket)
+                .destinationKey(targetFolderPath + targetFileName)
+                .build();
+
+        s3Client.copyObject(copyObjectRequest);
+
+        return targetFileName;
     }
 
     /**

--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -15,6 +15,7 @@ import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.scheduling.annotation.Async;
 import org.springframework.web.multipart.MultipartFile;
 import software.amazon.awssdk.services.s3.S3Client;
 import software.amazon.awssdk.services.s3.model.CopyObjectRequest;
@@ -91,13 +92,15 @@ public class S3FileHandler {
                 .build();
     }
 
-    private void upload(String fullPath, InputStream is, ObjectMetadata metadata) {
+    @Async
+    protected void upload(String fullPath, InputStream is, ObjectMetadata metadata) {
         s3Operations.upload(bucket, fullPath, is, metadata);
     }
 
     /**
      * 파일 삭제
      */
+    @Async
     public void deleteFile(String folderPath, String key) {
         checkFileExist(folderPath, key);
 
@@ -138,7 +141,7 @@ public class S3FileHandler {
         checkFileExist(originFolderPath, originKey);
         checkFileNotExist(targetFolderPath, targetKey);
 
-        String targetFileName = fileNameGenerator.generate(targetKey + originKey);
+        String targetFileName = fileNameGenerator.generate(targetKey);
 
         CopyObjectRequest copyObjectRequest = CopyObjectRequest.builder()
                 .sourceBucket(bucket)
@@ -147,14 +150,20 @@ public class S3FileHandler {
                 .destinationKey(targetFolderPath + targetFileName)
                 .build();
 
-        s3Client.copyObject(copyObjectRequest);
+        copyFileAsync(copyObjectRequest);
 
         return targetFileName;
+    }
+
+    @Async
+    protected void copyFileAsync(CopyObjectRequest copyObjectRequest) {
+        s3Client.copyObject(copyObjectRequest);
     }
 
     /**
      * 파일 수정 (삭제 -> 업로드)
      */
+    @Async
     public void updateFile(MultipartFile file, String folderPath, String key) throws IOException {
         checkFileExist(folderPath, key);
 


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #288 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 애플 로그인 시 기본 프로필 이미지 지정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
기본 프로필로 지정할 이미지가 S3의 `user/default/user-profile.svg`로 저장되어있어요.
애플 로그인할 때 위 이미지를 복사해 사용자 이미지로 저장하는 로직을 구현했습니다.

[ 애플 로그인 성공 ]
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/639c1cb0-e046-4259-a181-a425b1aa3c88" />

[ 애플 로그인 이후 프로필 조회 ]
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/542cc10d-8ca4-4264-a415-9b6a53c34089" />

[ 프로필 조회에서 조회된 이미지 ]
<img width="1502" alt="image" src="https://github.com/user-attachments/assets/d6fb165d-16ca-4f39-842f-c10f2edaae37" />
