### PR TITLE
feat [#333] 선호 공연 출연 아티스트 음악 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -11,6 +11,7 @@ import org.sopt.confeti.api.performance.dto.response.PerformanceReservationRespo
 import org.sopt.confeti.api.performance.dto.response.RecentPerformancesResponse;
 import org.sopt.confeti.api.performance.dto.response.RecommendPerformancesResponse;
 import org.sopt.confeti.api.performance.dto.response.SearchACPerformancesResponse;
+import org.sopt.confeti.api.performance.dto.response.*;
 import org.sopt.confeti.api.performance.facade.PerformanceFacade;
 import org.sopt.confeti.api.performance.facade.dto.response.AnalyzePerformanceTypeDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
@@ -21,6 +22,7 @@ import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservati
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.SearchACPerformancesDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.*;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
@@ -144,5 +146,15 @@ public class PerformanceController {
         AnalyzePerformanceTypeDTO analyzePerformanceTypeDTO = performanceFacade.analyzePerformanceType(term);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 AnalyzePerformanceTypeResponse.from(analyzePerformanceTypeDTO));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/recommend/musics")
+    public ResponseEntity<BaseResponse<?>> getRecommendMusics(
+            @UserId(require = false) Long userId
+    ) {
+        RecommendMusicsDTO recommendMusicsDTO = performanceFacade.getRecommendMusics(userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                RecommendMusicsResponse.from(recommendMusicsDTO));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicDTO;
+
+public record RecommendMusicResponse(
+        String artistName,
+        String title,
+        String artWorkUrl,
+        String previewUrl
+) {
+    public static RecommendMusicResponse from(RecommendMusicDTO recommendMusicDTO) {
+        return new RecommendMusicResponse(
+                recommendMusicDTO.artistName(),
+                recommendMusicDTO.title(),
+                recommendMusicDTO.artWorkUrl(),
+                recommendMusicDTO.previewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicsResponse.java
@@ -6,6 +6,7 @@ import org.sopt.confeti.global.common.constant.PerformanceType;
 import java.util.List;
 
 public record RecommendMusicsResponse(
+        Long id,
         Long typeId,
         PerformanceType type,
         String title,
@@ -13,6 +14,7 @@ public record RecommendMusicsResponse(
 ) {
     public static RecommendMusicsResponse from(RecommendMusicsDTO recommendMusicsDTO) {
         return new RecommendMusicsResponse(
+                recommendMusicsDTO.id(),
                 recommendMusicsDTO.typeId(),
                 recommendMusicsDTO.type(),
                 recommendMusicsDTO.title(),

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicsResponse.java
@@ -1,0 +1,24 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsDTO;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+import java.util.List;
+
+public record RecommendMusicsResponse(
+        Long typeId,
+        PerformanceType type,
+        String title,
+        List<RecommendMusicResponse> musicList
+) {
+    public static RecommendMusicsResponse from(RecommendMusicsDTO recommendMusicsDTO) {
+        return new RecommendMusicsResponse(
+                recommendMusicsDTO.typeId(),
+                recommendMusicsDTO.type(),
+                recommendMusicsDTO.title(),
+                recommendMusicsDTO.musicList().stream()
+                        .map(RecommendMusicResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -10,6 +10,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import kr.co.shineware.nlp.komoran.model.KomoranResult;
+import java.util.stream.Collectors;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.facade.dto.response.AnalyzePerformanceTypeDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
@@ -21,6 +23,7 @@ import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservati
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.SearchACPerformancesDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.*;
 import org.sopt.confeti.api.user.facade.UserFavoriteFacade;
 import org.sopt.confeti.domain.artist_favorite.ArtistFavorite;
 import org.sopt.confeti.domain.artist_favorite.application.ArtistFavoriteService;
@@ -33,6 +36,7 @@ import org.sopt.confeti.domain.festival.application.FestivalService;
 import org.sopt.confeti.domain.festival_favorite.application.FestivalFavoriteService;
 import org.sopt.confeti.domain.user.application.UserService;
 import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.domain.view.performance.PerformanceArtist;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
@@ -42,6 +46,9 @@ import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.util.MorphemeAnalyzer;
+import org.sopt.confeti.global.resolver.music_api.MusicAPIResolver;
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.transaction.annotation.Transactional;
 
 @Facade
@@ -61,7 +68,7 @@ public class PerformanceFacade {
     private final ConcertFavoriteService concertFavoriteService;
     private final ArtistFavoriteService artistFavoriteService;
     private final PerformanceSearchService performanceSearchService;
-    private final UserFavoriteFacade userFavoriteFacade;
+    private final MusicAPIHandler musicAPIHandler;
 
     @Transactional(readOnly = true)
     public ConcertDetailDTO getConcertDetailInfo(final Long userId, final long concertId) {
@@ -294,5 +301,34 @@ public class PerformanceFacade {
         String processedTerm = MorphemeAnalyzer.getRemovedPerformanceTypesTerm(term, analyzeResult);
 
         return AnalyzePerformanceTypeDTO.of(processedTerm, performanceType);
+    }
+
+    @Transactional(readOnly = true)
+    public RecommendMusicsDTO getRecommendMusics(final Long userId) {
+
+        Performance performance = performanceService.getPerformanceByUserFavorites(userId);
+        if( userId == null || performance == null){
+            performance = performanceService.getPerformanceByRand();
+        }
+
+        Set<String> selectedArtistIds = setArtistsByRandom(performance);
+        List<ConfetiMusic> musicList = musicAPIHandler.getMusicsByArtistIds(selectedArtistIds);
+
+        return RecommendMusicsDTO.of(performance, musicList);
+    }
+
+    protected Set<String> setArtistsByRandom(Performance performance) {
+        List<PerformanceArtist> performanceArtists = performance.getArtists();
+
+        if (performanceArtists.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        List<String> artistList = performanceArtists.stream()
+                .map(PerformanceArtist::getArtistId).distinct().collect(Collectors.toList());
+        Collections.shuffle(artistList);
+
+        int artistCount = Math.min(artistList.size(), 3);
+        return new HashSet<>(artistList.subList(0, artistCount));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicDTO.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+
+public record RecommendMusicDTO(
+        String artistName,
+        String title,
+        String artWorkUrl,
+        String previewUrl
+) {
+    public static RecommendMusicDTO from(ConfetiMusic music) {
+        return new RecommendMusicDTO(
+                music.getArtistName(),
+                music.getTitle(),
+                music.getArtworkUrl(),
+                music.getPreviewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicsDTO.java
@@ -1,0 +1,25 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+
+import java.util.List;
+
+public record RecommendMusicsDTO(
+        Long typeId,
+        PerformanceType type,
+        String title,
+        List<RecommendMusicDTO> musicList
+) {
+    public static RecommendMusicsDTO of(Performance performance, List<ConfetiMusic> musicList) {
+        return new RecommendMusicsDTO(
+                performance.getTypeId(),
+                performance.getType(),
+                performance.getTitle(),
+                musicList.stream()
+                        .map(RecommendMusicDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicsDTO.java
@@ -7,6 +7,7 @@ import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 import java.util.List;
 
 public record RecommendMusicsDTO(
+        Long id,
         Long typeId,
         PerformanceType type,
         String title,
@@ -14,6 +15,7 @@ public record RecommendMusicsDTO(
 ) {
     public static RecommendMusicsDTO of(Performance performance, List<ConfetiMusic> musicList) {
         return new RecommendMusicsDTO(
+                performance.getId(),
                 performance.getTypeId(),
                 performance.getType(),
                 performance.getTitle(),

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -141,4 +141,14 @@ public class PerformanceService {
                 .map(PerformanceDTO::from)
                 .toList();
     }
+
+    @Transactional(readOnly = true)
+    public Performance getPerformanceByRand(){
+        return performanceRepository.findPerformanceByRand();
+    }
+
+    @Transactional(readOnly = true)
+    public Performance getPerformanceByUserFavorites(final Long userId) {
+        return performanceRepository.getPerformanceByUserFavorites(userId);
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -78,4 +78,16 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     List<Performance> findTop5ByRand();
 
     Optional<Performance> findPerformanceByIdAndEndAtGreaterThanEqualOrderByStartAt(long performanceId, LocalDate date);
+
+    @Query(value = "SELECT p FROM Performance p ORDER BY RAND() LIMIT 1")
+    Performance findPerformanceByRand();
+
+    @Query(value = "SELECT p FROM Performance p " +
+            "WHERE ((p.type = org.sopt.confeti.global.common.constant.PerformanceType.CONCERT " +
+            "        AND p.typeId IN (SELECT cf.concert.id FROM ConcertFavorite cf WHERE cf.user.id = :userId)) " +
+            "    OR (p.type = org.sopt.confeti.global.common.constant.PerformanceType.FESTIVAL " +
+            "        AND p.typeId IN (SELECT tf.festival.id FROM TimetableFestival tf WHERE tf.user.id = :userId))) " +
+            "AND p.endAt >= CURRENT_DATE " +
+            "ORDER BY RAND() ASC LIMIT 1 ")
+    Performance getPerformanceByUserFavorites(final @Param("userId") Long userId);
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -74,12 +74,12 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             "ORDER BY p.startAt ASC LIMIT 1 ")
     Optional<Performance> upcomingPerformance(final @Param("userId") long userId);
 
-    @Query(value = "SELECT p FROM Performance p ORDER BY RAND() LIMIT 5")
+    @Query(value = "SELECT p FROM Performance p WHERE p.endAt >= CURRENT_DATE ORDER BY RAND() LIMIT 5")
     List<Performance> findTop5ByRand();
 
     Optional<Performance> findPerformanceByIdAndEndAtGreaterThanEqualOrderByStartAt(long performanceId, LocalDate date);
 
-    @Query(value = "SELECT p FROM Performance p ORDER BY RAND() LIMIT 1")
+    @Query(value = "SELECT p FROM Performance p WHERE p.endAt >= CURRENT_DATE ORDER BY RAND() LIMIT 1")
     Performance findPerformanceByRand();
 
     @Query(value = "SELECT p FROM Performance p " +

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -1,13 +1,8 @@
 package org.sopt.confeti.global.util.music;
 
 import jakarta.annotation.PostConstruct;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
-import java.util.Set;
+
+import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -294,5 +289,46 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         if (fetchSize > CHARTS_FETCH_LIMIT) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
+    }
+
+    @Override
+    @RetryOnTokenExpire
+    public List<ConfetiMusic> getMusicsByArtistIds(final Set<String> artistIds) {
+        if (artistIds.isEmpty()) {
+            return Collections.emptyList();
+        }
+
+        int totalArtists = artistIds.size();
+        List<String> artistIdList = new ArrayList<>(artistIds);
+        List<ConfetiMusic> resultMusics = new ArrayList<>();
+
+        if (totalArtists == 1) {
+            resultMusics.addAll(getTopSongsByArtistId(artistIdList.get(0), 3));
+        } else if (totalArtists == 2) {
+            resultMusics.addAll(getTopSongsByArtistId(artistIdList.get(0), 1));
+            resultMusics.addAll(getTopSongsByArtistId(artistIdList.get(1), 2));
+        } else {
+            for (int i = 0; i < Math.min(totalArtists, 3); i++) {
+                resultMusics.addAll(getTopSongsByArtistId(artistIdList.get(i), 1));
+            }
+        }
+
+        return resultMusics;
+    }
+
+    public List<ConfetiMusic> getTopSongsByArtistId(final String artistId, final int fetchSize) {
+        Map<String, String> params = new HashMap<>();
+        params.put("limit", String.valueOf(fetchSize));
+
+        return convertToConfetiMusics(
+                restClient.request()
+                        .get()
+                        .baseUrl(appleMusicAPIURL.getBaseUrl())
+                        .path(appleMusicAPIURL.getArtistRelationshipViewByNamePath(artistId, "top-songs"))
+                        .params(MultiValueMap.fromSingleValue(params))
+                        .build()
+                        .connect(headers)
+                        .retrieve(AppleMusicMusicsResponse.class)
+        );
     }
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -22,4 +22,6 @@ public interface MusicAPIHandler {
     List<ConfetiMusic> getMusicsByMusicIds(final Set<String> musicIds);
 
     List<ConfetiMusic> getTopMusics(final int fetchSize);
+
+    List<ConfetiMusic> getMusicsByArtistIds(final Set<String> artistIds);
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #333

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MusicApiHandler 아티스트 Id 리스트로 음악 조회 가능하도록 추가 
- [x] 선호 공연 출연 아티스트 음악 조회 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
MusicApiHandler에 아티스트 ID 리스트를 기반으로 음악을 조회할 수 있는 기능을 추가했습니다.
현재는 아티스트 ID의 개수에 따라 AppleMusicApiHandler에서 조회하는 곡 수가 달라지도록 설정해두었지만, 확장성 측면에서 현재 구현한 코드가 좋은 방법이 아니라 생각해 이 부분은 스프린트 끝나고 여유가 생기면 리팩토링하겠습니다!
<img width="667" alt="스크린샷 2025-04-23 오전 12 01 03" src="https://github.com/user-attachments/assets/31fecbcb-a2d1-4620-867d-51a6de5aea3d" />

