### PR TITLE
fix [#296] My artist 미리보기 목록 조회 API 반환 개수 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/domain/artist_favorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artist_favorite/application/ArtistFavoriteService.java
@@ -17,7 +17,7 @@ public class ArtistFavoriteService {
 
     @Transactional(readOnly = true)
     public List<ArtistFavorite> getArtistListPreview(Long userId) {
-        List<ArtistFavorite> artistList = artistFavoriteRepository.findTop3ByUserIdOrderByRand(userId);
+        List<ArtistFavorite> artistList = artistFavoriteRepository.findTop4ByUserIdOrderByRand(userId);
         musicAPIResolver.load(artistList);
 
         return artistList;

--- a/src/main/java/org/sopt/confeti/domain/artist_favorite/infra/repository/ArtistFavoriteRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/artist_favorite/infra/repository/ArtistFavoriteRepository.java
@@ -7,8 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ArtistFavoriteRepository extends JpaRepository<ArtistFavorite, Long> {
-    @Query(value = "select * from artist_favorites where user_id = :userId order by rand() limit 3", nativeQuery = true)
-    List<ArtistFavorite> findTop3ByUserIdOrderByRand(@Param("userId") Long userId);
+    @Query(value = "select * from artist_favorites where user_id = :userId order by rand() limit 4", nativeQuery = true)
+    List<ArtistFavorite> findTop4ByUserIdOrderByRand(@Param("userId") Long userId);
 
     boolean existsByUserIdAndArtist_id(long userId, String artistId);
 

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
@@ -28,11 +28,6 @@ public class ArtistResolver implements MusicAPISpecificResolver {
             return;
         }
 
-        if (target instanceof List<?> list) {
-            list.forEach(this::load);
-            return;
-        }
-
         final ArtistStrategy strategy = getStrategy(target);
         if (notSupports(strategy)) {
             return;

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
@@ -28,6 +28,11 @@ public class ArtistResolver implements MusicAPISpecificResolver {
             return;
         }
 
+        if (target instanceof List<?> list) {
+            list.forEach(this::load);
+            return;
+        }
+
         final ArtistStrategy strategy = getStrategy(target);
         if (notSupports(strategy)) {
             return;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #296 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] My artist 미리보기 반환 개수 3개에서 4개로 수정
- [x] ArtistResolver에서 리스트도 처리 가능하도록 수정 


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
현재 방식은 단건 처리에만 대응하고 있어 List<ArtistFavorite>와 같이 다건이 입력될 경우 supports()를 통과하지 못하는 문제가 있었습니다. 이에 따라 load() 내부에서 입력값이 리스트인지 확인하고, 리스트인 경우 각 요소에 대해 재귀적으로 load()를 호출하도록 수정하였습니다.
혹시 이보다 더 나은 방법이 있다면 말씀해 주세요!


![image](https://github.com/user-attachments/assets/e3e9f15d-3573-4694-9968-1d4ae0b683b3)
