### PR TITLE
feat [#336] 예정된 공연 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -5,6 +5,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.dto.response.ArtistPerformancesResponse;
 import org.sopt.confeti.api.performance.dto.response.ConcertDetailResponse;
 import org.sopt.confeti.api.performance.dto.response.FestivalDetailResponse;
+import org.sopt.confeti.api.performance.dto.response.IntendedPerformancesResponse;
 import org.sopt.confeti.api.performance.dto.response.PerformanceReservationResponse;
 import org.sopt.confeti.api.performance.dto.response.RecentPerformancesResponse;
 import org.sopt.confeti.api.performance.dto.response.RecommendPerformancesResponse;
@@ -13,6 +14,7 @@ import org.sopt.confeti.api.performance.facade.PerformanceFacade;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ConcertDetailDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.IntendedPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformancesDTO;
@@ -21,6 +23,8 @@ import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.common.constant.Default;
+import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.common.constant.RequestConstraint;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
@@ -104,6 +108,7 @@ public class PerformanceController {
                 RecommendPerformancesResponse.of(recommendPerformances, s3FileHandler));
     }
 
+    @Permission(role = {Role.GENERAL})
     @GetMapping("/search/ac")
     public ResponseEntity<BaseResponse<?>> searchAutoComplete(
             @UserId(require = false) Long userId,
@@ -113,5 +118,18 @@ public class PerformanceController {
         SearchACPerformancesDTO performacnesDTO = performanceFacade.searchACPerformances(term, limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 SearchACPerformancesResponse.of(performacnesDTO, s3FileHandler));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/search")
+    public ResponseEntity<BaseResponse<?>> search(
+            @UserId(require = false) Long userId,
+            @RequestParam(required = false) Long pid,
+            @RequestParam(required = false) String aid,
+            @RequestParam(required = false, defaultValue = Default.PERFORMANCE_TYPE) PerformanceType type
+    ) {
+        IntendedPerformancesDTO performancesDTO = performanceFacade.getPerformances(userId, pid, aid, type);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                IntendedPerformancesResponse.of(performancesDTO, s3FileHandler));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -126,9 +126,9 @@ public class PerformanceController {
             @UserId(require = false) Long userId,
             @RequestParam(required = false) Long pid,
             @RequestParam(required = false) String aid,
-            @RequestParam(required = false, defaultValue = Default.PERFORMANCE_TYPE) PerformanceType type
+            @RequestParam(required = false, defaultValue = Default.PERFORMANCE_TYPE) PerformanceType ptype
     ) {
-        IntendedPerformancesDTO performancesDTO = performanceFacade.getPerformances(userId, pid, aid, type);
+        IntendedPerformancesDTO performancesDTO = performanceFacade.getPerformances(userId, pid, aid, ptype);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 IntendedPerformancesResponse.of(performancesDTO, s3FileHandler));
     }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/IntendedPerformanceResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/IntendedPerformanceResponse.java
@@ -1,0 +1,31 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import org.sopt.confeti.api.performance.facade.dto.response.IntendedPerformanceDTO;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.util.DateConvertor;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record IntendedPerformanceResponse(
+        long performanceId,
+        String title,
+        String posterUrl,
+        String startAt,
+        String endAt,
+        String area,
+        boolean isFavorite
+) {
+    public static IntendedPerformanceResponse of(IntendedPerformanceDTO performanceDTO, S3FileHandler s3FileHandler) {
+        return new IntendedPerformanceResponse(
+                performanceDTO.id(),
+                performanceDTO.title(),
+                s3FileHandler.getFileUrl(
+                        FolderPath.combine(FolderPath.getFolderPathByPerformanceType(performanceDTO.type()),
+                                FolderPath.POSTER),
+                        performanceDTO.posterPath()).toString(),
+                DateConvertor.convertToDefaultFormat(performanceDTO.startAt()),
+                DateConvertor.convertToDefaultFormat(performanceDTO.endAt()),
+                performanceDTO.area(),
+                performanceDTO.isFavorite()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/IntendedPerformancesResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/IntendedPerformancesResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.api.performance.facade.dto.response.IntendedPerformancesDTO;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record IntendedPerformancesResponse(
+        int performanceCount,
+        List<IntendedPerformanceResponse> performances
+) {
+    public static IntendedPerformancesResponse of(IntendedPerformancesDTO performancesDTO,
+                                                  S3FileHandler s3FileHandler) {
+        return new IntendedPerformancesResponse(
+                performancesDTO.performances().size(),
+                performancesDTO.performances().stream()
+                        .map(performanceDTO -> IntendedPerformanceResponse.of(performanceDTO, s3FileHandler))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -1,21 +1,25 @@
 package org.sopt.confeti.api.performance.facade;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDetailDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ConcertDetailDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.IntendedPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.SearchACPerformancesDTO;
+import org.sopt.confeti.api.user.facade.UserFavoriteFacade;
 import org.sopt.confeti.domain.artist_favorite.ArtistFavorite;
 import org.sopt.confeti.domain.artist_favorite.application.ArtistFavoriteService;
 import org.sopt.confeti.domain.concert.Concert;
@@ -29,8 +33,10 @@ import org.sopt.confeti.domain.user.application.UserService;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.transaction.annotation.Transactional;
@@ -42,6 +48,7 @@ public class PerformanceFacade {
     private static final int RECENT_PERFORMANCES_SIZE = 7;
     private static final boolean PERSONALIZED = true;
     private static final boolean UNPERSONALIZED = false;
+    private static final String TYPE_ALL = "ALL";
 
     private final ConcertService concertService;
     private final FestivalService festivalService;
@@ -51,6 +58,7 @@ public class PerformanceFacade {
     private final ConcertFavoriteService concertFavoriteService;
     private final ArtistFavoriteService artistFavoriteService;
     private final PerformanceSearchService performanceSearchService;
+    private final UserFavoriteFacade userFavoriteFacade;
 
     @Transactional(readOnly = true)
     public ConcertDetailDTO getConcertDetailInfo(final Long userId, final long concertId) {
@@ -164,12 +172,12 @@ public class PerformanceFacade {
 
     @Transactional(readOnly = true)
     public ArtistPerformancesDTO getPerformancesByArtistId(final Long userId, final String artistId) {
-        List<Performance> performances = performanceService.findPerformanceByArtistId(artistId);
+        List<PerformanceDTO> performances = performanceService.findPerformancesByArtistId(artistId);
 
         Map<String, Boolean> favoriteMap = getFavoriteMap(userId, performances);
         List<ArtistPerformancesDetailDTO> performanceList = performances.stream()
                 .map(performance -> {
-                    String key = performance.getTypeId() + "_" + performance.getType();
+                    String key = performance.typeId() + "_" + performance.type();
                     boolean isFavorite = favoriteMap.getOrDefault(key, false);
                     return ArtistPerformancesDetailDTO.from(performance, isFavorite);
                 })
@@ -179,7 +187,7 @@ public class PerformanceFacade {
     }
 
     @Transactional(readOnly = true)
-    public Map<String, Boolean> getFavoriteMap(final Long userId, List<Performance> performances) {
+    public Map<String, Boolean> getFavoriteMap(final Long userId, List<PerformanceDTO> performances) {
         if (userId == null || performances.isEmpty()) {
             return Collections.emptyMap();
         }
@@ -188,14 +196,14 @@ public class PerformanceFacade {
         return fetchFavoriteMap(userId, typeToIdsMap);
     }
 
-    private Map<PerformanceType, Set<Long>> groupPerformancesByType(List<Performance> performances) {
+    private Map<PerformanceType, Set<Long>> groupPerformancesByType(List<PerformanceDTO> performances) {
         Map<PerformanceType, Set<Long>> typeToIdsMap = new HashMap<>();
 
-        for (Performance performance : performances) {
-            if (!typeToIdsMap.containsKey(performance.getType())) {
-                typeToIdsMap.put(performance.getType(), new HashSet<>());
+        for (PerformanceDTO performance : performances) {
+            if (!typeToIdsMap.containsKey(performance.type())) {
+                typeToIdsMap.put(performance.type(), new HashSet<>());
             }
-            typeToIdsMap.get(performance.getType()).add(performance.getTypeId());
+            typeToIdsMap.get(performance.type()).add(performance.typeId());
         }
 
         return typeToIdsMap;
@@ -218,6 +226,7 @@ public class PerformanceFacade {
         return switch (type) {
             case CONCERT -> concertFavoriteService.findFavorites(userId, ids);
             case FESTIVAL -> festivalFavoriteService.findFavorites(userId, ids);
+            default -> List.of();
         };
     }
 
@@ -233,5 +242,46 @@ public class PerformanceFacade {
         return SearchACPerformancesDTO.from(
                 performanceSearchService.getPerformancesByTitle(term, limit)
         );
+    }
+
+    @Transactional(readOnly = true)
+    public IntendedPerformancesDTO getPerformances(Long userId, Long pid, String aid, PerformanceType type) {
+        if (!isPresent(pid) && !isPresent(aid)) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
+
+        List<PerformanceDTO> performances = new ArrayList<>();
+
+        if (isPresent(pid)) {
+            performances = List.of(performanceService.getPerformance(pid));
+        }
+
+        if (isPresent(aid)) {
+            performances = performanceService.getPerformancesByArtistIdAndType(aid, type);
+        }
+
+        Map<Long, Boolean> performanceFavorites = getPerformanceFavorites(userId, performances);
+        return IntendedPerformancesDTO.of(performances, performanceFavorites);
+    }
+
+    private boolean isPresent(Object target) {
+        return Objects.nonNull(target);
+    }
+
+    private Map<Long, Boolean> getPerformanceFavorites(Long userId, List<PerformanceDTO> performances) {
+        Map<Long, Boolean> performanceFavorites = new HashMap<>();
+        performances.forEach(performance -> performanceFavorites.put(performance.id(), false));
+
+        if (isPresent(userId)) {
+            List<PerformanceDTO> favoritePerformances = performanceService.getFavoritePerformancesAll(userId, TYPE_ALL);
+
+            favoritePerformances.forEach(favoritePerformance -> {
+                if (performanceFavorites.containsKey(favoritePerformance.id())) {
+                    performanceFavorites.put(favoritePerformance.id(), true);
+                }
+            });
+        }
+
+        return performanceFavorites;
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -245,7 +245,7 @@ public class PerformanceFacade {
     }
 
     @Transactional(readOnly = true)
-    public IntendedPerformancesDTO getPerformances(Long userId, Long pid, String aid, PerformanceType type) {
+    public IntendedPerformancesDTO getPerformances(Long userId, Long pid, String aid, PerformanceType ptype) {
         if (!isPresent(pid) && !isPresent(aid)) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
@@ -257,7 +257,7 @@ public class PerformanceFacade {
         }
 
         if (isPresent(aid)) {
-            performances = performanceService.getPerformancesByArtistIdAndType(aid, type);
+            performances = performanceService.getPerformancesByArtistIdAndType(aid, ptype);
         }
 
         Map<Long, Boolean> performanceFavorites = getPerformanceFavorites(userId, performances);

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ArtistPerformancesDetailDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ArtistPerformancesDetailDTO.java
@@ -1,7 +1,7 @@
 package org.sopt.confeti.api.performance.facade.dto.response;
 
 import java.time.LocalDate;
-import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 
 public record ArtistPerformancesDetailDTO(
@@ -15,16 +15,16 @@ public record ArtistPerformancesDetailDTO(
         String area,
         boolean isFavorite
 ) {
-    public static ArtistPerformancesDetailDTO from(Performance performance, boolean isFavorite) {
+    public static ArtistPerformancesDetailDTO from(PerformanceDTO performance, boolean isFavorite) {
         return new ArtistPerformancesDetailDTO(
-                performance.getId(),
-                performance.getTypeId(),
-                performance.getType(),
-                performance.getTitle(),
-                performance.getStartAt(),
-                performance.getEndAt(),
-                performance.getPosterPath(),
-                performance.getArea(),
+                performance.id(),
+                performance.typeId(),
+                performance.type(),
+                performance.title(),
+                performance.startAt(),
+                performance.endAt(),
+                performance.posterPath(),
+                performance.area(),
                 isFavorite
         );
     }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/IntendedPerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/IntendedPerformanceDTO.java
@@ -1,0 +1,29 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import java.time.LocalDate;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+public record IntendedPerformanceDTO(
+        long id,
+        PerformanceType type,
+        String title,
+        String posterPath,
+        LocalDate startAt,
+        LocalDate endAt,
+        String area,
+        boolean isFavorite
+) {
+    public static IntendedPerformanceDTO of(PerformanceDTO performanceDTO, boolean isFavorite) {
+        return new IntendedPerformanceDTO(
+                performanceDTO.id(),
+                performanceDTO.type(),
+                performanceDTO.title(),
+                performanceDTO.posterPath(),
+                performanceDTO.startAt(),
+                performanceDTO.endAt(),
+                performanceDTO.area(),
+                isFavorite
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/IntendedPerformancesDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/IntendedPerformancesDTO.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import java.util.List;
+import java.util.Map;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
+
+public record IntendedPerformancesDTO(
+        List<IntendedPerformanceDTO> performances
+) {
+    public static IntendedPerformancesDTO of(List<PerformanceDTO> performanceDTOs, Map<Long, Boolean> favorites) {
+        return new IntendedPerformancesDTO(
+                performanceDTOs.stream()
+                        .map(performanceDTO ->
+                                IntendedPerformanceDTO.of(performanceDTO, favorites.get(performanceDTO.id()))
+                        )
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -20,6 +20,7 @@ import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.application.UserService;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformancePreviewDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.common.constant.PerformanceType;
@@ -157,7 +158,7 @@ public class UserFavoriteFacade {
         validateExistUser(userId);
         validateType(type);
 
-        List<Performance> performances = performanceService.getFavoritePerformancesAll(userId, type);
+        List<PerformanceDTO> performances = performanceService.getFavoritePerformancesAll(userId, type);
         return UserFavoritePerformancesAllDTO.from(performances);
     }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformanceAllDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformanceAllDTO.java
@@ -1,7 +1,7 @@
 package org.sopt.confeti.api.user.facade.dto.response;
 
 import java.time.LocalDate;
-import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 
 public record UserFavoritePerformanceAllDTO(
@@ -13,15 +13,15 @@ public record UserFavoritePerformanceAllDTO(
         LocalDate endAt,
         String area
 ) {
-    public static UserFavoritePerformanceAllDTO from(Performance performance) {
+    public static UserFavoritePerformanceAllDTO from(PerformanceDTO performance) {
         return new UserFavoritePerformanceAllDTO(
-                performance.getTypeId(),
-                performance.getType(),
-                performance.getTitle(),
-                performance.getPosterPath(),
-                performance.getStartAt(),
-                performance.getEndAt(),
-                performance.getArea()
+                performance.typeId(),
+                performance.type(),
+                performance.title(),
+                performance.posterPath(),
+                performance.startAt(),
+                performance.endAt(),
+                performance.area()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformancesAllDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UserFavoritePerformancesAllDTO.java
@@ -1,12 +1,12 @@
 package org.sopt.confeti.api.user.facade.dto.response;
 
 import java.util.List;
-import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 
 public record UserFavoritePerformancesAllDTO(
         List<UserFavoritePerformanceAllDTO> performances
 ) {
-    public static UserFavoritePerformancesAllDTO from(final List<Performance> performances) {
+    public static UserFavoritePerformancesAllDTO from(final List<PerformanceDTO> performances) {
         return new UserFavoritePerformancesAllDTO(
                 performances.stream()
                         .map(UserFavoritePerformanceAllDTO::from)

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.domain.view.performance.application;
 
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.view.performance.Performance;
@@ -34,8 +35,10 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
-    public List<Performance> getFavoritePerformancesAll(final long userId, final String type) {
-        return performanceRepository.findPerformancesByUserFavorites(userId, type);
+    public List<PerformanceDTO> getFavoritePerformancesAll(final long userId, final String type) {
+        return performanceRepository.findPerformancesByUserFavorites(userId, type).stream()
+                .map(PerformanceDTO::from)
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -72,8 +75,10 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
-    public List<Performance> findPerformanceByArtistId(final String artistId) {
-        return performanceRepository.findPerformancesByArtistId(artistId);
+    public List<PerformanceDTO> findPerformancesByArtistId(final String artistId) {
+        return performanceRepository.findPerformancesByArtistId(artistId).stream()
+                .map(PerformanceDTO::from)
+                .toList();
     }
 
     @Transactional(readOnly = true)
@@ -86,7 +91,7 @@ public class PerformanceService {
     @Transactional
     public void addPerformanceArtists(PerformanceType performanceType, long festivalId,
                                       List<PerformanceArtist> performanceArtists) {
-        Performance performance = performanceRepository.findPerformancesByTypeAndTypeId(performanceType, festivalId)
+        Performance performance = performanceRepository.findPerformanceByTypeAndTypeId(performanceType, festivalId)
                 .orElseThrow(
                         () -> new NotFoundException(ErrorMessage.NOT_FOUND)
                 );
@@ -110,5 +115,30 @@ public class PerformanceService {
     @Transactional(readOnly = true)
     public List<Performance> getRecommendPerformances() {
         return performanceRepository.findTop5ByRand();
+    }
+
+    @Transactional(readOnly = true)
+    public PerformanceDTO getPerformance(long performanceId) {
+        Performance performance = performanceRepository.findPerformanceByIdAndEndAtGreaterThanEqualOrderByStartAt(
+                        performanceId,
+                        LocalDate.now())
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+                );
+
+        return PerformanceDTO.from(performance);
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceDTO> getPerformancesByArtistIdAndType(String artistId, PerformanceType type) {
+        if (type == PerformanceType.PERFORMANCE) {
+            return performanceRepository.findPerformancesByArtistId(artistId).stream()
+                    .map(PerformanceDTO::from)
+                    .toList();
+        }
+
+        return performanceRepository.findPerformancesByTypeAndArtistId(type, artistId).stream()
+                .map(PerformanceDTO::from)
+                .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.domain.view.performance.infra.repository;
 
+import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.sopt.confeti.domain.view.performance.Performance;
@@ -38,7 +39,17 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             final @Param("artistId") String artistId
     );
 
-    Optional<Performance> findPerformancesByTypeAndTypeId(PerformanceType type, long typeId);
+    Optional<Performance> findPerformanceByTypeAndTypeId(PerformanceType type, long typeId);
+
+    @Query(
+            "SELECT p"
+                    + " FROM Performance p"
+                    + " JOIN FETCH p.artists pa"
+                    + " WHERE p.endAt >= CURRENT_DATE AND p.type = :type AND pa.artistId = :artistId"
+                    + " ORDER BY p.startAt"
+    )
+    List<Performance> findPerformancesByTypeAndArtistId(@Param("type") PerformanceType type,
+                                                        @Param("artistId") String artistId);
 
     @Query("SELECT p FROM Performance p " +
             "WHERE ((:type = '" + TYPE_CONCERT + "' OR :type = '" + TYPE_ALL
@@ -65,4 +76,6 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
 
     @Query(value = "SELECT p FROM Performance p ORDER BY RAND() LIMIT 5")
     List<Performance> findTop5ByRand();
+
+    Optional<Performance> findPerformanceByIdAndEndAtGreaterThanEqualOrderByStartAt(long performanceId, LocalDate date);
 }

--- a/src/main/java/org/sopt/confeti/global/common/constant/Default.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/Default.java
@@ -6,8 +6,9 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class Default {
 
-    public static String IMG_PATH = "default/img_logo_3d.svg";
-    public static String URL = "https://www.naver.com/";
-    public static String TEXT = "CONFETI";
-    public static String PROFILE_IMG_NAME = "user-profile.svg";
+    public static final String IMG_PATH = "default/img_logo_3d.svg";
+    public static final String URL = "https://www.naver.com/";
+    public static final String TEXT = "CONFETI";
+    public static final String PROFILE_IMG_NAME = "user-profile.svg";
+    public static final String PERFORMANCE_TYPE = "performance";
 }

--- a/src/main/java/org/sopt/confeti/global/common/constant/PerformanceType.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/PerformanceType.java
@@ -9,7 +9,7 @@ import org.sopt.confeti.global.message.ErrorMessage;
 @Getter
 @AllArgsConstructor
 public enum PerformanceType {
-    CONCERT("concert"), FESTIVAL("festival");
+    CONCERT("concert"), FESTIVAL("festival"), PERFORMANCE("performance");
 
     private final String type;
 

--- a/src/main/java/org/sopt/confeti/global/config/WebMvcConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/WebMvcConfig.java
@@ -2,8 +2,10 @@ package org.sopt.confeti.global.config;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.global.converter.StringToPerformanceTypeConverter;
 import org.sopt.confeti.global.resolver.user.UserIdArgumentResolver;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.format.FormatterRegistry;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
 
@@ -15,5 +17,10 @@ public class WebMvcConfig implements WebMvcConfigurer {
     @Override
     public void addArgumentResolvers(List<HandlerMethodArgumentResolver> resolvers) {
         resolvers.add(userIdArgumentResolver);
+    }
+
+    @Override
+    public void addFormatters(FormatterRegistry registry) {
+        registry.addConverter(new StringToPerformanceTypeConverter());
     }
 }

--- a/src/main/java/org/sopt/confeti/global/converter/StringToPerformanceTypeConverter.java
+++ b/src/main/java/org/sopt/confeti/global/converter/StringToPerformanceTypeConverter.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.global.converter;
+
+import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.springframework.core.convert.converter.Converter;
+
+public class StringToPerformanceTypeConverter implements Converter<String, PerformanceType> {
+
+    @Override
+    public PerformanceType convert(String source) {
+        try {
+            return PerformanceType.convert(source);
+        } catch (ConfetiException | IllegalArgumentException e) {
+            return null;
+        }
+    }
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #336 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 예정된 공연 목록 조회 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/779fe2e0-e7f4-47f5-acec-5709040e4a99" />
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/f8019796-95a7-4da1-ac68-a047c8c76c20" />
<img width="1066" alt="image" src="https://github.com/user-attachments/assets/df3bb0cb-7402-4bb9-905e-6606adf682bf" />

예정된 공연이 조회되는 경우는 크게 세 가지가 존재해요.

1. 특정 아티스트가 출연하는 공연을 조회
    a. 아티스트 아이디를 기준
2. 특정 공연을 조회
    a. 공연 아이디를 기준
3. 특정 아티스트가 출연하는 공연 중 타입을 결정해서 조회
    a. 콘서트 | 페스티벌 | 공연 (콘서트 + 페스티벌) 타입이 존재
    b. 아티스트 아이디를 기준

따라서, 경우를 나눠서 요청을 하자면 다음의 쿼리 파라미터를 포함해야 해요.

1. 사용자가 아티스트 연관 검색어를 클릭한 경우
    a. aid
2. 사용자가 공연 연관 검색어를 클릭한 경우
    a. pid
3. 사용자가 검색어에 키워드 (”콘서트”, “페스티벌”, “공연”)을 포함해 엔터를 누른 경우
    a. aid
    b. ptype
    
이 경우, 통합 검색 API에서 사용자가 입력한 값을 형태소 분석한 뒤 “아티스트 아이디”와 “어떤 공연 타입”을 조회해야하는지에 대한 정보를 반환할 예정입니다.