### PR TITLE
feat [#298] 다가오는 공연 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
@@ -2,10 +2,12 @@ package org.sopt.confeti.api.user.controller;
 
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.dto.response.UpcomingPerformanceResponse;
 import org.sopt.confeti.api.user.dto.response.UserFavoritePerformancesAllResponse;
 import org.sopt.confeti.api.user.dto.response.UserFavoritePerformancesResponse;
 import org.sopt.confeti.api.user.dto.response.UserFavoriteResponse;
 import org.sopt.confeti.api.user.facade.UserFavoriteFacade;
+import org.sopt.confeti.api.user.facade.dto.response.UpcomingPerformanceDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoriteArtistDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoritePerformancesAllDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoritePerformancesDTO;
@@ -13,7 +15,6 @@ import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
-import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.common.constant.RequestConstraint;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
@@ -118,5 +119,15 @@ public class UserFavoriteController {
         UserFavoritePerformancesAllDTO userFavoritePerformancesAllDTO = userFavoriteFacade.getFavoritePerformancesAll(userId, type);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 UserFavoritePerformancesAllResponse.of(userFavoritePerformancesAllDTO, s3FileHandler));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/performance")
+    public ResponseEntity<BaseResponse<?>> getUpcomingPerformance(
+            @UserId Long userId
+    ) {
+        UpcomingPerformanceDTO upcomingPerformanceDTO = userFavoriteFacade.getUpcomingPerformance(userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                UpcomingPerformanceResponse.of(upcomingPerformanceDTO, s3FileHandler));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UpcomingPerformanceResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UpcomingPerformanceResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.confeti.api.user.dto.response;
+
+import org.sopt.confeti.api.user.facade.dto.response.UpcomingPerformanceDTO;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.util.DateConvertor;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record UpcomingPerformanceResponse (
+        long typeId,
+        PerformanceType type,
+        String title,
+        String posterUrl,
+        String startAt,
+        String endAt,
+        String area
+) {
+    public static UpcomingPerformanceResponse of(final UpcomingPerformanceDTO upcomingPerformanceDTO, final S3FileHandler s3FileHandler) {
+        FolderPath topFolder = FolderPath.getFolderPathByPerformanceType(upcomingPerformanceDTO.type());
+        return new UpcomingPerformanceResponse(
+                upcomingPerformanceDTO.typeId(),
+                upcomingPerformanceDTO.type(),
+                upcomingPerformanceDTO.title(),
+                s3FileHandler.getFileUrl(FolderPath.combine(topFolder, FolderPath.POSTER), upcomingPerformanceDTO.posterPath())
+                        .toString(),
+                DateConvertor.convertToDefaultFormat(upcomingPerformanceDTO.startAt()),
+                DateConvertor.convertToDefaultFormat(upcomingPerformanceDTO.endAt()),
+                upcomingPerformanceDTO.area()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.api.user.facade;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.facade.dto.response.UpcomingPerformanceDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoriteArtistDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoritePerformancesAllDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoritePerformancesDTO;
@@ -192,5 +193,13 @@ public class UserFavoriteFacade {
         if (!type.equalsIgnoreCase(PerformanceType.FESTIVAL.getType()) && !type.equalsIgnoreCase(PerformanceType.CONCERT.getType()) && !type.equalsIgnoreCase(TYPE_ALL)) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
+    }
+
+    @Transactional(readOnly = true)
+    public UpcomingPerformanceDTO getUpcomingPerformance(final long userId) {
+        validateExistUser(userId);
+
+        Performance performance = performanceService.getUpcomingPerformance(userId);
+        return UpcomingPerformanceDTO.from(performance);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UpcomingPerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UpcomingPerformanceDTO.java
@@ -1,0 +1,29 @@
+package org.sopt.confeti.api.user.facade.dto.response;
+
+import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+import java.time.LocalDate;
+
+public record  UpcomingPerformanceDTO(
+        long typeId,
+        PerformanceType type,
+        String title,
+        String posterPath,
+        LocalDate startAt,
+        LocalDate endAt,
+        String area
+) {
+    public static UpcomingPerformanceDTO from(Performance performance) {
+        return new UpcomingPerformanceDTO(
+                performance.getTypeId(),
+                performance.getType(),
+                performance.getTitle(),
+                performance.getPosterPath(),
+                performance.getStartAt(),
+                performance.getEndAt(),
+                performance.getArea()
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -89,4 +89,12 @@ public class PerformanceService {
 
         performance.addArtists(performanceArtists);
     }
+
+    @Transactional
+    public Performance getUpcomingPerformance(final Long userId){
+        return performanceRepository.upcomingPerformance(userId)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+                );
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -51,4 +51,14 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             @Param("userId") Long userId,
             @Param("type") String type
     );
+
+    @Query(value = "SELECT p FROM Performance p " +
+            "WHERE ((p.type = org.sopt.confeti.global.common.constant.PerformanceType.CONCERT " +
+            "        AND p.typeId IN (SELECT cf.concert.id FROM ConcertFavorite cf WHERE cf.user.id = :userId)) " +
+            "    OR (p.type = org.sopt.confeti.global.common.constant.PerformanceType.FESTIVAL " +
+            "        AND p.typeId IN (SELECT tf.festival.id FROM TimetableFestival tf WHERE tf.user.id = :userId))) " +
+            "AND p.endAt >= CURRENT_DATE " +
+            "ORDER BY p.startAt ASC LIMIT 1 ")
+    Optional<Performance> upcomingPerformance(final @Param("userId") long userId);
+
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #298

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x]  다가오는 공연 조회 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
다가오는 공연의 단일 항목 조회 API를 구현했습니다. 

<img width="883" alt="스크린샷 2025-04-17 오후 5 29 34" src="https://github.com/user-attachments/assets/d9528714-5b9a-4a37-96bf-9ddec12876f2" />

