### PR TITLE
refactor [#354] 온보딩 API 최소 아티스트 개수 1개로 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/auth/OnboardService.java
+++ b/src/main/java/org/sopt/confeti/auth/OnboardService.java
@@ -9,10 +9,8 @@ import org.springframework.stereotype.Service;
 @Service
 @RequiredArgsConstructor
 public class OnboardService {
-    private static final int MINIMUM_ARTIST_COUNT = 3;
-
     public void validateFavoriteArtistCount(OnboardDTO onboardDTO) {
-        if (onboardDTO.favoriteArtists().size() < MINIMUM_ARTIST_COUNT) {
+        if (onboardDTO.favoriteArtists().isEmpty()) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
     }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #354

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 온보딩 API 최소 아티스트 개수 1개로 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
![image](https://github.com/user-attachments/assets/60ef8420-e17d-42d0-ad0d-53af8576e465)

기획 요구사항에 따라 온보딩 시 아티스트 선택 최소 개수를 1개로 조정했습니다.