### PR TITLE
feat [#310] Elastic Search 연동 작업

### DIFF
--- a/.github/workflows/workflow-dev.yml
+++ b/.github/workflows/workflow-dev.yml
@@ -61,6 +61,13 @@ jobs:
           echo "${{ secrets.APPLICATION_CLOUD_YML }}" > ./src/main/resources/cloud/application-cloud.yml
         shell: bash
 
+      # application-elastic-search.yml 파일 생성
+      - name: make application-elastic-search.yml
+        run: |
+          touch ./src/main/resources/cloud/application-elastic-search.yml
+          echo "${{ secrets.APPLICATION_ELASTIC_SEARCH_YML }}" > ./src/main/resources/cloud/application-elastic-search.yml
+        shell: bash
+
       # openapi 폴더 생성
       - name: Create cloud folder if not exist
         run: |

--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -65,6 +65,13 @@ jobs:
           echo "${{ secrets.APPLICATION_CLOUD_YML }}" > ./src/main/resources/cloud/application-cloud.yml
         shell: bash
 
+      # application-elastic-search.yml 파일 생성
+      - name: make application-elastic-search.yml
+        run: |
+          touch ./src/main/resources/cloud/application-elastic-search.yml
+          echo "${{ secrets.APPLICATION_ELASTIC_SEARCH_YML }}" > ./src/main/resources/cloud/application-elastic-search.yml
+        shell: bash
+
       # openapi 폴더 생성
       - name: Create cloud folder if not exist
         run: |

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
     // AOP
     implementation 'org.springframework.boot:spring-boot-starter-aop'
 
+    // Elastic Search
+    implementation 'org.springframework.data:spring-data-elasticsearch'
+
     // Bouncy Castle
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'

--- a/src/main/java/org/sopt/confeti/api/dummy/controller/PerformanceSearchController.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/controller/PerformanceSearchController.java
@@ -1,0 +1,31 @@
+package org.sopt.confeti.api.dummy.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.dummy.facade.PerformanceSearchFacade;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequiredArgsConstructor
+@RequestMapping("${api.endpoints.es.base}")
+public class PerformanceSearchController {
+
+    private final PerformanceSearchFacade performanceSearchFacade;
+
+    @Permission(role = {Role.ADMIN})
+    @PatchMapping("${api.endpoints.es.batch}")
+    public ResponseEntity<BaseResponse<?>> batch(
+            @UserId Long userId
+    ) {
+        performanceSearchFacade.batch();
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/dummy/facade/PerformanceSearchFacade.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/facade/PerformanceSearchFacade.java
@@ -1,0 +1,28 @@
+package org.sopt.confeti.api.dummy.facade;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.elastic_search.PerformanceDocument;
+import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
+import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
+import org.sopt.confeti.global.annotation.Facade;
+import org.springframework.transaction.annotation.Transactional;
+
+@Facade
+@RequiredArgsConstructor
+public class PerformanceSearchFacade {
+
+    private final PerformanceSearchService performanceSearchService;
+    private final PerformanceService performanceService;
+
+    @Transactional
+    public void batch() {
+        performanceSearchService.deleteAll();
+        List<PerformanceDTO> performances = performanceService.getAllPerformances();
+        List<PerformanceDocument> performanceDocuments = performances.stream()
+                .map(PerformanceDocument::create)
+                .toList();
+        performanceSearchService.save(performanceDocuments);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -15,8 +15,8 @@ import org.sopt.confeti.domain.festival_favorite.application.FestivalFavoriteSer
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.application.UserService;
 import org.sopt.confeti.domain.view.performance.Performance;
-import org.sopt.confeti.domain.view.performance.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformancePreviewDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.exception.ConfetiException;
@@ -144,7 +144,7 @@ public class UserFavoriteFacade {
     public UserFavoritePerformancesDTO getFavoritePerformances(final long userId) {
         validateExistUser(userId);
 
-        List<PerformanceDTO> performances = performanceService.getFavoritePerformancesPreview(userId);
+        List<PerformancePreviewDTO> performances = performanceService.getFavoritePerformancesPreview(userId);
         return UserFavoritePerformancesDTO.from(performances);
     }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -17,8 +17,8 @@ import org.sopt.confeti.domain.festival_favorite.application.FestivalFavoriteSer
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.application.UserService;
 import org.sopt.confeti.domain.view.performance.Performance;
-import org.sopt.confeti.domain.view.performance.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformancePreviewDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.exception.ConfetiException;
@@ -146,7 +146,7 @@ public class UserFavoriteFacade {
     public UserFavoritePerformancesDTO getFavoritePerformances(final long userId) {
         validateExistUser(userId);
 
-        List<PerformanceDTO> performances = performanceService.getFavoritePerformancesPreview(userId);
+        List<PerformancePreviewDTO> performances = performanceService.getFavoritePerformancesPreview(userId);
         return UserFavoritePerformancesDTO.from(performances);
     }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformanceDTO.java
@@ -1,6 +1,6 @@
 package org.sopt.confeti.api.user.facade.dto.response;
 
-import org.sopt.confeti.domain.view.performance.PerformanceDTO;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformancePreviewDTO;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 
 public record UserFavoritePerformanceDTO(
@@ -9,7 +9,7 @@ public record UserFavoritePerformanceDTO(
         String title,
         String posterPath
 ) {
-    public static UserFavoritePerformanceDTO from(final PerformanceDTO performance) {
+    public static UserFavoritePerformanceDTO from(final PerformancePreviewDTO performance) {
         return new UserFavoritePerformanceDTO(
                 performance.typeId(),
                 performance.type(),

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformancesDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformancesDTO.java
@@ -1,12 +1,12 @@
 package org.sopt.confeti.api.user.facade.dto.response;
 
 import java.util.List;
-import org.sopt.confeti.domain.view.performance.PerformanceDTO;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformancePreviewDTO;
 
 public record UserFavoritePerformancesDTO(
         List<UserFavoritePerformanceDTO> performances
 ) {
-    public static UserFavoritePerformancesDTO from(final List<PerformanceDTO> performances) {
+    public static UserFavoritePerformancesDTO from(final List<PerformancePreviewDTO> performances) {
         return new UserFavoritePerformancesDTO(
                 performances.stream()
                         .map(UserFavoritePerformanceDTO::from)

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/PerformanceDocument.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/PerformanceDocument.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.domain.elastic_search;
 
 import java.time.LocalDate;
 import lombok.Builder;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
@@ -29,4 +30,14 @@ public record PerformanceDocument(
         @Field(type = FieldType.Text)
         String area
 ) {
+    public static PerformanceDocument create(PerformanceDTO performance) {
+        return PerformanceDocument.builder()
+                .id(performance.id())
+                .title(performance.title())
+                .startAt(performance.startAt())
+                .endAt(performance.endAt())
+                .posterPath(performance.posterPath())
+                .area(performance.area())
+                .build();
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/PerformanceDocument.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/PerformanceDocument.java
@@ -1,0 +1,32 @@
+package org.sopt.confeti.domain.elastic_search;
+
+import java.time.LocalDate;
+import lombok.Builder;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.elasticsearch.annotations.Document;
+import org.springframework.data.elasticsearch.annotations.Field;
+import org.springframework.data.elasticsearch.annotations.FieldType;
+
+@Builder
+@Document(indexName = "performances")
+public record PerformanceDocument(
+
+        @Id
+        long id,
+
+        @Field(type = FieldType.Text)
+        String title,
+
+        @Field(type = FieldType.Date)
+        LocalDate startAt,
+
+        @Field(type = FieldType.Date)
+        LocalDate endAt,
+
+        @Field(type = FieldType.Text)
+        String posterPath,
+
+        @Field(type = FieldType.Text)
+        String area
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
@@ -1,0 +1,25 @@
+package org.sopt.confeti.domain.elastic_search.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.elastic_search.PerformanceDocument;
+import org.sopt.confeti.domain.elastic_search.infra.PerformanceSearchRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceSearchService {
+
+    private final PerformanceSearchRepository performanceSearchRepository;
+
+    @Transactional
+    public void deleteAll() {
+        performanceSearchRepository.deleteAll();
+    }
+
+    @Transactional
+    public void save(List<PerformanceDocument> performanceDocuments) {
+        performanceSearchRepository.saveAll(performanceDocuments);
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/infra/PerformanceSearchRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/infra/PerformanceSearchRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.confeti.domain.elastic_search.infra;
+
+import org.sopt.confeti.domain.elastic_search.PerformanceDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface PerformanceSearchRepository extends ElasticsearchRepository<PerformanceDocument, Long> {
+}

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -4,8 +4,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceArtist;
-import org.sopt.confeti.domain.view.performance.PerformanceDTO;
+import org.sopt.confeti.domain.view.performance.PerformancePreviewDTO;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceDTORepository;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceRepository;
 import org.sopt.confeti.global.common.constant.PerformanceType;
@@ -28,7 +29,7 @@ public class PerformanceService {
     private final PerformanceRepository performanceRepository;
 
     @Transactional(readOnly = true)
-    public List<PerformanceDTO> getFavoritePerformancesPreview(final long userId) {
+    public List<PerformancePreviewDTO> getFavoritePerformancesPreview(final long userId) {
         return performanceDTORepository.findFavoritePerformancesPreview(userId);
     }
 
@@ -97,5 +98,12 @@ public class PerformanceService {
     public Performance getUpcomingPerformance(final Long userId){
         return performanceRepository.upcomingPerformance(userId)
                 .orElse(null);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceDTO> getAllPerformances() {
+        return performanceRepository.findAll().stream()
+                .map(org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO::from)
+                .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -7,6 +7,7 @@ import org.sopt.confeti.domain.view.performance.PerformanceArtist;
 import org.sopt.confeti.domain.view.performance.PerformancePreviewDTO;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformancePreviewDTO;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceDTORepository;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceRepository;
 import org.sopt.confeti.global.common.constant.PerformanceType;

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -6,6 +6,7 @@ import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceArtist;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformancePreviewDTO;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceDTORepository;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceRepository;
 import org.sopt.confeti.global.common.constant.PerformanceType;
@@ -28,7 +29,7 @@ public class PerformanceService {
     private final PerformanceRepository performanceRepository;
 
     @Transactional(readOnly = true)
-    public List<PerformanceDTO> getFavoritePerformancesPreview(final long userId) {
+    public List<PerformancePreviewDTO> getFavoritePerformancesPreview(final long userId) {
         return performanceDTORepository.findFavoritePerformancesPreview(userId);
     }
 

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -4,8 +4,8 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceArtist;
-import org.sopt.confeti.domain.view.performance.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceDTORepository;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceRepository;
 import org.sopt.confeti.global.common.constant.PerformanceType;
@@ -91,5 +91,12 @@ public class PerformanceService {
                 );
 
         performance.addArtists(performanceArtists);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceDTO> getAllPerformances() {
+        return performanceRepository.findAll().stream()
+                .map(PerformanceDTO::from)
+                .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceDTO.java
@@ -1,0 +1,36 @@
+package org.sopt.confeti.domain.view.performance.application.dto.response;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+public record PerformanceDTO(
+        long id,
+        long typeId,
+        PerformanceType type,
+        String area,
+        String title,
+        String subtitle,
+        LocalDate startAt,
+        LocalDate endAt,
+        String posterPath,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PerformanceDTO from(final Performance performance) {
+        return new PerformanceDTO(
+                performance.getId(),
+                performance.getTypeId(),
+                performance.getType(),
+                performance.getArea(),
+                performance.getTitle(),
+                performance.getSubtitle(),
+                performance.getStartAt(),
+                performance.getEndAt(),
+                performance.getPosterPath(),
+                performance.getCreatedAt(),
+                performance.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformancePreviewDTO.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformancePreviewDTO.java
@@ -1,20 +1,20 @@
-package org.sopt.confeti.domain.view.performance;
+package org.sopt.confeti.domain.view.performance.application.dto.response;
 
 import org.sopt.confeti.global.common.constant.PerformanceType;
 
-public record PerformanceDTO(
+public record PerformancePreviewDTO(
         long typeId,
         PerformanceType type,
         String title,
         String posterPath
 ) {
-    public static PerformanceDTO of(
+    public static PerformancePreviewDTO of(
             final long typeId,
             final String type,
             final String title,
             final String posterPath
     ) {
-        return new PerformanceDTO(
+        return new PerformancePreviewDTO(
                 typeId,
                 PerformanceType.convert(type),
                 title,

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceDTORepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceDTORepository.java
@@ -8,8 +8,8 @@ import java.time.LocalDateTime;
 import java.time.ZoneId;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.domain.view.performance.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformancePreviewDTO;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.springframework.stereotype.Repository;
 
@@ -22,7 +22,7 @@ public class PerformanceDTORepository {
     private static final int PREVIEW_FAVORITE_PERFORMANCE_COUNT = 4;
     private static final int RESERVE_FAVORITE_PERFORMANCE_COUNT = 5;
 
-    public List<PerformanceDTO> findFavoritePerformancesPreview(final Long userId) {
+    public List<PerformancePreviewDTO> findFavoritePerformancesPreview(final Long userId) {
         String sql =
                 "SELECT c.id id, :concertType type, c.title title, c.poster_path posterPath, c.start_at startAt" +
                         " FROM concert_favorites cf INNER JOIN concerts c ON cf.concert_id = c.id" +
@@ -44,9 +44,9 @@ public class PerformanceDTORepository {
         return convertToPerformanceDTOs(query.getResultList());
     }
 
-    private List<PerformanceDTO> convertToPerformanceDTOs(final List<Object[]> results) {
+    private List<PerformancePreviewDTO> convertToPerformanceDTOs(final List<Object[]> results) {
         return results.stream()
-                .map(result -> PerformanceDTO.of(
+                .map(result -> PerformancePreviewDTO.of(
                         ((Number) result[0]).longValue(),
                         (String) result[1],
                         (String) result[2],

--- a/src/main/java/org/sopt/confeti/global/config/ElasticSearchConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/ElasticSearchConfig.java
@@ -1,0 +1,24 @@
+package org.sopt.confeti.global.config;
+
+import lombok.NonNull;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.client.ClientConfiguration;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchConfiguration;
+import org.springframework.data.elasticsearch.repository.config.EnableReactiveElasticsearchRepositories;
+
+@Configuration
+@EnableReactiveElasticsearchRepositories(basePackages = "")
+public class ElasticSearchConfig extends ElasticsearchConfiguration {
+
+    @Value("${spring.data.elasticsearch.uris}")
+    private String[] esHosts;
+
+    @NonNull
+    @Override
+    public ClientConfiguration clientConfiguration() {
+        return ClientConfiguration.builder()
+                .connectedTo(esHosts)
+                .build();
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/config/ElasticSearchConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/ElasticSearchConfig.java
@@ -12,13 +12,21 @@ import org.springframework.data.elasticsearch.repository.config.EnableReactiveEl
 public class ElasticSearchConfig extends ElasticsearchConfiguration {
 
     @Value("${spring.data.elasticsearch.uris}")
-    private String[] esHosts;
+    private String esHost;
+
+    @Value("${spring.data.elasticsearch.username}")
+    private String username;
+
+    @Value("${spring.data.elasticsearch.password}")
+    private String password;
 
     @NonNull
     @Override
     public ClientConfiguration clientConfiguration() {
         return ClientConfiguration.builder()
-                .connectedTo(esHosts)
+                .connectedTo(esHost)
+                .usingSsl()
+                .withBasicAuth(username, password)
                 .build();
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #310 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] Spring Data ElasticSearch 라이브러리 추가
- [x] Elastic Search Config 작성
- [x] Document 작성
- [x] 임시 배치 작업 API 구현

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
[ 공연 데이터 배치 작업 API 실행 결과 ]
<img width="1067" alt="image" src="https://github.com/user-attachments/assets/4712e11c-44c3-4bef-af44-4c294873c6bd" />
<img width="1496" alt="image" src="https://github.com/user-attachments/assets/21f1698e-b08a-4ab6-9509-8f5037db8258" />

위 API에 요청하면, 기존 엘라스틱 서치에 들어있는 데이터가 전부 삭제되고 현재 데이터베이스에 저장된 공연 정보가 다시 색인됩니다.

이렇게 처리할 경우 다음과 같은 문제가 발생할 수 있다고 생각해요.
1. 처리하는 과정에서 개념상 존재하는 데이터가 조회 안됨.
2. 기존 데이터 삭제, 공연 데이터 조회, 조회된 데이터 색인 세 가지 과정 중 하나라도 failure 되면 처음부터 다시 해야함.
3. 수동으로 배치 작업을 실행해야 함.
4. 데이터가 많아질 경우 서버에 부담이 됨.

그래서 나중에는 배치 작업을 자동으로 수행하기 위해 서버를 분리하고, 전체 색인과 부분 색인의 과정을 분리할 예정입니다!

엘라스틱 서치와 관련한 서버, 키바나 등의 정보는 스프린트 이후에 문서 작성하고 알려드릴게요!
