### PR TITLE
feat [#347] 다른 노래 더보기 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.api.performance.controller;
 
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.performance.dto.request.PatchRecommendMusics;
 import org.sopt.confeti.api.performance.dto.response.AnalyzePerformanceTypeResponse;
 import org.sopt.confeti.api.performance.dto.response.ArtistPerformancesResponse;
 import org.sopt.confeti.api.performance.dto.response.ConcertDetailResponse;
@@ -35,11 +36,7 @@ import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
@@ -156,5 +153,15 @@ public class PerformanceController {
         RecommendMusicsDTO recommendMusicsDTO = performanceFacade.getRecommendMusics(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 RecommendMusicsResponse.from(recommendMusicsDTO));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @PatchMapping("/recommend/musics")
+    public ResponseEntity<BaseResponse<?>> getRecommendMusics(
+            @RequestBody PatchRecommendMusics patchRecommendMusics
+    ) {
+        RecommendNewMusicsDTO recommendMusicsDTO = performanceFacade.getNewRecommendMusics(patchRecommendMusics);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                RecommendNewMusicsResponse.from(recommendMusicsDTO));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/request/PatchRecommendMusic.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/request/PatchRecommendMusic.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.api.performance.dto.request;
+
+public record PatchRecommendMusic(
+        String musicId
+) {
+    public static PatchRecommendMusic from(PatchRecommendMusic music) {
+        return new PatchRecommendMusic(music.musicId());
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/dto/request/PatchRecommendMusics.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/request/PatchRecommendMusics.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.performance.dto.request;
+
+import java.util.List;
+
+public record PatchRecommendMusics(
+        Long performanceId,
+        List<PatchRecommendMusic> musicList
+) {
+    public static PatchRecommendMusics from(PatchRecommendMusics patchRecommendMusics) {
+        return new PatchRecommendMusics(
+                patchRecommendMusics.performanceId(),
+                patchRecommendMusics.musicList.stream()
+                        .map(PatchRecommendMusic::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicResponse.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.api.performance.dto.response;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicDTO;
 
 public record RecommendMusicResponse(
+        String musicId,
         String artistName,
         String title,
         String artWorkUrl,
@@ -10,6 +11,7 @@ public record RecommendMusicResponse(
 ) {
     public static RecommendMusicResponse from(RecommendMusicDTO recommendMusicDTO) {
         return new RecommendMusicResponse(
+                recommendMusicDTO.id(),
                 recommendMusicDTO.artistName(),
                 recommendMusicDTO.title(),
                 recommendMusicDTO.artWorkUrl(),

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendNewMusicsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendNewMusicsResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import org.sopt.confeti.api.performance.facade.dto.response.RecommendNewMusicsDTO;
+import java.util.List;
+
+public record RecommendNewMusicsResponse(
+        List<RecommendMusicResponse> musicList
+) {
+    public static RecommendNewMusicsResponse from(RecommendNewMusicsDTO musicListDTO) {
+        return new RecommendNewMusicsResponse(
+                musicListDTO.musicList().stream()
+                        .map(RecommendMusicResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -337,6 +337,8 @@ public class PerformanceFacade {
 
     @Transactional(readOnly = true)
     public RecommendNewMusicsDTO getNewRecommendMusics(PatchRecommendMusics patchRecommendMusics) {
+        validatePatchRecommendMusics(patchRecommendMusics);
+
         Performance performance = performanceService.getPerformanceById(patchRecommendMusics.performanceId());
         Set<String> selectedArtistIds = setArtistsByRandom(performance);
         Set<String> existingMusicIds = extractMusicIds(patchRecommendMusics);
@@ -384,5 +386,12 @@ public class PerformanceFacade {
         return patchRecommendMusics.musicList().stream()
                 .map(PatchRecommendMusic::musicId)
                 .collect(Collectors.toSet());
+    }
+
+    private void validatePatchRecommendMusics(PatchRecommendMusics patchRecommendMusics) {
+        if (patchRecommendMusics.performanceId() == null || patchRecommendMusics.musicList() == null ||
+                patchRecommendMusics.musicList().isEmpty()) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -13,6 +13,8 @@ import kr.co.shineware.nlp.komoran.model.KomoranResult;
 import java.util.stream.Collectors;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.performance.dto.request.PatchRecommendMusic;
+import org.sopt.confeti.api.performance.dto.request.PatchRecommendMusics;
 import org.sopt.confeti.api.performance.facade.dto.response.AnalyzePerformanceTypeDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDetailDTO;
@@ -56,6 +58,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PerformanceFacade {
 
     private static final int RECENT_PERFORMANCES_SIZE = 7;
+    private static final int RECOMMEND_MUSIC_SIZE = 3;
     private static final boolean PERSONALIZED = true;
     private static final boolean UNPERSONALIZED = false;
     private static final String TYPE_ALL = "ALL";
@@ -330,5 +333,56 @@ public class PerformanceFacade {
 
         int artistCount = Math.min(artistList.size(), 3);
         return new HashSet<>(artistList.subList(0, artistCount));
+    }
+
+    @Transactional(readOnly = true)
+    public RecommendNewMusicsDTO getNewRecommendMusics(PatchRecommendMusics patchRecommendMusics) {
+        Performance performance = performanceService.getPerformanceById(patchRecommendMusics.performanceId());
+        Set<String> selectedArtistIds = setArtistsByRandom(performance);
+        Set<String> existingMusicIds = extractMusicIds(patchRecommendMusics);
+
+        List<String> artistIdList = new ArrayList<>(selectedArtistIds);
+        List<ConfetiMusic> recommendMusics = recommendMusicsByArtistCount(artistIdList, existingMusicIds);
+
+        return RecommendNewMusicsDTO.from(recommendMusics);
+    }
+
+    private List<ConfetiMusic> recommendMusicsByArtistCount(List<String> artistIdList, Set<String> existingMusicIds) {
+        int artistCount = artistIdList.size();
+        if (artistCount == 1) {
+            return recommendForSingleArtist(artistIdList, existingMusicIds);
+        }
+        if (artistCount == 2) {
+            return recommendForTwoArtists(artistIdList, existingMusicIds);
+        }
+        return recommendForMultipleArtists(artistIdList, existingMusicIds);
+    }
+
+    private List<ConfetiMusic> recommendForSingleArtist(List<String> artistIdList, Set<String> existingMusicIds) {
+        return musicAPIHandler.getFilteredTopSongsByArtist(
+                artistIdList.getFirst(), RECOMMEND_MUSIC_SIZE, existingMusicIds
+        );
+    }
+
+    private List<ConfetiMusic> recommendForTwoArtists(List<String> artistIdList, Set<String> existingMusicIds) {
+        List<ConfetiMusic> musics = new ArrayList<>();
+        musics.addAll(musicAPIHandler.getFilteredTopSongsByArtist(artistIdList.getFirst(), 2, existingMusicIds));
+        musics.addAll(musicAPIHandler.getFilteredTopSongsByArtist(artistIdList.getLast(), 1, existingMusicIds));
+        return musics;
+    }
+
+    private List<ConfetiMusic> recommendForMultipleArtists(List<String> artistIdList, Set<String> existingMusicIds) {
+        List<ConfetiMusic> musics = new ArrayList<>();
+        for (String artistId : artistIdList) {
+            if (musics.size() >= RECOMMEND_MUSIC_SIZE) break;
+            musics.addAll(musicAPIHandler.getFilteredTopSongsByArtist(artistId, 1, existingMusicIds));
+        }
+        return musics;
+    }
+
+    private Set<String> extractMusicIds(PatchRecommendMusics patchRecommendMusics) {
+        return patchRecommendMusics.musicList().stream()
+                .map(PatchRecommendMusic::musicId)
+                .collect(Collectors.toSet());
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicDTO.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.api.performance.facade.dto.response;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 
 public record RecommendMusicDTO(
+        String id,
         String artistName,
         String title,
         String artWorkUrl,
@@ -10,6 +11,7 @@ public record RecommendMusicDTO(
 ) {
     public static RecommendMusicDTO from(ConfetiMusic music) {
         return new RecommendMusicDTO(
+                music.getId(),
                 music.getArtistName(),
                 music.getTitle(),
                 music.getArtworkUrl(),

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendNewMusicsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendNewMusicsDTO.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+import java.util.List;
+
+public record RecommendNewMusicsDTO(
+        List<RecommendMusicDTO> musicList
+) {
+    public static RecommendNewMusicsDTO from(List<ConfetiMusic> musicList) {
+        return new RecommendNewMusicsDTO(
+                musicList.stream()
+                        .map(RecommendMusicDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -151,4 +151,12 @@ public class PerformanceService {
     public Performance getPerformanceByUserFavorites(final Long userId) {
         return performanceRepository.getPerformanceByUserFavorites(userId);
     }
+
+    @Transactional(readOnly = true)
+    public Performance getPerformanceById(long performanceId) {
+        return performanceRepository.findById(performanceId)
+                .orElseThrow(
+                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+                );
+    }
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -331,4 +331,27 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                         .retrieve(AppleMusicMusicsResponse.class)
         );
     }
+
+    @Override
+    @RetryOnTokenExpire
+    public List<ConfetiMusic> getFilteredTopSongsByArtist(String artistId, int limit, Set<String> excludedMusicIds) {
+        List<ConfetiMusic> songs = getTopSongsByArtistId(artistId, limit * 5);
+
+        List<ConfetiMusic> filteredSongs = songs.stream()
+                .filter(song -> !excludedMusicIds.contains(song.getId()))
+                .collect(Collectors.toList());
+
+        if (filteredSongs.isEmpty()) return Collections.emptyList();
+
+        List<ConfetiMusic> result = new ArrayList<>();
+        Random random = new Random();
+
+        for (int i = 0; i < limit && !filteredSongs.isEmpty(); i++) {
+            int randomIndex = random.nextInt(filteredSongs.size());
+            result.add(filteredSongs.get(randomIndex));
+            filteredSongs.remove(randomIndex);
+        }
+
+        return result;
+    }
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -24,4 +24,6 @@ public interface MusicAPIHandler {
     List<ConfetiMusic> getTopMusics(final int fetchSize);
 
     List<ConfetiMusic> getMusicsByArtistIds(final Set<String> artistIds);
+
+    List<ConfetiMusic> getFilteredTopSongsByArtist(String artistId, int limit, Set<String> excludedMusicIds);
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #347

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 추천 음악 조회 시 musicId도 반환하도록 응답값 추가
- [x] 다른 노래 더보기 API 구현
- [x] AppleMusicAPIHandler getFilteredTopSongsByArtist 추가

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
홈뷰의 선호 공연 기반 추천 음악 더보기 API를 구현했습니다.
클라이언트로 입력된 performanceId를 기반으로 공연에 출연하는 아티스트 목록 조회 후,
새로운 추천 음악을 반환할 때 클라이언트로부터 입력된 musicList 를 제외한 음악들을 반환하도록 했습니다. 
<img width="709" alt="스크린샷 2025-04-24 오전 1 02 50" src="https://github.com/user-attachments/assets/1ee8a827-c76b-4784-95f4-26e5a5ed3e4e" />
