### PR TITLE
fix [#334] 공연 연관 검색어 조회 시 공백을 포함할 수 있도록 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/domain/elastic_search/PerformanceDocument.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/PerformanceDocument.java
@@ -16,7 +16,7 @@ public record PerformanceDocument(
         @Id
         long id,
 
-        @Field(type = FieldType.Text)
+        @Field(type = FieldType.Text, analyzer = "autocomplete_analyzer", searchAnalyzer = "search_analyzer")
         String title,
 
         @Field(type = FieldType.Date)

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
@@ -26,12 +26,16 @@ public class PerformanceSearchService {
 
     @Transactional(readOnly = true)
     public List<SearchPerformanceResult> getPerformancesByTitle(String title, int limit) {
-        List<PerformanceDocument> performances = performanceSearchRepository.findPerformanceDocumentsByTitleStartsWith(
-                title);
+        List<PerformanceDocument> performances = performanceSearchRepository.findPerformanceDocumentsByTitleStartingWith(
+                clearSentence(title));
 
         return performances.stream()
                 .map(SearchPerformanceResult::from)
                 .limit(limit)
                 .toList();
+    }
+
+    private String clearSentence(String sentence) {
+        return sentence.replaceAll("\"", "").replace("*", "\\*");
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/infra/PerformanceSearchRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/infra/PerformanceSearchRepository.java
@@ -2,9 +2,11 @@ package org.sopt.confeti.domain.elastic_search.infra;
 
 import java.util.List;
 import org.sopt.confeti.domain.elastic_search.PerformanceDocument;
+import org.springframework.data.elasticsearch.annotations.Query;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
 
 public interface PerformanceSearchRepository extends ElasticsearchRepository<PerformanceDocument, Long> {
 
-    List<PerformanceDocument> findPerformanceDocumentsByTitleStartsWith(String title);
+    @Query("{\"bool\": {\"should\": [{\"prefix\": {\"title.keyword\": \"?0\"}}, {\"match_phrase_prefix\": {\"title\": \"?0\"}}]}}")
+    List<PerformanceDocument> findPerformanceDocumentsByTitleStartingWith(String title);
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #334

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 공연 연관 검색어 조회 시 공백을 포함할 수 있도록 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/2c5b8f9c-b3e4-40f1-9f66-833635d02f3c" />
입력 값에 공백이 포함될 경우 500 에러가 발생하는 이슈가 있었습니다.

@Query 어노테이션으로 요청 본문 템플릿을 직접 작성해서 해결했습니다.
