### PR TITLE
feat [#350] MY 셋리스트 > 공연 미리보기 목록 조회 API 구현 

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
@@ -1,9 +1,11 @@
 package org.sopt.confeti.api.setlist;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.application.SetlistService;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
@@ -32,6 +34,15 @@ public class SetlistController {
     ) {
         SetlistSortType sortType = SetlistSortType.from(sort);
         GetAllSetlistsResponse data = setlistService.getAllMySetlists(userId, sortType);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/preview")
+    public ResponseEntity<BaseResponse<?>> getPreviewMySetlists(
+            @UserId(require = false) Long userId
+    ) {
+        List<SetlistSummaryDto> data = setlistService.getPreviewMySetlists(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
@@ -4,6 +4,9 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.application.SetlistService;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
@@ -21,9 +24,10 @@ public class SetlistController {
 
     private final SetlistService setlistService;
 
+    @Permission(role = {Role.GENERAL})
     @GetMapping("/all")
     public ResponseEntity<BaseResponse<?>> getAllMySetlists(
-            @AuthenticationPrincipal Long userId,
+            @UserId(require = false) Long userId,
             @RequestParam(required = false) String sort
     ) {
         SetlistSortType sortType = SetlistSortType.from(sort);

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.domain.setlist.application;
 
+import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.concert.Concert;
@@ -55,4 +56,26 @@ public class SetlistService {
         return new GetAllSetlistsResponse(dtoList.size(), dtoList);
     }
 
+    @Transactional(readOnly = true)
+    public List<SetlistSummaryDto> getPreviewMySetlists(Long userId) {
+        List<Setlist> setlists = setlistRepository.findAllByUserId(userId);
+
+        return setlists.stream()
+                .map(setlist -> {
+                    if (setlist.getType() == SetlistType.CONCERT) {
+                        Concert concert = concertRepository.findById(setlist.getTypeId())
+                                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+                        return SetlistSummaryDto.of(
+                                setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt());
+                    } else {
+                        Festival festival = festivalRepository.findById(setlist.getTypeId())
+                                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+                        return SetlistSummaryDto.of(
+                                setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt());
+                    }
+                })
+                .sorted(Comparator.comparing(SetlistSummaryDto::endAt))
+                .limit(3)
+                .toList();
+    }
 }

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
@@ -31,174 +32,128 @@ class SetlistServiceTest {
     @InjectMocks
     private SetlistService setlistService;
 
-    @Mock
-    private SetlistRepository setlistRepository;
-    @Mock
-    private ConcertRepository concertRepository;
-    @Mock
-    private FestivalRepository festivalRepository;
+    @Mock private SetlistRepository setlistRepository;
+    @Mock private ConcertRepository concertRepository;
+    @Mock private FestivalRepository festivalRepository;
+
+    private final Long userId = 1L;
+    private final User user = mockUser(userId);
 
     @Test
     void 셋리스트_전체조회_OLDEST() {
-        // given
-        Long userId = 1L;
-        User mockUser = User.builder()
-                .provider(OAuthProvider.KAKAO)
-                .socialId("kakao-123")
-                .name("테스트 유저")
-                .profilePath("profile.jpg")
-                .role(Role.GENERAL)
-                .build();
-        ReflectionTestUtils.setField(mockUser, "id", userId);
-
-        Setlist concertSetlist = Setlist.builder()
-                .user(mockUser)
-                .type(SetlistType.CONCERT)
-                .typeId(100L)
-                .build();
-
-        Setlist festivalSetlist = Setlist.builder()
-                .user(mockUser)
-                .type(SetlistType.FESTIVAL)
-                .typeId(200L)
-                .build();
-
-        Concert concert = Concert.builder()
-                .title("IU 콘서트")
-                .subtitle("Love Poem")
-                .startAt(LocalDate.of(2024, 11, 1))
-                .endAt(LocalDate.of(2024, 11, 3))
-                .area("서울")
-                .posterPath("iu.jpg")
-                .posterBgPath("bg.jpg")
-                .concertInfoImgPath("info.jpg")
-                .reserveAt(LocalDate.now().atStartOfDay())
-                .reservationUrl("url")
-                .reservationOffice("office")
-                .ageRating("전체관람가")
-                .time("18:00")
-                .price("99,000원")
-                .address("서울 올림픽공원")
-                .artists(List.of())
-                .musics(List.of())
-                .reservationUrls(List.of())
-                .build();
-
-        Festival festival = Festival.builder()
-                .title("서울재즈페스티벌")
-                .subtitle("2024 Edition")
-                .startAt(LocalDate.of(2024, 4, 28))
-                .endAt(LocalDate.of(2024, 5, 1))
-                .area("서울")
-                .posterPath("jazz.jpg")
-                .posterBgPath("bg.jpg")
-                .festivalInfoImgPath("info.jpg")
-                .logoPath("logo.jpg")
-                .reserveAt(LocalDate.now().atStartOfDay())
-                .reservationUrl("url")
-                .reservationOffice("office")
-                .ageRating("19세 이상")
-                .time("14:00")
-                .price("79,000원")
-                .address("서울 난지공원")
-                .dates(List.of())
-                .musics(List.of())
-                .reservationUrls(List.of())
-                .build();
+        Setlist concertSetlist = createSetlist(SetlistType.CONCERT, 100L);
+        Setlist festivalSetlist = createSetlist(SetlistType.FESTIVAL, 200L);
 
         given(setlistRepository.findAllByUserId(userId)).willReturn(List.of(concertSetlist, festivalSetlist));
-        given(concertRepository.findById(100L)).willReturn(Optional.of(concert));
-        given(festivalRepository.findById(200L)).willReturn(Optional.of(festival));
+        given(concertRepository.findById(100L)).willReturn(Optional.of(mockConcert("IU 콘서트", LocalDate.of(2024, 11, 3))));
+        given(festivalRepository.findById(200L)).willReturn(Optional.of(mockFestival("서울재즈페스티벌", LocalDate.of(2024, 5, 1))));
 
-        // when
-        GetAllSetlistsResponse response = setlistService.getAllMySetlists(userId, SetlistSortType.OLDEST);
+        GetAllSetlistsResponse result = setlistService.getAllMySetlists(userId, SetlistSortType.OLDEST);
 
-        // then
-        assertThat(response.totalCount()).isEqualTo(2);
-        assertThat(response.setlists())
-                .extracting(SetlistSummaryDto::title)
-                .containsExactly("서울재즈페스티벌", "IU 콘서트"); // endAt 기준 오름차순 정렬
+        assertThat(result.totalCount()).isEqualTo(2);
+        assertThat(result.setlists()).extracting(SetlistSummaryDto::title)
+                .containsExactly("서울재즈페스티벌", "IU 콘서트");
     }
 
     @Test
     void 셋리스트_전체조회_LATEST() {
-        // given
-        Long userId = 1L;
-        User mockUser = User.builder()
+        Setlist concertSetlist = createSetlist(SetlistType.CONCERT, 100L);
+        Setlist festivalSetlist = createSetlist(SetlistType.FESTIVAL, 200L);
+
+        given(setlistRepository.findAllByUserId(userId)).willReturn(List.of(concertSetlist, festivalSetlist));
+        given(concertRepository.findById(100L)).willReturn(Optional.of(mockConcert("IU 콘서트", LocalDate.of(2024, 11, 3))));
+        given(festivalRepository.findById(200L)).willReturn(Optional.of(mockFestival("서울재즈페스티벌", LocalDate.of(2024, 5, 1))));
+
+        GetAllSetlistsResponse result = setlistService.getAllMySetlists(userId, SetlistSortType.LATEST);
+
+        assertThat(result.totalCount()).isEqualTo(2);
+        assertThat(result.setlists()).extracting(SetlistSummaryDto::title)
+                .containsExactly("IU 콘서트", "서울재즈페스티벌");
+    }
+
+    @Test
+    void 셋리스트_미리보기_최대_3개까지만_오래된_순으로_반환() {
+        List<Setlist> setlists = List.of(
+                createSetlist(SetlistType.FESTIVAL, 201L),
+                createSetlist(SetlistType.FESTIVAL, 200L),
+                createSetlist(SetlistType.CONCERT, 100L),
+                createSetlist(SetlistType.CONCERT, 101L),
+                createSetlist(SetlistType.CONCERT, 102L)
+        );
+
+        given(setlistRepository.findAllByUserId(userId)).willReturn(setlists);
+        given(festivalRepository.findById(201L)).willReturn(Optional.of(mockFestival("F2", LocalDate.of(2024, 3, 1))));
+        given(festivalRepository.findById(200L)).willReturn(Optional.of(mockFestival("F1", LocalDate.of(2024, 4, 1))));
+        given(concertRepository.findById(100L)).willReturn(Optional.of(mockConcert("C1", LocalDate.of(2024, 5, 1))));
+        given(concertRepository.findById(101L)).willReturn(Optional.of(mockConcert("C2", LocalDate.of(2024, 6, 1))));
+        given(concertRepository.findById(102L)).willReturn(Optional.of(mockConcert("C3", LocalDate.of(2024, 7, 1))));
+
+        List<SetlistSummaryDto> result = setlistService.getPreviewMySetlists(userId);
+
+        assertThat(result).hasSize(3);
+        assertThat(result).extracting(SetlistSummaryDto::title).containsExactly("F2", "F1", "C1");
+    }
+
+    private static User mockUser(Long id) {
+        User user = User.builder()
                 .provider(OAuthProvider.KAKAO)
-                .socialId("kakao-123")
-                .name("테스트 유저")
+                .socialId("mock")
+                .name("mockUser")
                 .profilePath("profile.jpg")
                 .role(Role.GENERAL)
                 .build();
-        ReflectionTestUtils.setField(mockUser, "id", userId);
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
 
-        Setlist concertSetlist = Setlist.builder()
-                .user(mockUser)
-                .type(SetlistType.CONCERT)
-                .typeId(100L)
-                .build();
+    private Setlist createSetlist(SetlistType type, Long typeId) {
+        return Setlist.builder().user(user).type(type).typeId(typeId).build();
+    }
 
-        Setlist festivalSetlist = Setlist.builder()
-                .user(mockUser)
-                .type(SetlistType.FESTIVAL)
-                .typeId(200L)
-                .build();
-
-        Concert concert = Concert.builder()
-                .title("IU 콘서트")
-                .subtitle("Love Poem")
-                .startAt(LocalDate.of(2024, 11, 1))
-                .endAt(LocalDate.of(2024, 11, 3))
+    private Concert mockConcert(String title, LocalDate endAt) {
+        return Concert.builder()
+                .title(title)
+                .subtitle("sub")
+                .startAt(endAt.minusDays(2))
+                .endAt(endAt)
                 .area("서울")
-                .posterPath("iu.jpg")
+                .posterPath(title + ".jpg")
                 .posterBgPath("bg.jpg")
                 .concertInfoImgPath("info.jpg")
-                .reserveAt(LocalDate.now().atStartOfDay())
+                .reserveAt(LocalDateTime.now())
                 .reservationUrl("url")
                 .reservationOffice("office")
-                .ageRating("전체관람가")
+                .ageRating("ALL")
                 .time("18:00")
-                .price("99,000원")
-                .address("서울 올림픽공원")
+                .price("10000")
+                .address("서울시")
                 .artists(List.of())
                 .musics(List.of())
                 .reservationUrls(List.of())
                 .build();
+    }
 
-        Festival festival = Festival.builder()
-                .title("서울재즈페스티벌")
-                .subtitle("2024 Edition")
-                .startAt(LocalDate.of(2024, 4, 28))
-                .endAt(LocalDate.of(2024, 5, 1))
-                .area("서울")
-                .posterPath("jazz.jpg")
+    private Festival mockFestival(String title, LocalDate endAt) {
+        return Festival.builder()
+                .title(title)
+                .subtitle("sub")
+                .startAt(endAt.minusDays(2))
+                .endAt(endAt)
+                .area("부산")
+                .posterPath(title + ".jpg")
                 .posterBgPath("bg.jpg")
                 .festivalInfoImgPath("info.jpg")
                 .logoPath("logo.jpg")
-                .reserveAt(LocalDate.now().atStartOfDay())
+                .reserveAt(LocalDateTime.now())
                 .reservationUrl("url")
                 .reservationOffice("office")
-                .ageRating("19세 이상")
-                .time("14:00")
-                .price("79,000원")
-                .address("서울 난지공원")
+                .ageRating("ALL")
+                .time("16:00")
+                .price("8000")
+                .address("부산시")
                 .dates(List.of())
                 .musics(List.of())
                 .reservationUrls(List.of())
                 .build();
-
-        given(setlistRepository.findAllByUserId(userId)).willReturn(List.of(concertSetlist, festivalSetlist));
-        given(concertRepository.findById(100L)).willReturn(Optional.of(concert));
-        given(festivalRepository.findById(200L)).willReturn(Optional.of(festival));
-
-        // when
-        GetAllSetlistsResponse response = setlistService.getAllMySetlists(userId, SetlistSortType.LATEST);
-
-        // then
-        assertThat(response.totalCount()).isEqualTo(2);
-        assertThat(response.setlists())
-                .extracting(SetlistSummaryDto::title)
-                .containsExactly("IU 콘서트", "서울재즈페스티벌"); // endAt 기준 내림차순 정렬
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #350 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 공연 미리보기 목록 조회 API 구현 


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- MY 셋리스트 > 공연 미리보기 목록을 조회하는 API를 구현했습니다!
- 현재는 Mock을 이용해 핵심 비즈니스로직에 대한 테스트코드만 작성하는 방식으로 진행했으나, 이후 셋리스트 추가 API 개발 이후 POSTMAN으로 추가적인 연동테스트 진행 예정입니다.

단계 | 설명
-- | --
1 | 사용자 ID 기반 Setlist 전부 조회
2 | 공연 타입별로 해당 공연(Festival/Concert) 정보 병합
3 | 종료일 기준 정렬 후 3개로 제한
4 | SetlistSummaryDto 리스트로 변환

### 테스트
<img width="371" alt="image" src="https://github.com/user-attachments/assets/eea63839-b564-44ad-8e85-4ba0318ed817" />



