### PR TITLE
feat [#306] 아티스트 연관 검색어 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.api.artist.facade;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.artist.facade.dto.response.SearchArtistDTO;
@@ -13,12 +14,15 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class ArtistFacade {
 
+    private static final int ARTISTS_SEARCH_COUNT = 5;
+
     private final ArtistFavoriteService artistFavoriteService;
     private final MusicAPIHandler musicAPIHandler;
 
     @Transactional(readOnly = true)
     public SearchArtistDTO searchByKeyword(final Long userId, final String keyword) {
-        Optional<ConfetiArtist> confetiArtist = musicAPIHandler.findArtistByKeyword(keyword);
+        List<ConfetiArtist> confetiArtists = musicAPIHandler.findArtistByKeyword(keyword, ARTISTS_SEARCH_COUNT);
+        Optional<ConfetiArtist> confetiArtist = confetiArtists.stream().findFirst();
 
         boolean isFavorite = false;
 

--- a/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
@@ -21,7 +21,7 @@ public class ArtistFacade {
 
     @Transactional(readOnly = true)
     public SearchArtistDTO searchByKeyword(final Long userId, final String keyword) {
-        List<ConfetiArtist> confetiArtists = musicAPIHandler.findArtistByKeyword(keyword, ARTISTS_SEARCH_COUNT);
+        List<ConfetiArtist> confetiArtists = musicAPIHandler.findArtistsByKeyword(keyword, ARTISTS_SEARCH_COUNT);
         Optional<ConfetiArtist> confetiArtist = confetiArtists.stream().findFirst();
 
         boolean isFavorite = false;

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
@@ -13,14 +13,19 @@ import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
-import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.common.constant.RequestConstraint;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -112,10 +117,11 @@ public class UserFavoriteController {
     @Permission(role = {Role.GENERAL})
     @GetMapping("/performances")
     public ResponseEntity<BaseResponse<?>> getFavoritePerformancesAll(
-            @RequestParam (value = "type") String type,
+            @RequestParam(value = "type") String type,
             @UserId Long userId
     ) {
-        UserFavoritePerformancesAllDTO userFavoritePerformancesAllDTO = userFavoriteFacade.getFavoritePerformancesAll(userId, type);
+        UserFavoritePerformancesAllDTO userFavoritePerformancesAllDTO = userFavoriteFacade.getFavoritePerformancesAll(
+                userId, type);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 UserFavoritePerformancesAllResponse.of(userFavoritePerformancesAllDTO, s3FileHandler));
     }

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -1,5 +1,7 @@
 package org.sopt.confeti.api.user.controller;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.dto.response.UserOnboardTopArtistsResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardRelatedArtistsResponse;
@@ -15,6 +17,7 @@ import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -24,6 +27,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user/onboard")
+@Validated
 public class UserOnboardController {
 
     private final UserOnboardFacade userOnboardFacade;
@@ -33,7 +37,7 @@ public class UserOnboardController {
     public ResponseEntity<BaseResponse<?>> getArtistsRelatedTerm(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
             @RequestParam String term,
-            @RequestParam(defaultValue = "1") Integer limit
+            @RequestParam(defaultValue = "1") @Min(1) @Max(25) Integer limit
     ) {
         UserOnboardRelatedArtistsDTO relatedArtistsDTO = userOnboardFacade.getArtistsRelatedTerm(term, limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -1,5 +1,7 @@
 package org.sopt.confeti.api.user.controller;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardRelatedArtistsResponse;
 import org.sopt.confeti.api.user.facade.UserOnboardFacade;
@@ -11,6 +13,7 @@ import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -20,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("/user/onboard")
+@Validated
 public class UserOnboardController {
 
     private final UserOnboardFacade userOnboardFacade;
@@ -29,7 +33,7 @@ public class UserOnboardController {
     public ResponseEntity<BaseResponse<?>> getArtistsRelatedTerm(
             @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
             @RequestParam String term,
-            @RequestParam(defaultValue = "1") Integer limit
+            @RequestParam(defaultValue = "1") @Min(1) @Max(25) Integer limit
     ) {
         UserOnboardRelatedArtistsDTO relatedArtistsDTO = userOnboardFacade.getArtistsRelatedTerm(term, limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -2,17 +2,23 @@ package org.sopt.confeti.api.user.controller;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.dto.response.UserOnboardTopArtistsResponse;
+import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardRelatedArtistsResponse;
 import org.sopt.confeti.api.user.facade.UserOnboardFacade;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
@@ -21,6 +27,18 @@ import org.springframework.web.bind.annotation.RestController;
 public class UserOnboardController {
 
     private final UserOnboardFacade userOnboardFacade;
+
+    @Permission(role = {Role.ONBOARDING})
+    @GetMapping("/artists/search")
+    public ResponseEntity<BaseResponse<?>> getArtistsRelatedTerm(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
+            @RequestParam String term,
+            @RequestParam(defaultValue = "1") Integer limit
+    ) {
+        UserOnboardRelatedArtistsDTO relatedArtistsDTO = userOnboardFacade.getArtistsRelatedTerm(term, limit);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                UserOnboardRelatedArtistsResponse.from(relatedArtistsDTO));
+    }
 
     @Permission(role = {Role.ONBOARDING})
     @GetMapping("/artists")

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -1,0 +1,33 @@
+package org.sopt.confeti.api.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.dto.response.UserOnboardTopArtistsResponse;
+import org.sopt.confeti.api.user.facade.UserOnboardFacade;
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/onboard")
+public class UserOnboardController {
+
+    private final UserOnboardFacade userOnboardFacade;
+
+    @Permission(role = {Role.ONBOARDING})
+    @GetMapping("/artists")
+    public ResponseEntity<BaseResponse<?>> getTopArtists(
+            @UserId Long userId
+    ) {
+        UserOnboardTopArtistsDTO topArtists = userOnboardFacade.getTopArtists();
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserOnboardTopArtistsResponse.from(topArtists));
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -1,0 +1,38 @@
+package org.sopt.confeti.api.user.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardRelatedArtistsResponse;
+import org.sopt.confeti.api.user.facade.UserOnboardFacade;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/onboard")
+public class UserOnboardController {
+
+    private final UserOnboardFacade userOnboardFacade;
+
+    @Permission(role = {Role.ONBOARDING})
+    @GetMapping("/artists/search")
+    public ResponseEntity<BaseResponse<?>> getArtistsRelatedTerm(
+            @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
+            @RequestParam String term,
+            @RequestParam(defaultValue = "1") Integer limit
+    ) {
+        UserOnboardRelatedArtistsDTO relatedArtistsDTO = userOnboardFacade.getArtistsRelatedTerm(term, limit);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                UserOnboardRelatedArtistsResponse.from(relatedArtistsDTO));
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -8,14 +8,13 @@ import org.sopt.confeti.api.user.facade.UserOnboardFacade;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -31,7 +30,7 @@ public class UserOnboardController {
     @Permission(role = {Role.ONBOARDING})
     @GetMapping("/artists/search")
     public ResponseEntity<BaseResponse<?>> getArtistsRelatedTerm(
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
+            @UserId Long userId,
             @RequestParam String term,
             @RequestParam(defaultValue = "1") @Min(1) @Max(25) Integer limit
     ) {

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -12,14 +12,13 @@ import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -35,7 +34,7 @@ public class UserOnboardController {
     @Permission(role = {Role.ONBOARDING})
     @GetMapping("/artists/search")
     public ResponseEntity<BaseResponse<?>> getArtistsRelatedTerm(
-            @RequestHeader(HttpHeaders.AUTHORIZATION) String accessToken,
+            @UserId Long userId,
             @RequestParam String term,
             @RequestParam(defaultValue = "1") @Min(1) @Max(25) Integer limit
     ) {

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UserFavoritePerformanceAllResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UserFavoritePerformanceAllResponse.java
@@ -1,13 +1,12 @@
 package org.sopt.confeti.api.user.dto.response;
 
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoritePerformanceAllDTO;
-
 import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.common.constant.PerformanceType;
-import org.sopt.confeti.global.util. DateConvertor;
+import org.sopt.confeti.global.util.DateConvertor;
 import org.sopt.confeti.global.util.S3FileHandler;
 
-public record UserFavoritePerformanceAllResponse (
+public record UserFavoritePerformanceAllResponse(
         long typeId,
         PerformanceType type,
         String title,
@@ -16,7 +15,7 @@ public record UserFavoritePerformanceAllResponse (
         String endAt,
         String area,
         boolean isFavorite
-){
+) {
     public static UserFavoritePerformanceAllResponse of(
             final UserFavoritePerformanceAllDTO userFavoritePerformanceAllDTO, final S3FileHandler s3FileHandler) {
         FolderPath topFolder = FolderPath.getFolderPathByPerformanceType(userFavoritePerformanceAllDTO.type());
@@ -25,7 +24,8 @@ public record UserFavoritePerformanceAllResponse (
                 userFavoritePerformanceAllDTO.typeId(),
                 userFavoritePerformanceAllDTO.type(),
                 userFavoritePerformanceAllDTO.title(),
-                s3FileHandler.getFileUrl(FolderPath.combine(topFolder, FolderPath.POSTER), userFavoritePerformanceAllDTO.posterPath())
+                s3FileHandler.getFileUrl(FolderPath.combine(topFolder, FolderPath.POSTER),
+                                userFavoritePerformanceAllDTO.posterPath())
                         .toString(),
                 DateConvertor.convertToDefaultFormat(userFavoritePerformanceAllDTO.startAt()),
                 DateConvertor.convertToDefaultFormat(userFavoritePerformanceAllDTO.endAt()),

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UserFavoritePerformancesAllResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UserFavoritePerformancesAllResponse.java
@@ -1,14 +1,13 @@
 package org.sopt.confeti.api.user.dto.response;
 
+import java.util.List;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoritePerformancesAllDTO;
 import org.sopt.confeti.global.util.S3FileHandler;
 
-import java.util.List;
-
 public record UserFavoritePerformancesAllResponse(
         List<UserFavoritePerformanceAllResponse> performances) {
-        public static UserFavoritePerformancesAllResponse of (
-                final UserFavoritePerformancesAllDTO performancesDTO, final S3FileHandler s3FileHandler){
+    public static UserFavoritePerformancesAllResponse of(
+            final UserFavoritePerformancesAllDTO performancesDTO, final S3FileHandler s3FileHandler) {
         return new UserFavoritePerformancesAllResponse(
                 performancesDTO.performances().stream()
                         .map(userFavoritePerformanceAllDTO ->

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UserOnboardTopArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UserOnboardTopArtistResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.dto.response;
+
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistDTO;
+
+public record UserOnboardTopArtistResponse(
+        String artistId,
+        String profileUrl,
+        String name
+) {
+    public static UserOnboardTopArtistResponse from(UserOnboardTopArtistDTO topArtistDTO) {
+        return new UserOnboardTopArtistResponse(
+                topArtistDTO.id(),
+                topArtistDTO.profileUrl(),
+                topArtistDTO.name()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/UserOnboardTopArtistsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/UserOnboardTopArtistsResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.user.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+
+public record UserOnboardTopArtistsResponse(
+        List<UserOnboardTopArtistResponse> artists
+) {
+    public static UserOnboardTopArtistsResponse from(UserOnboardTopArtistsDTO topArtistsDTO) {
+        return new UserOnboardTopArtistsResponse(
+                topArtistsDTO.artists().stream()
+                        .map(UserOnboardTopArtistResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardRelatedArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardRelatedArtistResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.dto.response.onboard;
+
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistDTO;
+
+public record UserOnboardRelatedArtistResponse(
+        String artistId,
+        String profileUrl,
+        String name
+) {
+    public static UserOnboardRelatedArtistResponse from(UserOnboardRelatedArtistDTO relatedArtistDTO) {
+        return new UserOnboardRelatedArtistResponse(
+                relatedArtistDTO.artistId(),
+                relatedArtistDTO.profileUrl(),
+                relatedArtistDTO.name()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardRelatedArtistsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardRelatedArtistsResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.user.dto.response.onboard;
+
+import java.util.List;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
+
+public record UserOnboardRelatedArtistsResponse(
+        List<UserOnboardRelatedArtistResponse> artists
+) {
+    public static UserOnboardRelatedArtistsResponse from(UserOnboardRelatedArtistsDTO relatedArtistsDTO) {
+        return new UserOnboardRelatedArtistsResponse(
+                relatedArtistsDTO.artists().stream()
+                        .map(UserOnboardRelatedArtistResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -189,7 +189,8 @@ public class UserFavoriteFacade {
 
     @Transactional(readOnly = true)
     protected void validateType(final String type) {
-        if (!type.equalsIgnoreCase(PerformanceType.FESTIVAL.getType()) && !type.equalsIgnoreCase(PerformanceType.CONCERT.getType()) && !type.equalsIgnoreCase(TYPE_ALL)) {
+        if (!type.equalsIgnoreCase(PerformanceType.FESTIVAL.getType()) && !type.equalsIgnoreCase(
+                PerformanceType.CONCERT.getType()) && !type.equalsIgnoreCase(TYPE_ALL)) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
     }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,0 +1,37 @@
+package org.sopt.confeti.api.user.facade;
+
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusicArtist;
+import org.sopt.confeti.global.util.music.AppleMusicAPIHandler;
+
+@Facade
+@RequiredArgsConstructor
+public class UserOnboardFacade {
+
+    private static final int TOP_MUSICS_COUNT = 200;
+
+    private final AppleMusicAPIHandler appleMusicAPIHandler;
+
+    public UserOnboardTopArtistsDTO getTopArtists() {
+        List<ConfetiMusic> topMusics = appleMusicAPIHandler.getTopMusics(TOP_MUSICS_COUNT);
+        Set<String> topMusicIds = topMusics.stream()
+                .map(ConfetiMusic::getId)
+                .collect(Collectors.toSet());
+
+        List<ConfetiMusic> topMusicsWithArtists = appleMusicAPIHandler.getMusicsByMusicIds(topMusicIds);
+        Set<String> topArtistIds = topMusicsWithArtists.stream()
+                .flatMap(music -> music.getArtists().stream())
+                .map(ConfetiMusicArtist::getId)
+                .collect(Collectors.toSet());
+
+        List<ConfetiArtist> topArtists = appleMusicAPIHandler.getArtistsByArtistIds(topArtistIds);
+        return UserOnboardTopArtistsDTO.from(topArtists);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -3,20 +3,13 @@ package org.sopt.confeti.api.user.facade;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
-import java.util.List;
-import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
-import org.sopt.confeti.global.util.music.MusicAPIHandler;
-import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
-import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusicArtist;
-import org.sopt.confeti.global.util.music.AppleMusicAPIHandler;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
 
 @Facade

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
+import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
+
+@Facade
+@RequiredArgsConstructor
+public class UserOnboardFacade {
+
+    private final MusicAPIHandler musicAPIHandler;
+
+    public UserOnboardRelatedArtistsDTO getArtistsRelatedTerm(String term, int limit) {
+        return UserOnboardRelatedArtistsDTO.from(musicAPIHandler.findArtistsByKeyword(term, limit));
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -3,13 +3,21 @@ package org.sopt.confeti.api.user.facade;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
 import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusicArtist;
 import org.sopt.confeti.global.util.music.AppleMusicAPIHandler;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
 
 @Facade
 @RequiredArgsConstructor
@@ -17,21 +25,25 @@ public class UserOnboardFacade {
 
     private static final int TOP_MUSICS_COUNT = 200;
 
-    private final AppleMusicAPIHandler appleMusicAPIHandler;
+    private final MusicAPIHandler musicAPIHandler;
+
+    public UserOnboardRelatedArtistsDTO getArtistsRelatedTerm(String term, int limit) {
+        return UserOnboardRelatedArtistsDTO.from(musicAPIHandler.findArtistsByKeyword(term, limit));
+    }
 
     public UserOnboardTopArtistsDTO getTopArtists() {
-        List<ConfetiMusic> topMusics = appleMusicAPIHandler.getTopMusics(TOP_MUSICS_COUNT);
+        List<ConfetiMusic> topMusics = musicAPIHandler.getTopMusics(TOP_MUSICS_COUNT);
         Set<String> topMusicIds = topMusics.stream()
                 .map(ConfetiMusic::getId)
                 .collect(Collectors.toSet());
 
-        List<ConfetiMusic> topMusicsWithArtists = appleMusicAPIHandler.getMusicsByMusicIds(topMusicIds);
+        List<ConfetiMusic> topMusicsWithArtists = musicAPIHandler.getMusicsByMusicIds(topMusicIds);
         Set<String> topArtistIds = topMusicsWithArtists.stream()
                 .flatMap(music -> music.getArtists().stream())
                 .map(ConfetiMusicArtist::getId)
                 .collect(Collectors.toSet());
 
-        List<ConfetiArtist> topArtists = appleMusicAPIHandler.getArtistsByArtistIds(topArtistIds);
+        List<ConfetiArtist> topArtists = musicAPIHandler.getArtistsByArtistIds(topArtistIds);
         return UserOnboardTopArtistsDTO.from(topArtists);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformanceAllDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformanceAllDTO.java
@@ -1,8 +1,8 @@
 package org.sopt.confeti.api.user.facade.dto.response;
 
+import java.time.LocalDate;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.global.common.constant.PerformanceType;
-import java.time.LocalDate;
 
 public record UserFavoritePerformanceAllDTO(
         long typeId,
@@ -12,7 +12,7 @@ public record UserFavoritePerformanceAllDTO(
         LocalDate startAt,
         LocalDate endAt,
         String area
-        ) {
+) {
     public static UserFavoritePerformanceAllDTO from(Performance performance) {
         return new UserFavoritePerformanceAllDTO(
                 performance.getTypeId(),

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformancesAllDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformancesAllDTO.java
@@ -1,8 +1,7 @@
 package org.sopt.confeti.api.user.facade.dto.response;
 
-import org.sopt.confeti.domain.view.performance.Performance;
-
 import java.util.List;
+import org.sopt.confeti.domain.view.performance.Performance;
 
 public record UserFavoritePerformancesAllDTO(
         List<UserFavoritePerformanceAllDTO> performances

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserOnboardTopArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserOnboardTopArtistDTO.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.facade.dto.response;
+
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardTopArtistDTO(
+        String id,
+        String profileUrl,
+        String name
+) {
+    public static UserOnboardTopArtistDTO from(ConfetiArtist artist) {
+        return new UserOnboardTopArtistDTO(
+                artist.getId(),
+                artist.getProfileUrl(),
+                artist.getName()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserOnboardTopArtistsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserOnboardTopArtistsDTO.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.user.facade.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardTopArtistsDTO(
+        List<UserOnboardTopArtistDTO> artists
+) {
+    public static UserOnboardTopArtistsDTO from(List<ConfetiArtist> artists) {
+        return new UserOnboardTopArtistsDTO(
+                artists.stream()
+                        .map(UserOnboardTopArtistDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardRelatedArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardRelatedArtistDTO.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.facade.dto.response.onboard;
+
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardRelatedArtistDTO(
+        String artistId,
+        String profileUrl,
+        String name
+) {
+    public static UserOnboardRelatedArtistDTO from(ConfetiArtist artist) {
+        return new UserOnboardRelatedArtistDTO(
+                artist.getId(),
+                artist.getProfileUrl(),
+                artist.getName()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardRelatedArtistsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardRelatedArtistsDTO.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.user.facade.dto.response.onboard;
+
+import java.util.List;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardRelatedArtistsDTO(
+        List<UserOnboardRelatedArtistDTO> artists
+) {
+    public static UserOnboardRelatedArtistsDTO from(List<ConfetiArtist> artists) {
+        return new UserOnboardRelatedArtistsDTO(
+                artists.stream()
+                        .map(UserOnboardRelatedArtistDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
@@ -127,7 +127,7 @@ public class Performance {
                 )
                 .build();
     }
-    
+
     public void addArtists(List<PerformanceArtist> artists) {
         this.artists.addAll(artists);
         artists.forEach(artist -> artist.setPerformance(this));

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -2,7 +2,10 @@ package org.sopt.confeti.domain.view.performance.application;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.domain.view.performance.*;
+import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.domain.view.performance.PerformanceArtist;
+import org.sopt.confeti.domain.view.performance.PerformanceDTO;
+import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceDTORepository;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceRepository;
 import org.sopt.confeti.global.common.constant.PerformanceType;

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -41,9 +41,11 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     Optional<Performance> findPerformancesByTypeAndTypeId(PerformanceType type, long typeId);
 
     @Query("SELECT p FROM Performance p " +
-            "WHERE ((:type = '" + TYPE_CONCERT + "' OR :type = '" + TYPE_ALL + "') AND p.type = org.sopt.confeti.global.common.constant.PerformanceType.CONCERT " +
+            "WHERE ((:type = '" + TYPE_CONCERT + "' OR :type = '" + TYPE_ALL
+            + "') AND p.type = org.sopt.confeti.global.common.constant.PerformanceType.CONCERT " +
             "       AND p.typeId IN (SELECT cf.concert.id FROM ConcertFavorite cf WHERE cf.user.id = :userId)) " +
-            "OR ((:type = '" + TYPE_FESTIVAL + "' OR :type = '" + TYPE_ALL + "') AND p.type = org.sopt.confeti.global.common.constant.PerformanceType.FESTIVAL " +
+            "OR ((:type = '" + TYPE_FESTIVAL + "' OR :type = '" + TYPE_ALL
+            + "') AND p.type = org.sopt.confeti.global.common.constant.PerformanceType.FESTIVAL " +
             "    AND p.typeId IN (SELECT ff.festival.id FROM FestivalFavorite ff WHERE ff.user.id = :userId)) " +
             "AND p.endAt >= CURRENT_DATE " +
             "ORDER BY p.startAt ASC")

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.global.resolver.music_api.artist.vo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Transient;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -41,18 +42,27 @@ public class ConfetiArtist {
     }
 
     public static ConfetiArtist from(final AppleMusicArtistResponse artist) {
-        Optional<AppleMusicArtistAlbumResponse> album = artist
-                .relationships()
-                .albums()
-                .data()
-                .stream().findFirst();
+        Optional<AppleMusicArtistAlbumResponse> album = Optional.empty();
+
+        if (Objects.nonNull(artist.relationships())) {
+            album = artist.relationships()
+                    .albums()
+                    .data()
+                    .stream().findFirst();
+        }
+
+        String profileUrl = null;
+
+        if (Objects.nonNull(artist.attributes().artwork())) {
+            profileUrl = UriComponentsBuilder.fromUriString(artist.attributes().artwork().url())
+                    .buildAndExpand(ArtistConstant.PROFILE_IMG_SIZE)
+                    .toUriString();
+        }
 
         return new ConfetiArtist(
                 artist.id(),
                 artist.attributes().name(),
-                UriComponentsBuilder.fromUriString(artist.attributes().artwork().url())
-                        .buildAndExpand(ArtistConstant.PROFILE_IMG_SIZE)
-                        .toUriString(),
+                profileUrl,
                 album.map(ConfetiAlbum::from).orElse(null)
         );
     }

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusic.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusic.java
@@ -3,6 +3,9 @@ package org.sopt.confeti.global.resolver.music_api.music.vo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Transient;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -38,6 +41,9 @@ public class ConfetiMusic {
     @Transient
     private String previewUrl;
 
+    @Transient
+    private List<ConfetiMusicArtist> artists = new ArrayList<>();
+
     private ConfetiMusic(String musicId) {
         this.id = musicId;
     }
@@ -47,6 +53,14 @@ public class ConfetiMusic {
     }
 
     public static ConfetiMusic from(final AppleMusicMusicResponse music) {
+        List<ConfetiMusicArtist> artists = new ArrayList<>();
+
+        if (Objects.nonNull(music.relationships())) {
+            artists = music.relationships().artists().data().stream()
+                    .map(ConfetiMusicArtist::from)
+                    .toList();
+        }
+
         return new ConfetiMusic(
                 music.id(),
                 music.attributes().name(),
@@ -57,7 +71,8 @@ public class ConfetiMusic {
                 music.attributes().previews().stream()
                         .findFirst()
                         .map(AppleMusicMusicPreviewResponse::url)
-                        .orElse(null)
+                        .orElse(null),
+                artists
         );
     }
 

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusicArtist.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusicArtist.java
@@ -1,0 +1,21 @@
+package org.sopt.confeti.global.resolver.music_api.music.vo;
+
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicArtistResponse;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+public class ConfetiMusicArtist {
+
+    private String id;
+
+    public static ConfetiMusicArtist from(final AppleMusicMusicArtistResponse artist) {
+        return new ConfetiMusicArtist(
+                artist.id()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -99,11 +99,12 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
 
     @Override
     @RetryOnTokenExpire
-    public List<ConfetiArtist> findArtistByKeyword(final String keyword, final int limit) {
+    public List<ConfetiArtist> findArtistsByKeyword(final String keyword, final int limit) {
         Map<String, String> params = new HashMap<>();
         params.put("term", keyword);
         params.put("types", ARTISTS_TYPE);
         params.put("limit", String.valueOf(limit));
+        params.put("with", "topResults");
 
         return convertToConfetiArtists(
                 restClient.request()

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -14,12 +14,17 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.annotation.Handler;
 import org.sopt.confeti.global.annotation.RetryOnTokenExpire;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.module.rest_client.builder.ApiRestClientBuilder;
 import org.sopt.confeti.global.resolver.music_api.album.vo.ConfetiAlbum;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 import org.sopt.confeti.global.util.music.dto.album.AppleMusicAlbumsResponse;
 import org.sopt.confeti.global.util.music.dto.artist.AppleMusicArtistsResponse;
+import org.sopt.confeti.global.util.music.dto.chart.AppleMusicChartSongResponse;
+import org.sopt.confeti.global.util.music.dto.chart.AppleMusicChartsResponse;
+import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicResponse;
 import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicsResponse;
 import org.sopt.confeti.global.util.music.dto.search.AppleMusicSearchResponse;
 import org.springframework.http.HttpHeaders;
@@ -31,11 +36,13 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
 
     private static final String QUERY_PARAMETER_IDS_DELIMITER = ",";
     private static final String ARTISTS_TYPE = "artists";
+    private static final String SONGS_TYPE = "songs";
 
     // Fetch Limit 목록
     private static final int ARTISTS_FETCH_LIMIT = 25;
     private static final int ALBUMS_FETCH_LIMIT = 100;
     private static final int MUSICS_FETCH_LIMIT = 300;
+    private static final int CHARTS_FETCH_LIMIT = 200;
 
     private final AppleMusicAPITokenGenerator tokenGenerator;
     private final AppleMusicAPIURL appleMusicAPIURL;
@@ -220,5 +227,43 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         return musics.data().stream()
                 .map(ConfetiMusic::from)
                 .toList();
+    }
+
+    @Override
+    @RetryOnTokenExpire
+    public List<ConfetiMusic> getTopMusics(final int fetchSize) {
+        validateFetchSize(fetchSize);
+
+        Map<String, String> params = new HashMap<>();
+        params.put("types", SONGS_TYPE);
+        params.put("limit", String.valueOf(fetchSize));
+
+        return convertToConfetiMusics(
+                restClient.request()
+                        .get()
+                        .baseUrl(appleMusicAPIURL.getBaseUrl())
+                        .path(appleMusicAPIURL.getChartsPath())
+                        .params(MultiValueMap.fromSingleValue(params))
+                        .build()
+                        .connect(headers)
+                        .retrieve(AppleMusicChartsResponse.class)
+        );
+    }
+
+    private List<ConfetiMusic> convertToConfetiMusics(final AppleMusicChartsResponse charts) {
+        List<AppleMusicMusicResponse> musics = charts.results().songs().stream()
+                .findFirst()
+                .map(AppleMusicChartSongResponse::data)
+                .orElseGet(List::of);
+
+        return musics.stream()
+                .map(ConfetiMusic::from)
+                .toList();
+    }
+
+    private void validateFetchSize(int fetchSize) {
+        if (fetchSize > CHARTS_FETCH_LIMIT) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -92,12 +92,13 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
 
     @Override
     @RetryOnTokenExpire
-    public Optional<ConfetiArtist> findArtistByKeyword(final String keyword) {
+    public List<ConfetiArtist> findArtistByKeyword(final String keyword, final int limit) {
         Map<String, String> params = new HashMap<>();
         params.put("term", keyword);
         params.put("types", ARTISTS_TYPE);
+        params.put("limit", String.valueOf(limit));
 
-        return convertToConfetiArtist(
+        return convertToConfetiArtists(
                 restClient.request()
                         .get()
                         .baseUrl(appleMusicAPIURL.getBaseUrl())
@@ -129,8 +130,8 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                 .toList();
     }
 
-    private Optional<ConfetiArtist> convertToConfetiArtist(final AppleMusicSearchResponse searchResult) {
-        return convertToConfetiArtist(searchResult.results().artists());
+    private List<ConfetiArtist> convertToConfetiArtists(final AppleMusicSearchResponse searchResult) {
+        return convertToConfetiArtists(searchResult.results().artists());
     }
 
     private Optional<ConfetiArtist> convertToConfetiArtist(final AppleMusicArtistsResponse artists) {

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -92,11 +92,12 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
 
     @Override
     @RetryOnTokenExpire
-    public List<ConfetiArtist> findArtistByKeyword(final String keyword, final int limit) {
+    public List<ConfetiArtist> findArtistsByKeyword(final String keyword, final int limit) {
         Map<String, String> params = new HashMap<>();
         params.put("term", keyword);
         params.put("types", ARTISTS_TYPE);
         params.put("limit", String.valueOf(limit));
+        params.put("with", "topResults");
 
         return convertToConfetiArtists(
                 restClient.request()

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -99,12 +99,13 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
 
     @Override
     @RetryOnTokenExpire
-    public Optional<ConfetiArtist> findArtistByKeyword(final String keyword) {
+    public List<ConfetiArtist> findArtistByKeyword(final String keyword, final int limit) {
         Map<String, String> params = new HashMap<>();
         params.put("term", keyword);
         params.put("types", ARTISTS_TYPE);
+        params.put("limit", String.valueOf(limit));
 
-        return convertToConfetiArtist(
+        return convertToConfetiArtists(
                 restClient.request()
                         .get()
                         .baseUrl(appleMusicAPIURL.getBaseUrl())
@@ -136,8 +137,8 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                 .toList();
     }
 
-    private Optional<ConfetiArtist> convertToConfetiArtist(final AppleMusicSearchResponse searchResult) {
-        return convertToConfetiArtist(searchResult.results().artists());
+    private List<ConfetiArtist> convertToConfetiArtists(final AppleMusicSearchResponse searchResult) {
+        return convertToConfetiArtists(searchResult.results().artists());
     }
 
     private Optional<ConfetiArtist> convertToConfetiArtist(final AppleMusicArtistsResponse artists) {

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIURL.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIURL.java
@@ -72,6 +72,9 @@ public class AppleMusicAPIURL {
     @Value("${apple-music.api.endpoints.search-path.suggestions}")
     private String searchPathSuggestions;
 
+    @Value("${apple-music.api.endpoints.charts-path.base}")
+    private String chartsPathBase;
+
 
     private String getArtistsBasePath() {
         return pathPrefix + artistsPathBase;
@@ -87,6 +90,10 @@ public class AppleMusicAPIURL {
 
     private String getSearchBasePath() {
         return pathPrefix + searchPathBase;
+    }
+
+    private String getChartsPathBase() {
+        return pathPrefix + chartsPathBase;
     }
 
     public String getSingleArtistPath(String id) {
@@ -159,5 +166,9 @@ public class AppleMusicAPIURL {
 
     public String getSearchSuggestionsPath() {
         return getSearchBasePath() + searchPathSuggestions;
+    }
+
+    public String getChartsPath() {
+        return getChartsPathBase();
     }
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -11,7 +11,7 @@ public interface MusicAPIHandler {
 
     List<ConfetiArtist> getArtistsByArtistIds(final Set<String> artistIds);
 
-    Optional<ConfetiArtist> findArtistByKeyword(final String keyword);
+    List<ConfetiArtist> findArtistByKeyword(final String keyword, final int limit);
 
     Optional<ConfetiArtist> findArtistByArtistId(final String artistId);
 

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -11,7 +11,7 @@ public interface MusicAPIHandler {
 
     List<ConfetiArtist> getArtistsByArtistIds(final Set<String> artistIds);
 
-    List<ConfetiArtist> findArtistByKeyword(final String keyword, final int limit);
+    List<ConfetiArtist> findArtistsByKeyword(final String keyword, final int limit);
 
     Optional<ConfetiArtist> findArtistByArtistId(final String artistId);
 

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -18,4 +18,6 @@ public interface MusicAPIHandler {
     List<ConfetiAlbum> getAlbumsByAlbumIds(final Set<String> albumIds);
 
     List<ConfetiMusic> getMusicsByMusicIds(final Set<String> musicIds);
+
+    List<ConfetiMusic> getTopMusics(final int fetchSize);
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.confeti.global.util.music.dto.chart;
+
+import java.util.List;
+
+public record AppleMusicChartResponse(
+        List<AppleMusicChartSongResponse> songs
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartSongResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartSongResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.global.util.music.dto.chart;
+
+import java.util.List;
+import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicResponse;
+
+public record AppleMusicChartSongResponse(
+        List<AppleMusicMusicResponse> data
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartsResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/chart/AppleMusicChartsResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.confeti.global.util.music.dto.chart;
+
+public record AppleMusicChartsResponse(
+        AppleMusicChartResponse results
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicArtistResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.confeti.global.util.music.dto.music;
+
+public record AppleMusicMusicArtistResponse(
+        String id
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicArtistsResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicArtistsResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.confeti.global.util.music.dto.music;
+
+import java.util.List;
+
+public record AppleMusicMusicArtistsResponse(
+        List<AppleMusicMusicArtistResponse> data
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicRelationshipsResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicRelationshipsResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.confeti.global.util.music.dto.music;
+
+public record AppleMusicMusicRelationshipsResponse(
+        AppleMusicMusicArtistsResponse artists
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicResponse.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.global.util.music.dto.music;
 public record AppleMusicMusicResponse(
         String id,
         String type,
-        AppleMusicMusicAttributesResponse attributes
+        AppleMusicMusicAttributesResponse attributes,
+        AppleMusicMusicRelationshipsResponse relationships
 ) {
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #306 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 아티스트 연관 검색어 목록 조회 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1060" alt="image" src="https://github.com/user-attachments/assets/93c331bd-5a09-4859-8665-017677b99d61" />

Apple Music API의 응답 값이 불안정한걸 확인했어요. 특정 아티스트는 프로필 이미지가 없어서 null로 처리해두었습니다!
