### PR TITLE
fix [#342] 아티스트 연관 검색어 조회 API에서 조회 결과가 없을 때 빈 값을 주도록 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -152,6 +152,10 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
     }
 
     private List<ConfetiArtist> convertToConfetiArtists(final AppleMusicArtistsResponse artists) {
+        if (Objects.isNull(artists)) {
+            return List.of();
+        }
+
         return artists.data().stream()
                 .map(ConfetiArtist::from)
                 .toList();


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #342

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 아티스트 연관 검색어 조회 API에서 조회 결과가 없을 때 빈 값을 주도록 변경


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1059" alt="image" src="https://github.com/user-attachments/assets/46578e69-e482-4453-852f-8fd6f8595a16" />
![image](https://github.com/user-attachments/assets/3fd1bf18-9420-467e-9386-327b9c4d47ee)
조회 결과가 없을 때는 응답이 Null로 옵니다. 그래서 Null 검사 이후 빈 배열을 반환했습니다.