### PR TITLE
feat [#320] confeti’s pick 추천 공연 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -2,17 +2,9 @@ package org.sopt.confeti.api.performance.controller;
 
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.api.performance.dto.response.ArtistPerformancesResponse;
-import org.sopt.confeti.api.performance.dto.response.ConcertDetailResponse;
-import org.sopt.confeti.api.performance.dto.response.FestivalDetailResponse;
-import org.sopt.confeti.api.performance.dto.response.PerformanceReservationResponse;
-import org.sopt.confeti.api.performance.dto.response.RecentPerformancesResponse;
+import org.sopt.confeti.api.performance.dto.response.*;
 import org.sopt.confeti.api.performance.facade.PerformanceFacade;
-import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.ConcertDetailDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.*;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
@@ -88,5 +80,14 @@ public class PerformanceController {
         RecentPerformancesDTO recentPerformances = performanceFacade.getRecentPerformances(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 RecentPerformancesResponse.of(recentPerformances, s3FileHandler));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/recommend")
+    public ResponseEntity<BaseResponse<?>> getRecommendPerformances(
+    ) {
+        RecommendPerformancesDTO recommendPerformances = performanceFacade.getRecommendPerformances();
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                RecommendPerformancesResponse.of(recommendPerformances, s3FileHandler));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendPerformanceResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendPerformanceResponse.java
@@ -1,0 +1,26 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformanceDTO;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record RecommendPerformanceResponse(
+        long typeId,
+        String type,
+        String title,
+        String posterUrl
+) {
+    public static RecommendPerformanceResponse of(final RecommendPerformanceDTO recommendPerformanceDTO,
+                                                  final S3FileHandler s3FileHandler) {
+        FolderPath topFolder = FolderPath.getFolderPathByPerformanceType(recommendPerformanceDTO.type());
+
+        return new RecommendPerformanceResponse(
+                recommendPerformanceDTO.typeId(),
+                recommendPerformanceDTO.type().getType(),
+                recommendPerformanceDTO.title(),
+                s3FileHandler.getFileUrl(FolderPath.combine(topFolder, FolderPath.POSTER),
+                        recommendPerformanceDTO.posterPath()).toString()
+        );
+    }
+}
+

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendPerformancesResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendPerformancesResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformancesDTO;
+import org.sopt.confeti.global.util.S3FileHandler;
+import java.util.List;
+
+public record RecommendPerformancesResponse(
+        List<RecommendPerformanceResponse> performances
+) {
+    public static RecommendPerformancesResponse of(final RecommendPerformancesDTO recommendPerformancesDTO,
+                                                   final S3FileHandler s3FileHandler) {
+        return new RecommendPerformancesResponse(
+                recommendPerformancesDTO.performances().stream()
+                        .map(recommendPerformanceDTO -> RecommendPerformanceResponse.of(recommendPerformanceDTO, s3FileHandler))
+                        .toList()
+        );
+    }
+}
+

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -8,12 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDetailDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.ConcertDetailDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.*;
 import org.sopt.confeti.domain.artist_favorite.ArtistFavorite;
 import org.sopt.confeti.domain.artist_favorite.application.ArtistFavoriteService;
 import org.sopt.confeti.domain.concert.Concert;
@@ -29,6 +24,7 @@ import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.exception.NotFoundException;
+import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -217,4 +213,10 @@ public class PerformanceFacade {
         };
     }
 
+    @Transactional(readOnly = true)
+    public RecommendPerformancesDTO getRecommendPerformances() {
+        return RecommendPerformancesDTO.from(
+                performanceService.getRecommendPerformances()
+        );
+    }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendPerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendPerformanceDTO.java
@@ -1,0 +1,20 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+public record RecommendPerformanceDTO(
+        long typeId,
+        PerformanceType type,
+        String title,
+        String posterPath
+) {
+    public static RecommendPerformanceDTO from(Performance performance) {
+        return new RecommendPerformanceDTO(
+                performance.getTypeId(),
+                performance.getType(),
+                performance.getTitle(),
+                performance.getPosterPath()
+                );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendPerformancesDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendPerformancesDTO.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import org.sopt.confeti.domain.view.performance.Performance;
+import java.util.List;
+
+public record RecommendPerformancesDTO(
+        List<RecommendPerformanceDTO> performances
+) {
+    public static RecommendPerformancesDTO from(List<Performance> performances){
+        return new RecommendPerformancesDTO(
+                performances.stream()
+                        .map(RecommendPerformanceDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -106,4 +106,9 @@ public class PerformanceService {
                 .map(org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO::from)
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public List<Performance> getRecommendPerformances() {
+        return performanceRepository.findTop5ByRand();
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -63,4 +63,6 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             "ORDER BY p.startAt ASC LIMIT 1 ")
     Optional<Performance> upcomingPerformance(final @Param("userId") long userId);
 
+    @Query(value = "SELECT p FROM Performance p ORDER BY RAND() LIMIT 5")
+    List<Performance> findTop5ByRand();
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #320

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [ ] confeti’s pick 추천 공연 조회 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
confeti’s pick 추천 공연 조회 API를 구현했습니다!
로그인/비로그인 여부와 상관없이 퍼포먼스 최대 다섯 개를 랜덤으로 반환합니다! 
<img width="719" alt="스크린샷 2025-04-21 오후 10 13 04" src="https://github.com/user-attachments/assets/01f7af7b-961e-4b30-8fcf-5916f9e72c89" />