### PR TITLE
feat [#304] 프로필 편집 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserInfoController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserInfoController.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.api.user.controller;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.dto.request.PatchUserInfoRequest;
 import org.sopt.confeti.api.user.dto.response.UserInfoResponse;
 import org.sopt.confeti.api.user.facade.UserInfoFacade;
 import org.sopt.confeti.api.user.facade.dto.response.UserInfoDTO;
@@ -12,9 +13,7 @@ import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -31,5 +30,15 @@ public class UserInfoController {
     ) {
         UserInfoDTO userInfo = userInfoFacade.getUserInfo(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserInfoResponse.of(userInfo, s3FileHandler));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @PatchMapping
+    public ResponseEntity<BaseResponse<?>> patchUserInfo(
+            @UserId Long userId,
+            @RequestBody PatchUserInfoRequest patchUserInfoRequest
+    ) {
+        userInfoFacade.patchUserInfo(userId, patchUserInfoRequest);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/dto/request/PatchUserInfoRequest.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/request/PatchUserInfoRequest.java
@@ -1,0 +1,10 @@
+package org.sopt.confeti.api.user.dto.request;
+
+public record PatchUserInfoRequest(
+        String profileUrl,
+        String name
+) {
+    public static PatchUserInfoRequest from(PatchUserInfoRequest request) {
+        return new PatchUserInfoRequest(request.profileUrl(), request.name());
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
@@ -1,9 +1,14 @@
 package org.sopt.confeti.api.user.facade;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.dto.request.PatchUserInfoRequest;
 import org.sopt.confeti.api.user.facade.dto.response.UserInfoDTO;
 import org.sopt.confeti.domain.user.application.UserService;
 import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.exception.NotFoundException;
+import org.sopt.confeti.global.exception.UnauthorizedException;
+import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.transaction.annotation.Transactional;
 
 @Facade
@@ -16,5 +21,27 @@ public class UserInfoFacade {
         return UserInfoDTO.from(
                 userService.findById(userId)
         );
+    }
+
+    @Transactional
+    public void patchUserInfo(Long userId, PatchUserInfoRequest patchUserInfoRequest) {
+        validateExistUser(userId);
+        validateUserInfoRequest(patchUserInfoRequest);
+
+        userService.patchUserInfo(userId, patchUserInfoRequest);
+    }
+
+    @Transactional(readOnly = true)
+    protected void validateExistUser(final long userId) {
+        if (!userService.existsById(userId)) {
+            throw new UnauthorizedException(ErrorMessage.UNAUTHORIZED);
+        }
+    }
+
+    @Transactional(readOnly = true)
+    protected void validateUserInfoRequest(PatchUserInfoRequest patchUserInfoRequest) {
+        if (patchUserInfoRequest.profileUrl() == null || patchUserInfoRequest.name() == null) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/user/User.java
+++ b/src/main/java/org/sopt/confeti/domain/user/User.java
@@ -40,9 +40,11 @@ public class User {
     @Column(length = 100, nullable = false)
     private String socialId;
 
+    @Setter
     @Column(length = 30, nullable = false)
     private String name;
 
+    @Setter
     @Column(length = 250)
     private String profilePath;
 

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
@@ -1,17 +1,22 @@
 package org.sopt.confeti.domain.user.application;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.dto.request.PatchUserInfoRequest;
 import org.sopt.confeti.auth.dto.CreateUserDTO;
 import org.sopt.confeti.domain.user.AuthUser;
 import org.sopt.confeti.domain.user.OAuthProvider;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.infra.repository.AllUserRepository;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
+import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
+import org.sopt.confeti.global.util.FileDownloader;
+import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import java.nio.file.Path;
 
 @Service
 @RequiredArgsConstructor
@@ -19,6 +24,8 @@ public class UserService {
 
     private final UserRepository userRepository;
     private final AllUserRepository allUserRepository;
+    private final S3FileHandler s3FileHandler;
+    private final FileDownloader fileDownloader;
 
     @Transactional(readOnly = true)
     public User findById(Long userId) {
@@ -71,5 +78,26 @@ public class UserService {
                 .orElseThrow(
                         () -> new NotFoundException(ErrorMessage.NOT_FOUND)
                 );
+    }
+
+    @Transactional
+    public void patchUserInfo(long userId, PatchUserInfoRequest patchUserInfoRequest) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+
+        String fileName = uploadProfile(patchUserInfoRequest.profileUrl());
+
+        user.setProfilePath(fileName);
+        user.setName(patchUserInfoRequest.name());
+    }
+
+    public String uploadProfile(String profileImgUrl) {
+        Path profileImg = fileDownloader.downloadFile(profileImgUrl);
+        try {
+            return s3FileHandler.uploadFile(profileImg.toFile(),
+                    FolderPath.combine(FolderPath.USER, FolderPath.PROFILE));
+        } finally {
+            fileDownloader.deleteTempFile(profileImg);
+        }
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #304

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 프로필 편집 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
프로필 편집 API를 구현했습니다. 
이름, 프로필 url의 변경 여부와 상관없이 관련 필드를 모두 입력 받고, 해당 정보를 바탕으로 전체 수정하는 로직으로 작성했습니다.
<img width="640" alt="스크린샷 2025-04-19 오후 11 38 40" src="https://github.com/user-attachments/assets/8652f081-d454-4f89-8074-6a33d2fef40a" />

