### PR TITLE
feat [#324] 타임테이블에 페스티벌 추가 API에 추가된 이력을 기록하는 로직 추가

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -86,6 +86,7 @@ public class UserTimetableFacade {
         validateCountTimetableFestival(user.getTimetableFestivals().size(), addFestivals.size());
 
         timetableFestivalService.addTimetableFestivals(user, addFestivals);
+        userService.updateHasTimetableHistory(userId);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/confeti/domain/user/User.java
+++ b/src/main/java/org/sopt/confeti/domain/user/User.java
@@ -53,6 +53,10 @@ public class User {
     @Column(length = 20, nullable = false)
     private Role role;
 
+    @Setter
+    @Column(nullable = false)
+    private boolean hasTimetableHistory;
+
     @OneToMany(mappedBy = "user", cascade = CascadeType.REMOVE, orphanRemoval = true)
     private List<ArtistFavorite> artistFavorites = new ArrayList<>();
 
@@ -72,6 +76,7 @@ public class User {
         this.name = name;
         this.profilePath = profilePath;
         this.role = role;
+        this.hasTimetableHistory = false;
     }
 
     public static User create(AuthUser authUser) {

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.domain.user.application;
 
+import java.nio.file.Path;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.dto.request.PatchUserInfoRequest;
 import org.sopt.confeti.auth.dto.CreateUserDTO;
@@ -16,11 +17,12 @@ import org.sopt.confeti.global.util.FileDownloader;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import java.nio.file.Path;
 
 @Service
 @RequiredArgsConstructor
 public class UserService {
+
+    private static final boolean TIMETABLE_ADDED = true;
 
     private final UserRepository userRepository;
     private final AllUserRepository allUserRepository;
@@ -99,5 +101,15 @@ public class UserService {
         } finally {
             fileDownloader.deleteTempFile(profileImg);
         }
+    }
+
+    @Transactional
+    public void updateHasTimetableHistory(long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+                );
+
+        user.setHasTimetableHistory(TIMETABLE_ADDED);
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #324 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 유저에 타임테이블 페스티벌 추가 이력 컬럼 생성
- [x] 페스티벌 추가 로직에서 이력 기록 로직 추가

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/e7c41531-01c9-46fd-a07d-885d100d7119" />
<img width="749" alt="image" src="https://github.com/user-attachments/assets/3200c7fc-4851-4dbb-8ba0-7e07c09fa74e" />

유저 테이블에 타임테이블에 페스티벌을 추가 여부인 `hasTimetableHistory` 컬럼을 추가했어요!
그리고 페스티벌 등록 로직에 이력을 기록하는 로직도 추가했습니다 :)