### PR TITLE
feat [#352] MY 셋리스트 > 공연 추가 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
@@ -4,7 +4,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.application.SetlistService;
+import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.domain.setlist.application.dto.response.SetlistCreateResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
@@ -13,8 +15,9 @@ import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -44,5 +47,15 @@ public class SetlistController {
     ) {
         List<SetlistSummaryDto> data = setlistService.getPreviewMySetlists(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @PostMapping
+    public ResponseEntity<BaseResponse<?>> createSetlists(
+            @UserId(require = false) Long userId,
+            @RequestBody List<SetlistCreateRequest> requests
+    ) {
+        List<Long> ids = setlistService.createSetLists(userId, requests);
+        return ApiResponseUtil.success(SuccessMessage.CREATED, new SetlistCreateResponse(ids));
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -10,9 +10,12 @@ import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
 import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.SetlistType;
+import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
+import org.sopt.confeti.domain.user.User;
+import org.sopt.confeti.domain.user.infra.repository.UserRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
@@ -25,6 +28,7 @@ public class SetlistService {
     private final SetlistRepository setlistRepository;
     private final ConcertRepository concertRepository;
     private final FestivalRepository festivalRepository;
+    private final UserRepository userRepository;
 
     @Transactional(readOnly = true)
     public GetAllSetlistsResponse getAllMySetlists(Long userId, SetlistSortType sortType) {
@@ -76,6 +80,22 @@ public class SetlistService {
                 })
                 .sorted(Comparator.comparing(SetlistSummaryDto::endAt))
                 .limit(3)
+                .toList();
+    }
+
+    @Transactional
+    public List<Long> createSetLists(Long userId, List<SetlistCreateRequest> requests) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+
+        return requests.stream()
+                .map(req -> Setlist.builder()
+                        .user(user)
+                        .type(req.type())
+                        .typeId(req.typeId())
+                        .build())
+                .map(setlistRepository::save)
+                .map(Setlist::getId)
                 .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.domain.setlist.application;
 import java.util.Comparator;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.infra.repository.ConcertRepository;
 import org.sopt.confeti.domain.festival.Festival;
@@ -18,11 +19,13 @@ import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
+import org.springframework.data.elasticsearch.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class SetlistService {
 
     private final SetlistRepository setlistRepository;
@@ -87,8 +90,8 @@ public class SetlistService {
     public List<Long> createSetLists(Long userId, List<SetlistCreateRequest> requests) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-
         return requests.stream()
+                .filter(req -> !setlistRepository.existsByUserIdAndTypeAndTypeId(userId, req.type(), req.typeId()))
                 .map(req -> Setlist.builder()
                         .user(user)
                         .type(req.type())

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/SetlistCreateRequest.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/SetlistCreateRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.domain.setlist.application.dto.request;
+
+import org.sopt.confeti.domain.setlist.SetlistType;
+
+public record SetlistCreateRequest(
+        SetlistType type,
+        Long typeId
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistCreateResponse.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistCreateResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.confeti.domain.setlist.application.dto.response;
+
+import java.util.List;
+
+public record SetlistCreateResponse(
+        List<Long> setlistIds
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.domain.setlist.infra.repository;
 
 import java.util.List;
 import org.sopt.confeti.domain.setlist.Setlist;
+import org.sopt.confeti.domain.setlist.SetlistType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -10,4 +11,6 @@ public interface SetlistRepository extends JpaRepository<Setlist, Long> {
 
     @Query("SELECT s FROM Setlist s WHERE s.user.id = :userId")
     List<Setlist> findAllByUserId(@Param("userId") Long userId);
+
+    boolean existsByUserIdAndTypeAndTypeId(Long userId, SetlistType type, Long typeId);
 }

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -18,12 +18,14 @@ import org.sopt.confeti.domain.concert.infra.repository.ConcertRepository;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
 import org.sopt.confeti.domain.setlist.*;
+import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.OAuthProvider;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.domain.user.infra.repository.UserRepository;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -35,6 +37,7 @@ class SetlistServiceTest {
     @Mock private SetlistRepository setlistRepository;
     @Mock private ConcertRepository concertRepository;
     @Mock private FestivalRepository festivalRepository;
+    @Mock private UserRepository userRepository;
 
     private final Long userId = 1L;
     private final User user = mockUser(userId);
@@ -155,5 +158,31 @@ class SetlistServiceTest {
                 .musics(List.of())
                 .reservationUrls(List.of())
                 .build();
+    }
+
+    @Test
+    void 여러개의_공연을_셋리스트로_생성() {
+        // given
+        SetlistCreateRequest request1 = new SetlistCreateRequest(SetlistType.CONCERT, 100L);
+        SetlistCreateRequest request2 = new SetlistCreateRequest(SetlistType.FESTIVAL, 200L);
+        List<SetlistCreateRequest> requests = List.of(request1, request2);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        Setlist savedSetlist1 = createSetlist(SetlistType.CONCERT, 100L);
+        Setlist savedSetlist2 = createSetlist(SetlistType.FESTIVAL, 200L);
+        ReflectionTestUtils.setField(savedSetlist1, "id", 1L);
+        ReflectionTestUtils.setField(savedSetlist2, "id", 2L);
+
+        given(setlistRepository.save(org.mockito.ArgumentMatchers.any(Setlist.class)))
+                .willReturn(savedSetlist1)
+                .willReturn(savedSetlist2);
+
+        // when
+        List<Long> result = setlistService.createSetLists(userId, requests);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result).containsExactly(1L, 2L);
     }
 }

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.domain.setlist.application;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
 
 import java.time.LocalDate;
@@ -174,7 +175,7 @@ class SetlistServiceTest {
         ReflectionTestUtils.setField(savedSetlist1, "id", 1L);
         ReflectionTestUtils.setField(savedSetlist2, "id", 2L);
 
-        given(setlistRepository.save(org.mockito.ArgumentMatchers.any(Setlist.class)))
+        given(setlistRepository.save(any(Setlist.class)))
                 .willReturn(savedSetlist1)
                 .willReturn(savedSetlist2);
 
@@ -185,4 +186,27 @@ class SetlistServiceTest {
         assertThat(result).hasSize(2);
         assertThat(result).containsExactly(1L, 2L);
     }
+
+    @Test
+    void 이미_생성된_셋리스트는_중복_생성되지_않는다() {
+        // given
+        SetlistCreateRequest request1 = new SetlistCreateRequest(SetlistType.CONCERT, 100L);
+        SetlistCreateRequest request2 = new SetlistCreateRequest(SetlistType.FESTIVAL, 200L);
+        List<SetlistCreateRequest> requests = List.of(request1, request2);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(setlistRepository.existsByUserIdAndTypeAndTypeId(userId, SetlistType.CONCERT, 100L)).willReturn(true); // 이미 존재
+        given(setlistRepository.existsByUserIdAndTypeAndTypeId(userId, SetlistType.FESTIVAL, 200L)).willReturn(false);
+
+        Setlist newSetlist = createSetlist(SetlistType.FESTIVAL, 200L);
+        ReflectionTestUtils.setField(newSetlist, "id", 999L);
+        given(setlistRepository.save(any(Setlist.class))).willReturn(newSetlist);
+
+        // when
+        List<Long> result = setlistService.createSetLists(userId, requests);
+
+        // then
+        assertThat(result).containsExactly(999L);
+    }
+
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #352 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 공연 추가 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- MY 셋리스트 > 공연 추가 API를 구현했습니다!
- 여러 개의 콘서트/페스티벌을 선택해서 각 공연마다 1개의 셋리스트 생성하도록 구현했습니다.
- 이미 셋리스트로 생성된 공연은 셋리스트에 중복으로 추가할 수 없도록 구현했습니다.
- 현재 셋리스트 검색 API가 구현되어 있지 않은 상황으로, 필드값이 변경될 여지가 있습니다! (해당 사항에 대해 서버 리드와 함께 논의 후, 임의의 필드값으로 구현을 진행했습니다.)
- 셋리스트 생성 이후, 제대로 생성되었는지 확인할 수 있도록 셋리스트 Id 리스트를 반환하도록 구현하였습니다. 이 부분도 이후 불필요하다고 생각되면 삭제할 예정입니다.

### 테스트
<img width="548" alt="image" src="https://github.com/user-attachments/assets/e889f968-bf3b-44d9-8698-06b353de33f0" />

