### PR TITLE
feat [#274] MY 셋리스트 > 공연 전체보기 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
@@ -1,0 +1,33 @@
+package org.sopt.confeti.api.setlist;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.setlist.SetlistSortType;
+import org.sopt.confeti.domain.setlist.application.SetlistService;
+import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my/setlists")
+public class SetlistController {
+
+    private final SetlistService setlistService;
+
+    @GetMapping("/all")
+    public ResponseEntity<BaseResponse<?>> getAllMySetlists(
+            @AuthenticationPrincipal Long userId,
+            @RequestParam(required = false) String sort
+    ) {
+        SetlistSortType sortType = SetlistSortType.from(sort);
+        GetAllSetlistsResponse data = setlistService.getAllMySetlists(userId, sortType);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/Setlist.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/Setlist.java
@@ -1,0 +1,44 @@
+package org.sopt.confeti.domain.setlist;
+
+import jakarta.persistence.*;
+import java.util.*;
+import lombok.*;
+import org.sopt.confeti.domain.user.User;
+
+@Entity
+@Table(name = "setlists")
+@Getter
+@NoArgsConstructor
+@AllArgsConstructor
+public class Setlist {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private SetlistType type;
+
+    @Column(name = "type_id", nullable = false)
+    private Long typeId;
+
+    @OneToMany(mappedBy = "setlist", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<SetlistMusic> musics = new ArrayList<>();
+
+    @Builder
+    public Setlist(User user, SetlistType type, Long typeId) {
+        this.user = user;
+        this.type = type;
+        this.typeId = typeId;
+    }
+
+    public void addMusics(SetlistMusic music) {
+        musics.add(music);
+        music.setSetlist(this);
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/SetlistMusic.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/SetlistMusic.java
@@ -1,0 +1,52 @@
+package org.sopt.confeti.domain.setlist;
+
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "setlist_musics")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class SetlistMusic {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "setlist_id", nullable = false)
+    private Setlist setlist;
+
+    @Column(name = "artist_name", nullable = false)
+    private String artistName;
+
+    @Column(name = "track_name", nullable = false)
+    private String trackName;
+
+    @Column(name = "artwork_url")
+    private String artworkUrl;
+
+    @Column(name = "preview_url")
+    private String previewUrl;
+
+    @Column(name = "orders", nullable = false)
+    private int orders;
+
+    @Builder
+    public SetlistMusic(String artistName, String trackName, String artworkUrl, String previewUrl, int orders) {
+        this.artistName = artistName;
+        this.trackName = trackName;
+        this.artworkUrl = artworkUrl;
+        this.previewUrl = previewUrl;
+        this.orders = orders;
+    }
+
+    public void setSetlist(Setlist setlist) {
+        this.setlist = setlist;
+    }
+
+    public void changeOrder(int newOrder) {
+        this.orders = newOrder;
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/SetlistSortType.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/SetlistSortType.java
@@ -1,0 +1,28 @@
+package org.sopt.confeti.domain.setlist;
+
+import java.util.Arrays;
+
+public enum SetlistSortType {
+    OLDEST("oldest"),
+    LATEST("latest");
+
+    private final String value;
+
+    SetlistSortType(String value) {
+        this.value = value;
+    }
+
+    public static SetlistSortType from(String value) {
+        if (value == null || value.isBlank())
+            return OLDEST;
+        return Arrays.stream(values())
+                .filter(type -> type.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElse(OLDEST);
+    }
+
+    public String getValue() {
+        return value;
+    }
+}
+

--- a/src/main/java/org/sopt/confeti/domain/setlist/SetlistType.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/SetlistType.java
@@ -1,0 +1,5 @@
+package org.sopt.confeti.domain.setlist;
+
+public enum SetlistType {
+    CONCERT, FESTIVAL
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -1,0 +1,58 @@
+package org.sopt.confeti.domain.setlist.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.concert.Concert;
+import org.sopt.confeti.domain.concert.infra.repository.ConcertRepository;
+import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
+import org.sopt.confeti.domain.setlist.Setlist;
+import org.sopt.confeti.domain.setlist.SetlistSortType;
+import org.sopt.confeti.domain.setlist.SetlistType;
+import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
+import org.sopt.confeti.global.exception.NotFoundException;
+import org.sopt.confeti.global.message.ErrorMessage;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class SetlistService {
+
+    private final SetlistRepository setlistRepository;
+    private final ConcertRepository concertRepository;
+    private final FestivalRepository festivalRepository;
+
+    @Transactional(readOnly = true)
+    public GetAllSetlistsResponse getAllMySetlists(Long userId, SetlistSortType sortType) {
+        List<Setlist> setlists = setlistRepository.findAllByUserId(userId);
+
+        List<SetlistSummaryDto> dtoList = setlists.stream()
+                .map(setlist -> {
+                    if (setlist.getType() == SetlistType.CONCERT) {
+                        Concert concert = concertRepository.findById(setlist.getTypeId())
+                                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+                        return SetlistSummaryDto.of(
+                                setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt());
+                    } else {
+                        Festival festival = festivalRepository.findById(setlist.getTypeId())
+                                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+                        return SetlistSummaryDto.of(
+                                setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt());
+                    }
+                })
+                .sorted((a, b) -> {
+                    if (sortType == SetlistSortType.OLDEST) {
+                        return a.endAt().compareTo(b.endAt());
+                    } else {
+                        return b.endAt().compareTo(a.endAt());
+                    }
+                })
+                .toList();
+
+        return new GetAllSetlistsResponse(dtoList.size(), dtoList);
+    }
+
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/GetAllSetlistsResponse.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/GetAllSetlistsResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.domain.setlist.application.dto.response;
+
+import java.util.List;
+
+public record GetAllSetlistsResponse(
+        int totalCount,
+        List<SetlistSummaryDto> setlists
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistSummaryDto.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistSummaryDto.java
@@ -1,0 +1,24 @@
+package org.sopt.confeti.domain.setlist.application.dto.response;
+
+import java.time.LocalDate;
+import org.sopt.confeti.domain.setlist.Setlist;
+
+public record SetlistSummaryDto(
+        Long setlistId,
+        String type,
+        Long typeId,
+        String title,
+        String posterUrl,
+        LocalDate endAt
+) {
+    public static SetlistSummaryDto of(Setlist setlist, String title, String posterUrl, LocalDate endAt) {
+        return new SetlistSummaryDto(
+                setlist.getId(),
+                setlist.getType().name(),
+                setlist.getTypeId(),
+                title,
+                posterUrl,
+                endAt
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.domain.setlist.infra.repository;
+
+import java.util.List;
+import org.sopt.confeti.domain.setlist.Setlist;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface SetlistRepository extends JpaRepository<Setlist, Long> {
+
+    @Query("SELECT s FROM Setlist s WHERE s.user.id = :userId")
+    List<Setlist> findAllByUserId(@Param("userId") Long userId);
+}

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -1,0 +1,204 @@
+package org.sopt.confeti.domain.setlist.application;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+
+import java.time.LocalDate;
+import java.util.List;
+import java.util.Optional;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.confeti.domain.concert.Concert;
+import org.sopt.confeti.domain.concert.infra.repository.ConcertRepository;
+import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
+import org.sopt.confeti.domain.setlist.*;
+import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
+import org.sopt.confeti.domain.user.OAuthProvider;
+import org.sopt.confeti.domain.user.User;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class SetlistServiceTest {
+
+    @InjectMocks
+    private SetlistService setlistService;
+
+    @Mock
+    private SetlistRepository setlistRepository;
+    @Mock
+    private ConcertRepository concertRepository;
+    @Mock
+    private FestivalRepository festivalRepository;
+
+    @Test
+    void 셋리스트_전체조회_OLDEST() {
+        // given
+        Long userId = 1L;
+        User mockUser = User.builder()
+                .provider(OAuthProvider.KAKAO)
+                .socialId("kakao-123")
+                .name("테스트 유저")
+                .profilePath("profile.jpg")
+                .role(Role.GENERAL)
+                .build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);
+
+        Setlist concertSetlist = Setlist.builder()
+                .user(mockUser)
+                .type(SetlistType.CONCERT)
+                .typeId(100L)
+                .build();
+
+        Setlist festivalSetlist = Setlist.builder()
+                .user(mockUser)
+                .type(SetlistType.FESTIVAL)
+                .typeId(200L)
+                .build();
+
+        Concert concert = Concert.builder()
+                .title("IU 콘서트")
+                .subtitle("Love Poem")
+                .startAt(LocalDate.of(2024, 11, 1))
+                .endAt(LocalDate.of(2024, 11, 3))
+                .area("서울")
+                .posterPath("iu.jpg")
+                .posterBgPath("bg.jpg")
+                .concertInfoImgPath("info.jpg")
+                .reserveAt(LocalDate.now().atStartOfDay())
+                .reservationUrl("url")
+                .reservationOffice("office")
+                .ageRating("전체관람가")
+                .time("18:00")
+                .price("99,000원")
+                .address("서울 올림픽공원")
+                .artists(List.of())
+                .musics(List.of())
+                .reservationUrls(List.of())
+                .build();
+
+        Festival festival = Festival.builder()
+                .title("서울재즈페스티벌")
+                .subtitle("2024 Edition")
+                .startAt(LocalDate.of(2024, 4, 28))
+                .endAt(LocalDate.of(2024, 5, 1))
+                .area("서울")
+                .posterPath("jazz.jpg")
+                .posterBgPath("bg.jpg")
+                .festivalInfoImgPath("info.jpg")
+                .logoPath("logo.jpg")
+                .reserveAt(LocalDate.now().atStartOfDay())
+                .reservationUrl("url")
+                .reservationOffice("office")
+                .ageRating("19세 이상")
+                .time("14:00")
+                .price("79,000원")
+                .address("서울 난지공원")
+                .dates(List.of())
+                .musics(List.of())
+                .reservationUrls(List.of())
+                .build();
+
+        given(setlistRepository.findAllByUserId(userId)).willReturn(List.of(concertSetlist, festivalSetlist));
+        given(concertRepository.findById(100L)).willReturn(Optional.of(concert));
+        given(festivalRepository.findById(200L)).willReturn(Optional.of(festival));
+
+        // when
+        GetAllSetlistsResponse response = setlistService.getAllMySetlists(userId, SetlistSortType.OLDEST);
+
+        // then
+        assertThat(response.totalCount()).isEqualTo(2);
+        assertThat(response.setlists())
+                .extracting(SetlistSummaryDto::title)
+                .containsExactly("서울재즈페스티벌", "IU 콘서트"); // endAt 기준 오름차순 정렬
+    }
+
+    @Test
+    void 셋리스트_전체조회_LATEST() {
+        // given
+        Long userId = 1L;
+        User mockUser = User.builder()
+                .provider(OAuthProvider.KAKAO)
+                .socialId("kakao-123")
+                .name("테스트 유저")
+                .profilePath("profile.jpg")
+                .role(Role.GENERAL)
+                .build();
+        ReflectionTestUtils.setField(mockUser, "id", userId);
+
+        Setlist concertSetlist = Setlist.builder()
+                .user(mockUser)
+                .type(SetlistType.CONCERT)
+                .typeId(100L)
+                .build();
+
+        Setlist festivalSetlist = Setlist.builder()
+                .user(mockUser)
+                .type(SetlistType.FESTIVAL)
+                .typeId(200L)
+                .build();
+
+        Concert concert = Concert.builder()
+                .title("IU 콘서트")
+                .subtitle("Love Poem")
+                .startAt(LocalDate.of(2024, 11, 1))
+                .endAt(LocalDate.of(2024, 11, 3))
+                .area("서울")
+                .posterPath("iu.jpg")
+                .posterBgPath("bg.jpg")
+                .concertInfoImgPath("info.jpg")
+                .reserveAt(LocalDate.now().atStartOfDay())
+                .reservationUrl("url")
+                .reservationOffice("office")
+                .ageRating("전체관람가")
+                .time("18:00")
+                .price("99,000원")
+                .address("서울 올림픽공원")
+                .artists(List.of())
+                .musics(List.of())
+                .reservationUrls(List.of())
+                .build();
+
+        Festival festival = Festival.builder()
+                .title("서울재즈페스티벌")
+                .subtitle("2024 Edition")
+                .startAt(LocalDate.of(2024, 4, 28))
+                .endAt(LocalDate.of(2024, 5, 1))
+                .area("서울")
+                .posterPath("jazz.jpg")
+                .posterBgPath("bg.jpg")
+                .festivalInfoImgPath("info.jpg")
+                .logoPath("logo.jpg")
+                .reserveAt(LocalDate.now().atStartOfDay())
+                .reservationUrl("url")
+                .reservationOffice("office")
+                .ageRating("19세 이상")
+                .time("14:00")
+                .price("79,000원")
+                .address("서울 난지공원")
+                .dates(List.of())
+                .musics(List.of())
+                .reservationUrls(List.of())
+                .build();
+
+        given(setlistRepository.findAllByUserId(userId)).willReturn(List.of(concertSetlist, festivalSetlist));
+        given(concertRepository.findById(100L)).willReturn(Optional.of(concert));
+        given(festivalRepository.findById(200L)).willReturn(Optional.of(festival));
+
+        // when
+        GetAllSetlistsResponse response = setlistService.getAllMySetlists(userId, SetlistSortType.LATEST);
+
+        // then
+        assertThat(response.totalCount()).isEqualTo(2);
+        assertThat(response.setlists())
+                .extracting(SetlistSummaryDto::title)
+                .containsExactly("IU 콘서트", "서울재즈페스티벌"); // endAt 기준 내림차순 정렬
+    }
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #274 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 공연 전체보기 목록 조회 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- MY 셋리스트 > 공연 전체보기 목록을 조회하는 API를 구현했습니다!
- 현재는 `Mock`을 이용해 핵심 비즈니스로직에 대한 테스트코드만 작성하는 방식으로 진행했으나, 이후 셋리스트 추가 API 개발 이후 `POSTMAN`으로 추가적인 연동테스트 진행 예정입니다.
- 정렬기준(OLDEST, LATEST) 에 따라 콘서트/페스티벌이 정렬되어 조회됩니다.
- type(FESTIVAL, CONTEST)별로 typeId를 조회해 해당 정보를 조회하도록 구현했습니다.

### 테스트
<img width="371" alt="image" src="https://github.com/user-attachments/assets/bbeff503-e43e-492b-a271-8a1b90c49777" />

