### PR TITLE
feat [#302] 상위 아티스트 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -1,0 +1,33 @@
+package org.sopt.confeti.api.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.dto.response.UserOnboardTopArtistsResponse;
+import org.sopt.confeti.api.user.facade.UserOnboardFacade;
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/onboard")
+public class UserOnboardController {
+
+    private final UserOnboardFacade userOnboardFacade;
+
+    @Permission(role = {Role.ONBOARDING})
+    @GetMapping("/artists")
+    public ResponseEntity<BaseResponse<?>> getTopArtists(
+            @UserId Long userId
+    ) {
+        UserOnboardTopArtistsDTO topArtists = userOnboardFacade.getTopArtists();
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserOnboardTopArtistsResponse.from(topArtists));
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UserOnboardTopArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UserOnboardTopArtistResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.dto.response;
+
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistDTO;
+
+public record UserOnboardTopArtistResponse(
+        String artistId,
+        String profileUrl,
+        String name
+) {
+    public static UserOnboardTopArtistResponse from(UserOnboardTopArtistDTO topArtistDTO) {
+        return new UserOnboardTopArtistResponse(
+                topArtistDTO.id(),
+                topArtistDTO.profileUrl(),
+                topArtistDTO.name()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UserOnboardTopArtistsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UserOnboardTopArtistsResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.user.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+
+public record UserOnboardTopArtistsResponse(
+        List<UserOnboardTopArtistResponse> artists
+) {
+    public static UserOnboardTopArtistsResponse from(UserOnboardTopArtistsDTO topArtistsDTO) {
+        return new UserOnboardTopArtistsResponse(
+                topArtistsDTO.artists().stream()
+                        .map(UserOnboardTopArtistResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,0 +1,37 @@
+package org.sopt.confeti.api.user.facade;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusicArtist;
+import org.sopt.confeti.global.util.music.AppleMusicAPIHandler;
+
+@Facade
+@RequiredArgsConstructor
+public class UserOnboardFacade {
+
+    private static final int TOP_MUSICS_COUNT = 200;
+
+    private final AppleMusicAPIHandler appleMusicAPIHandler;
+
+    public UserOnboardTopArtistsDTO getTopArtists() {
+        List<ConfetiMusic> topMusics = appleMusicAPIHandler.getTopMusics(TOP_MUSICS_COUNT);
+        Set<String> topMusicIds = topMusics.stream()
+                .map(ConfetiMusic::getId)
+                .collect(Collectors.toSet());
+
+        List<ConfetiMusic> topMusicsWithArtists = appleMusicAPIHandler.getMusicsByMusicIds(topMusicIds);
+        Set<String> topArtistIds = topMusicsWithArtists.stream()
+                .flatMap(music -> music.getArtists().stream())
+                .map(ConfetiMusicArtist::getId)
+                .collect(Collectors.toSet());
+
+        List<ConfetiArtist> topArtists = appleMusicAPIHandler.getArtistsByArtistIds(topArtistIds);
+        return UserOnboardTopArtistsDTO.from(topArtists);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserOnboardTopArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserOnboardTopArtistDTO.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.facade.dto.response;
+
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardTopArtistDTO(
+        String id,
+        String profileUrl,
+        String name
+) {
+    public static UserOnboardTopArtistDTO from(ConfetiArtist artist) {
+        return new UserOnboardTopArtistDTO(
+                artist.getId(),
+                artist.getProfileUrl(),
+                artist.getName()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserOnboardTopArtistsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserOnboardTopArtistsDTO.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.user.facade.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardTopArtistsDTO(
+        List<UserOnboardTopArtistDTO> artists
+) {
+    public static UserOnboardTopArtistsDTO from(List<ConfetiArtist> artists) {
+        return new UserOnboardTopArtistsDTO(
+                artists.stream()
+                        .map(UserOnboardTopArtistDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusic.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusic.java
@@ -5,6 +5,7 @@ import jakarta.persistence.Embeddable;
 import jakarta.persistence.Transient;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -52,6 +53,14 @@ public class ConfetiMusic {
     }
 
     public static ConfetiMusic from(final AppleMusicMusicResponse music) {
+        List<ConfetiMusicArtist> artists = new ArrayList<>();
+
+        if (Objects.nonNull(music.relationships())) {
+            artists = music.relationships().artists().data().stream()
+                    .map(ConfetiMusicArtist::from)
+                    .toList();
+        }
+
         return new ConfetiMusic(
                 music.id(),
                 music.attributes().name(),
@@ -63,9 +72,7 @@ public class ConfetiMusic {
                         .findFirst()
                         .map(AppleMusicMusicPreviewResponse::url)
                         .orElse(null),
-                music.relationships().artists().data().stream()
-                        .map(ConfetiMusicArtist::from)
-                        .toList()
+                artists
         );
     }
 

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusic.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusic.java
@@ -3,6 +3,8 @@ package org.sopt.confeti.global.resolver.music_api.music.vo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Transient;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -38,6 +40,9 @@ public class ConfetiMusic {
     @Transient
     private String previewUrl;
 
+    @Transient
+    private List<ConfetiMusicArtist> artists = new ArrayList<>();
+
     private ConfetiMusic(String musicId) {
         this.id = musicId;
     }
@@ -57,7 +62,10 @@ public class ConfetiMusic {
                 music.attributes().previews().stream()
                         .findFirst()
                         .map(AppleMusicMusicPreviewResponse::url)
-                        .orElse(null)
+                        .orElse(null),
+                music.relationships().artists().data().stream()
+                        .map(ConfetiMusicArtist::from)
+                        .toList()
         );
     }
 

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusicArtist.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusicArtist.java
@@ -1,0 +1,21 @@
+package org.sopt.confeti.global.resolver.music_api.music.vo;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicArtistResponse;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConfetiMusicArtist {
+
+    private String id;
+
+    public static ConfetiMusicArtist from(final AppleMusicMusicArtistResponse artist) {
+        return new ConfetiMusicArtist(
+                artist.id()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -14,12 +14,17 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Handler;
 import org.sopt.confeti.global.annotation.RetryOnTokenExpire;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.module.rest_client.builder.ApiRestClientBuilder;
 import org.sopt.confeti.global.resolver.music_api.album.vo.ConfetiAlbum;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 import org.sopt.confeti.global.util.music.dto.album.AppleMusicAlbumsResponse;
 import org.sopt.confeti.global.util.music.dto.artist.AppleMusicArtistsResponse;
+import org.sopt.confeti.global.util.music.dto.chart.AppleMusicChartSongResponse;
+import org.sopt.confeti.global.util.music.dto.chart.AppleMusicChartsResponse;
+import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicResponse;
 import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicsResponse;
 import org.sopt.confeti.global.util.music.dto.search.AppleMusicSearchResponse;
 import org.springframework.http.HttpHeaders;
@@ -31,11 +36,13 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
 
     private static final String QUERY_PARAMETER_IDS_DELIMITER = ",";
     private static final String ARTISTS_TYPE = "artists";
+    private static final String SONGS_TYPE = "songs";
 
     // Fetch Limit 목록
     private static final int ARTISTS_FETCH_LIMIT = 25;
     private static final int ALBUMS_FETCH_LIMIT = 100;
     private static final int MUSICS_FETCH_LIMIT = 300;
+    private static final int CHARTS_FETCH_LIMIT = 200;
 
     private final AppleMusicAPITokenGenerator tokenGenerator;
     private final AppleMusicAPIURL appleMusicAPIURL;
@@ -220,5 +227,43 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         return musics.data().stream()
                 .map(ConfetiMusic::from)
                 .toList();
+    }
+
+    @Override
+    @RetryOnTokenExpire
+    public List<ConfetiMusic> getTopMusics(final int fetchSize) {
+        validateFetchSize(fetchSize);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("types", SONGS_TYPE);
+        params.put("limit", String.valueOf(fetchSize));
+
+        return convertToConfetiMusics(
+                restClient.request()
+                        .get()
+                        .baseUrl(appleMusicAPIURL.getBaseUrl())
+                        .path(appleMusicAPIURL.getChartsPath())
+                        .params(MultiValueMap.fromSingleValue(params))
+                        .build()
+                        .connect(headers)
+                        .retrieve(AppleMusicChartsResponse.class)
+        );
+    }
+
+    private List<ConfetiMusic> convertToConfetiMusics(final AppleMusicChartsResponse charts) {
+        List<AppleMusicMusicResponse> musics = charts.results().songs().stream()
+                .findFirst()
+                .map(AppleMusicChartSongResponse::data)
+                .orElseGet(List::of);
+
+        return musics.stream()
+                .map(ConfetiMusic::from)
+                .toList();
+    }
+
+    private void validateFetchSize(int fetchSize) {
+        if (fetchSize > CHARTS_FETCH_LIMIT) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIURL.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIURL.java
@@ -72,6 +72,9 @@ public class AppleMusicAPIURL {
     @Value("${apple-music.api.endpoints.search-path.suggestions}")
     private String searchPathSuggestions;
 
+    @Value("${apple-music.api.endpoints.charts-path.base}")
+    private String chartsPathBase;
+
 
     private String getArtistsBasePath() {
         return pathPrefix + artistsPathBase;
@@ -87,6 +90,10 @@ public class AppleMusicAPIURL {
 
     private String getSearchBasePath() {
         return pathPrefix + searchPathBase;
+    }
+
+    private String getChartsPathBase() {
+        return pathPrefix + chartsPathBase;
     }
 
     public String getSingleArtistPath(String id) {
@@ -159,5 +166,9 @@ public class AppleMusicAPIURL {
 
     public String getSearchSuggestionsPath() {
         return getSearchBasePath() + searchPathSuggestions;
+    }
+
+    public String getChartsPath() {
+        return getChartsPathBase();
     }
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -18,4 +18,6 @@ public interface MusicAPIHandler {
     List<ConfetiAlbum> getAlbumsByAlbumIds(final Set<String> albumIds);
 
     List<ConfetiMusic> getMusicsByMusicIds(final Set<String> musicIds);
+
+    List<ConfetiMusic> getTopMusics(final int fetchSize);
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.confeti.global.util.music.dto.chart;
+
+import java.util.List;
+
+public record AppleMusicChartResponse(
+        List<AppleMusicChartSongResponse> songs
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartSongResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartSongResponse.java
@@ -1,9 +1,9 @@
 package org.sopt.confeti.global.util.music.dto.chart;
 
 import java.util.List;
-import org.sopt.confeti.global.util.music.dto.song.AppleMusicSongResponse;
+import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicResponse;
 
 public record AppleMusicChartSongResponse(
-        List<AppleMusicSongResponse> data
+        List<AppleMusicMusicResponse> data
 ) {
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartSongResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartSongResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.global.util.music.dto.chart;
+
+import java.util.List;
+import org.sopt.confeti.global.util.music.dto.song.AppleMusicSongResponse;
+
+public record AppleMusicChartSongResponse(
+        List<AppleMusicSongResponse> data
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartsResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartsResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.confeti.global.util.music.dto.chart;
+
+public record AppleMusicChartsResponse(
+        AppleMusicChartResponse results
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicArtistResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.confeti.global.util.music.dto.music;
+
+public record AppleMusicMusicArtistResponse(
+        String id
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicArtistsResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicArtistsResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.confeti.global.util.music.dto.music;
+
+import java.util.List;
+
+public record AppleMusicMusicArtistsResponse(
+        List<AppleMusicMusicArtistResponse> data
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicRelationshipsResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicRelationshipsResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.confeti.global.util.music.dto.music;
+
+public record AppleMusicMusicRelationshipsResponse(
+        AppleMusicMusicArtistsResponse artists
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicResponse.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.global.util.music.dto.music;
 public record AppleMusicMusicResponse(
         String id,
         String type,
-        AppleMusicMusicAttributesResponse attributes
+        AppleMusicMusicAttributesResponse attributes,
+        AppleMusicMusicRelationshipsResponse relationships
 ) {
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #302 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 애플 뮤직 API의 charts 항목 연결
- [x] 음악 인기 목록 가져온 후 아티스트 중복 제거

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/3c53240e-4abf-4000-830f-fe6d6671f4cf" />

아티스트 약 100개가 조회됩니다.

Apple Music API에는 상위권 아티스트를 조회하는 기능을 제공하지 않았어요.
그래서 우회하는 방법을 선택했습니다!

우회해서 가져오는 방법은 다음과 같이 구성했어요.
1. 상위 200 개의 인기 음악 목록 조회
2. 다수의 음악 아이디로 음악 정보 조회 (아티스트 정보를 여기서 제공합니다)
3. 다수의 아티스트 아이디로 아티스트 정보 조회

차트 가져오는 기능을 추가하고 기존에 구현했던 음악 응답 구조에 음악과 관련한 아티스트 정보를 추가했습니다!
