### PR TITLE
feat [#356] MY 셋리스트 > 곡 추가 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
@@ -4,7 +4,9 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.application.SetlistService;
+import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRequest;
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
+import org.sopt.confeti.domain.setlist.application.dto.response.AddSetListMusicResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistCreateResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
@@ -16,6 +18,7 @@ import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -57,5 +60,16 @@ public class SetlistController {
     ) {
         List<Long> ids = setlistService.createSetLists(userId, requests);
         return ApiResponseUtil.success(SuccessMessage.CREATED, new SetlistCreateResponse(ids));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @PostMapping("/{setlistId}/musics")
+    public ResponseEntity<BaseResponse<?>> addMusicsToSetlist(
+            @UserId(require = false) Long userId,
+            @PathVariable Long setlistId,
+            @RequestBody List<AddSetListMusicRequest> requests
+    ) {
+        int count = setlistService.addMusics(userId, setlistId, requests);
+        return ApiResponseUtil.success(SuccessMessage.CREATED, new AddSetListMusicResponse(count));
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -9,8 +9,10 @@ import org.sopt.confeti.domain.concert.infra.repository.ConcertRepository;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
 import org.sopt.confeti.domain.setlist.Setlist;
+import org.sopt.confeti.domain.setlist.SetlistMusic;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.SetlistType;
+import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRequest;
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
@@ -18,6 +20,7 @@ import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
+import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.data.elasticsearch.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
@@ -100,5 +103,32 @@ public class SetlistService {
                 .map(setlistRepository::save)
                 .map(Setlist::getId)
                 .toList();
+    }
+
+    @Transactional
+    public int addMusics(Long userId, Long setlistId, List<AddSetListMusicRequest> requests) {
+        Setlist setlist = setlistRepository.findById(setlistId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+
+        if (!setlist.getUser().getId().equals(userId)) {
+            throw new UnauthorizedException(ErrorMessage.UNAUTHORIZED);
+        }
+
+        int startOrder = setlist.getMusics().size() + 1;
+
+        for (int i = 0; i < requests.size(); i++) {
+            AddSetListMusicRequest req = requests.get(i);
+            SetlistMusic music = SetlistMusic.builder()
+                    .artistName(req.artistName())
+                    .trackName(req.trackName())
+                    .artworkUrl(req.artworkUrl())
+                    .previewUrl(req.previewUrl())
+                    .orders(startOrder + i)
+                    .build();
+
+            setlist.addMusics(music);
+        }
+
+        return requests.size();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/AddSetListMusicRequest.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/AddSetListMusicRequest.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.domain.setlist.application.dto.request;
+
+public record AddSetListMusicRequest(
+        String artistName,
+        String trackName,
+        String artworkUrl,
+        String previewUrl
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/AddSetListMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/AddSetListMusicResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.confeti.domain.setlist.application.dto.response;
+
+public record AddSetListMusicResponse(
+        int addCount
+) {
+}

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -19,6 +19,7 @@ import org.sopt.confeti.domain.concert.infra.repository.ConcertRepository;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
 import org.sopt.confeti.domain.setlist.*;
+import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRequest;
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
@@ -208,5 +209,43 @@ class SetlistServiceTest {
         // then
         assertThat(result).containsExactly(999L);
     }
+
+    @Test
+    void 셋리스트에_여러_곡을_추가하면_순서가_자동으로_부여된다() {
+        // given
+        Long setlistId = 100L;
+        Setlist setlist = Setlist.builder()
+                .user(user)
+                .type(SetlistType.CONCERT)
+                .typeId(1L)
+                .build();
+
+        SetlistMusic existing1 = SetlistMusic.builder()
+                .artistName("EXO").trackName("Love Shot").orders(1).build();
+        SetlistMusic existing2 = SetlistMusic.builder()
+                .artistName("BTS").trackName("Dynamite").orders(2).build();
+        setlist.addMusics(existing1);
+        setlist.addMusics(existing2);
+
+        given(setlistRepository.findById(setlistId)).willReturn(Optional.of(setlist));
+
+        List<AddSetListMusicRequest> requests = List.of(
+                new AddSetListMusicRequest("IU", "Love wins all", "url1", "preview1"),
+                new AddSetListMusicRequest("NewJeans", "Hype Boy", "url2", "preview2")
+        );
+
+        // when
+        int result = setlistService.addMusics(userId, setlistId, requests);
+
+        // then
+        assertThat(result).isEqualTo(2);
+        List<SetlistMusic> allMusics = setlist.getMusics();
+        assertThat(allMusics).hasSize(4);
+        assertThat(allMusics.get(2).getOrders()).isEqualTo(3);
+        assertThat(allMusics.get(2).getArtistName()).isEqualTo("IU");
+        assertThat(allMusics.get(3).getOrders()).isEqualTo(4);
+        assertThat(allMusics.get(3).getArtistName()).isEqualTo("NewJeans");
+    }
+
 
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #356 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 곡 추가 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- MY 셋리스트에 곡을 추가하는 API (`POST /my/setlists/{setlistId}/musics`)를 구현했습니다.
- Apple Music API에서 받은 곡 정보를 기반으로 셋리스트에 다수의 곡을 동시에 추가 가능하도록 구현했습니다.
- 요청 시 orders는 클라이언트에서 지정하지 않고, 서버에서 기존 곡 개수 기준으로 자동으로 순번이 지정되도록 구현했습니다.

## 🧪 추가 사항
곡 삭제/순서 변경 기능과의 연동성을 고려해 orders는 기존 곡 개수를 기준으로 n+1부터 시작하여 순차적으로 저장되도록 하였고, 이후 셋리스트의 곡을 삭제하는 경우, 순서를 재정렬하고자 하는 계획입니다!

### 테스트
<img width="554" alt="image" src="https://github.com/user-attachments/assets/423ddab0-fa98-4cea-884a-4c63471ba804" />

<img width="652" alt="image" src="https://github.com/user-attachments/assets/07ef7b88-d8d2-4392-ab45-0796ec22ac28" />

