### PR TITLE
fix [#299] 외부 음악 리졸버에서 리스트 타입의 전략을 가져올 수 있도록 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/domain/artist_favorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artist_favorite/application/ArtistFavoriteService.java
@@ -17,7 +17,7 @@ public class ArtistFavoriteService {
 
     @Transactional(readOnly = true)
     public List<ArtistFavorite> getArtistListPreview(Long userId) {
-        List<ArtistFavorite> artistList = artistFavoriteRepository.findTop3ByUserIdOrderByRand(userId);
+        List<ArtistFavorite> artistList = artistFavoriteRepository.findTop4ByUserIdOrderByRand(userId);
         musicAPIResolver.load(artistList);
 
         return artistList;

--- a/src/main/java/org/sopt/confeti/domain/artist_favorite/infra/repository/ArtistFavoriteRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/artist_favorite/infra/repository/ArtistFavoriteRepository.java
@@ -7,8 +7,8 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface ArtistFavoriteRepository extends JpaRepository<ArtistFavorite, Long> {
-    @Query(value = "select * from artist_favorites where user_id = :userId order by rand() limit 3", nativeQuery = true)
-    List<ArtistFavorite> findTop3ByUserIdOrderByRand(@Param("userId") Long userId);
+    @Query(value = "select * from artist_favorites where user_id = :userId order by rand() limit 4", nativeQuery = true)
+    List<ArtistFavorite> findTop4ByUserIdOrderByRand(@Param("userId") Long userId);
 
     boolean existsByUserIdAndArtist_id(long userId, String artistId);
 

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/AbstractMusicAPISpecificResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/AbstractMusicAPISpecificResolver.java
@@ -1,0 +1,37 @@
+package org.sopt.confeti.global.resolver.music_api;
+
+import java.util.List;
+import java.util.Optional;
+import org.sopt.confeti.global.resolver.music_api.strategy.MusicAPIStrategy;
+
+public abstract class AbstractMusicAPISpecificResolver implements MusicAPISpecificResolver {
+
+    protected <T> boolean isListType(final T target) {
+        return target instanceof List<?>;
+    }
+
+    protected <T> boolean isEmpty(T target) {
+        return target == null || isListType(target) && ((List<?>) target).isEmpty();
+    }
+
+    protected boolean notSupports(MusicAPIStrategy<?> strategy) {
+        return strategy == null;
+    }
+
+    protected <T> Class<?> getTargetClass(T target) {
+        Class<?> targetClass = target.getClass();
+
+        if (isListType(target)) {
+            Optional<Class<?>> firstItem = ((List<?>) target).stream()
+                    .findFirst()
+                    .map(Object::getClass);
+
+            // 값이 비어있을 때는 List 타입
+            if (firstItem.isPresent()) {
+                targetClass = firstItem.get();
+            }
+        }
+
+        return targetClass;
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/album/AlbumResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/album/AlbumResolver.java
@@ -2,12 +2,11 @@ package org.sopt.confeti.global.resolver.music_api.album;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Resolver;
-import org.sopt.confeti.global.resolver.music_api.MusicAPISpecificResolver;
+import org.sopt.confeti.global.resolver.music_api.AbstractMusicAPISpecificResolver;
 import org.sopt.confeti.global.resolver.music_api.album.strategy.AlbumStrategy;
 import org.sopt.confeti.global.resolver.music_api.album.strategy.AlbumStrategyRegistry;
 import org.sopt.confeti.global.resolver.music_api.album.vo.ConfetiAlbum;
@@ -16,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Resolver
 @RequiredArgsConstructor
-public class AlbumResolver implements MusicAPISpecificResolver {
+public class AlbumResolver extends AbstractMusicAPISpecificResolver {
 
     private final MusicAPIHandler musicAPIHandler;
     private final AlbumStrategyRegistry albumStrategyRegistry;
@@ -40,28 +39,8 @@ public class AlbumResolver implements MusicAPISpecificResolver {
         );
     }
 
-    private <T> boolean isEmpty(T target) {
-        return target == null || isListType(target) && ((List<?>) target).isEmpty();
-    }
-
     private <T> AlbumStrategy getStrategy(T target) {
-        Class<?> targetClass = target.getClass();
-
-        if (isListType(target)) {
-            Optional<Class<?>> firstItem = ((List<?>) target).stream()
-                    .findFirst()
-                    .map(Object::getClass);
-
-            if (firstItem.isPresent()) {
-                targetClass = firstItem.get();
-            }
-        }
-
-        return albumStrategyRegistry.getAlbumStrategyByClass(targetClass);
-    }
-
-    private boolean notSupports(AlbumStrategy strategy) {
-        return strategy == null;
+        return albumStrategyRegistry.getAlbumStrategyByClass(getTargetClass(target));
     }
 
     private <T> void collect(
@@ -93,10 +72,6 @@ public class AlbumResolver implements MusicAPISpecificResolver {
             final T target
     ) {
         strategy.collect(albumMapper, target);
-    }
-
-    private <T> boolean isListType(final T target) {
-        return target instanceof List<?>;
     }
 
     private void injection(

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/album/AlbumResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/album/AlbumResolver.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.global.resolver.music_api.album;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -40,11 +41,23 @@ public class AlbumResolver implements MusicAPISpecificResolver {
     }
 
     private <T> boolean isEmpty(T target) {
-        return target == null;
+        return target == null || isListType(target) && ((List<?>) target).isEmpty();
     }
 
     private <T> AlbumStrategy getStrategy(T target) {
-        return albumStrategyRegistry.getAlbumStrategyByClass(target.getClass());
+        Class<?> targetClass = target.getClass();
+
+        if (isListType(target)) {
+            Optional<Class<?>> firstItem = ((List<?>) target).stream()
+                    .findFirst()
+                    .map(Object::getClass);
+
+            if (firstItem.isPresent()) {
+                targetClass = firstItem.get();
+            }
+        }
+
+        return albumStrategyRegistry.getAlbumStrategyByClass(targetClass);
     }
 
     private boolean notSupports(AlbumStrategy strategy) {

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
@@ -2,13 +2,12 @@ package org.sopt.confeti.global.resolver.music_api.artist;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.global.annotation.Resolver;
-import org.sopt.confeti.global.resolver.music_api.MusicAPISpecificResolver;
+import org.sopt.confeti.global.resolver.music_api.AbstractMusicAPISpecificResolver;
 import org.sopt.confeti.global.resolver.music_api.album.vo.ConfetiAlbum;
 import org.sopt.confeti.global.resolver.music_api.artist.strategy.ArtistStrategy;
 import org.sopt.confeti.global.resolver.music_api.artist.strategy.ArtistStrategyRegistry;
@@ -19,7 +18,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Slf4j
 @Resolver
 @RequiredArgsConstructor
-public class ArtistResolver implements MusicAPISpecificResolver {
+public class ArtistResolver extends AbstractMusicAPISpecificResolver {
 
     private final MusicAPIHandler musicAPIHandler;
     private final ArtistStrategyRegistry artistStrategyRegistry;
@@ -43,28 +42,8 @@ public class ArtistResolver implements MusicAPISpecificResolver {
         );
     }
 
-    private <T> boolean isEmpty(T target) {
-        return target == null || isListType(target) && ((List<?>) target).isEmpty();
-    }
-
     private <T> ArtistStrategy getStrategy(T target) {
-        Class<?> targetClass = target.getClass();
-
-        if (isListType(target)) {
-            Optional<Class<?>> firstItem = ((List<?>) target).stream()
-                    .findFirst()
-                    .map(Object::getClass);
-
-            if (firstItem.isPresent()) {
-                targetClass = firstItem.get();
-            }
-        }
-
-        return artistStrategyRegistry.getArtistStrategyByClass(targetClass);
-    }
-
-    private boolean notSupports(ArtistStrategy strategy) {
-        return strategy == null;
+        return artistStrategyRegistry.getArtistStrategyByClass(getTargetClass(target));
     }
 
     private <T> void collect(
@@ -96,10 +75,6 @@ public class ArtistResolver implements MusicAPISpecificResolver {
             final T target
     ) {
         strategy.collect(artistMapper, target);
-    }
-
-    private <T> boolean isListType(final T target) {
-        return target instanceof List<?>;
     }
 
     private void injection(

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
@@ -28,11 +28,6 @@ public class ArtistResolver implements MusicAPISpecificResolver {
             return;
         }
 
-        if (target instanceof List<?> list) {
-            list.forEach(this::load);
-            return;
-        }
-
         final ArtistStrategy strategy = getStrategy(target);
         if (notSupports(strategy)) {
             return;

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
@@ -28,6 +28,11 @@ public class ArtistResolver implements MusicAPISpecificResolver {
             return;
         }
 
+        if (target instanceof List<?> list) {
+            list.forEach(this::load);
+            return;
+        }
+
         final ArtistStrategy strategy = getStrategy(target);
         if (notSupports(strategy)) {
             return;

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/ArtistResolver.java
@@ -2,9 +2,11 @@ package org.sopt.confeti.global.resolver.music_api.artist;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.global.annotation.Resolver;
 import org.sopt.confeti.global.resolver.music_api.MusicAPISpecificResolver;
 import org.sopt.confeti.global.resolver.music_api.album.vo.ConfetiAlbum;
@@ -14,6 +16,7 @@ import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Resolver
 @RequiredArgsConstructor
 public class ArtistResolver implements MusicAPISpecificResolver {
@@ -41,11 +44,23 @@ public class ArtistResolver implements MusicAPISpecificResolver {
     }
 
     private <T> boolean isEmpty(T target) {
-        return target == null;
+        return target == null || isListType(target) && ((List<?>) target).isEmpty();
     }
 
     private <T> ArtistStrategy getStrategy(T target) {
-        return artistStrategyRegistry.getArtistStrategyByClass(target.getClass());
+        Class<?> targetClass = target.getClass();
+
+        if (isListType(target)) {
+            Optional<Class<?>> firstItem = ((List<?>) target).stream()
+                    .findFirst()
+                    .map(Object::getClass);
+
+            if (firstItem.isPresent()) {
+                targetClass = firstItem.get();
+            }
+        }
+
+        return artistStrategyRegistry.getArtistStrategyByClass(targetClass);
     }
 
     private boolean notSupports(ArtistStrategy strategy) {

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/music/MusicResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/music/MusicResolver.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.global.resolver.music_api.music;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
@@ -40,11 +41,23 @@ public class MusicResolver implements MusicAPISpecificResolver {
     }
 
     private <T> boolean isEmpty(T target) {
-        return target == null;
+        return target == null || isListType(target) && ((List<?>) target).isEmpty();
     }
 
     private <T> MusicStrategy getStrategy(T target) {
-        return musicStrategyRegistry.getMusicStrategyByClass(target.getClass());
+        Class<?> targetClass = target.getClass();
+
+        if (isListType(target)) {
+            Optional<Class<?>> firstItem = ((List<?>) target).stream()
+                    .findFirst()
+                    .map(Object::getClass);
+
+            if (firstItem.isPresent()) {
+                targetClass = firstItem.get();
+            }
+        }
+
+        return musicStrategyRegistry.getMusicStrategyByClass(targetClass);
     }
 
     private boolean notSupports(MusicStrategy strategy) {

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/music/MusicResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/music/MusicResolver.java
@@ -2,12 +2,11 @@ package org.sopt.confeti.global.resolver.music_api.music;
 
 import java.util.HashMap;
 import java.util.List;
-import java.util.Optional;
 import java.util.Queue;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Resolver;
-import org.sopt.confeti.global.resolver.music_api.MusicAPISpecificResolver;
+import org.sopt.confeti.global.resolver.music_api.AbstractMusicAPISpecificResolver;
 import org.sopt.confeti.global.resolver.music_api.music.strategy.MusicStrategy;
 import org.sopt.confeti.global.resolver.music_api.music.strategy.MusicStrategyRegistry;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
@@ -16,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Resolver
 @RequiredArgsConstructor
-public class MusicResolver implements MusicAPISpecificResolver {
+public class MusicResolver extends AbstractMusicAPISpecificResolver {
 
     private final MusicAPIHandler musicAPIHandler;
     private final MusicStrategyRegistry musicStrategyRegistry;
@@ -40,28 +39,8 @@ public class MusicResolver implements MusicAPISpecificResolver {
         );
     }
 
-    private <T> boolean isEmpty(T target) {
-        return target == null || isListType(target) && ((List<?>) target).isEmpty();
-    }
-
     private <T> MusicStrategy getStrategy(T target) {
-        Class<?> targetClass = target.getClass();
-
-        if (isListType(target)) {
-            Optional<Class<?>> firstItem = ((List<?>) target).stream()
-                    .findFirst()
-                    .map(Object::getClass);
-
-            if (firstItem.isPresent()) {
-                targetClass = firstItem.get();
-            }
-        }
-
-        return musicStrategyRegistry.getMusicStrategyByClass(targetClass);
-    }
-
-    private boolean notSupports(MusicStrategy strategy) {
-        return strategy == null;
+        return musicStrategyRegistry.getMusicStrategyByClass(getTargetClass(target));
     }
 
     private <T> void collect(
@@ -93,10 +72,6 @@ public class MusicResolver implements MusicAPISpecificResolver {
             final T target
     ) {
         strategy.collect(musicMapper, target);
-    }
-
-    private <T> boolean isListType(final T target) {
-        return target instanceof List<?>;
     }
 
     private void injection(


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #299 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 검사 로직과 같은 공통 로직을 추상 클래스로 추출
- [x] isEmpty, getStrategy 함수에 리스트 타입 처리 추가

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
전략 패턴을 찾을 때 리스트 타입인 경우 첫 번째 아이템의 타입으로 찾도록 수정했습니다!
그리고 공통된 로직이 있어 추상화 클래스로 묶었습니다.
