### PR TITLE
feat [#358] Redis 설정 + MY 셋리스트 > 편집 시작 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,12 @@ dependencies {
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testImplementation 'org.springframework.security:spring-security-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+
+    // Redis
+    implementation("org.springframework.boot:spring-boot-starter-data-redis")
+
+    // Jackson
+    implementation("com.fasterxml.jackson.core:jackson-databind")
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistEditController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistEditController.java
@@ -1,0 +1,30 @@
+package org.sopt.confeti.api.setlist;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.setlist.application.SetlistEditService;
+import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my/setlists")
+public class SetlistEditController {
+
+    private final SetlistEditService setlistEditService;
+
+    @PostMapping("/{setlistId}/edit/start")
+    public ResponseEntity<BaseResponse<?>> startEdit(
+            @UserId(require = false) Long userId,
+            @PathVariable Long setlistId
+    ) {
+        setlistEditService.startEdit(userId, setlistId);
+        return ApiResponseUtil.success(SuccessMessage.CREATED);
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/SetlistMusic.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/SetlistMusic.java
@@ -18,6 +18,9 @@ public class SetlistMusic {
     @JoinColumn(name = "setlist_id", nullable = false)
     private Setlist setlist;
 
+    @Column(nullable = false)
+    private String trackId;
+
     @Column(name = "artist_name", nullable = false)
     private String artistName;
 
@@ -34,7 +37,8 @@ public class SetlistMusic {
     private int orders;
 
     @Builder
-    public SetlistMusic(String artistName, String trackName, String artworkUrl, String previewUrl, int orders) {
+    public SetlistMusic(String trackId, String artistName, String trackName, String artworkUrl, String previewUrl, int orders) {
+        this.trackId = trackId;
         this.artistName = artistName;
         this.trackName = trackName;
         this.artworkUrl = artworkUrl;

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
@@ -1,0 +1,39 @@
+package org.sopt.confeti.domain.setlist.application;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.setlist.Setlist;
+import org.sopt.confeti.domain.setlist.SetlistMusic;
+import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicEditDto;
+import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
+import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
+import org.sopt.confeti.global.exception.NotFoundException;
+import org.sopt.confeti.global.message.ErrorMessage;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class SetlistEditService {
+
+    private final SetlistRepository setlistRepository;
+    private final SetlistMusicRepository setlistMusicRepository;
+    private final RedisTemplate<String, Object> redisTemplate;
+
+    public void startEdit(Long userId, Long setlistId) {
+        Setlist setlist = setlistRepository.findByIdAndUserId(setlistId, userId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+
+        List<SetlistMusic> musics = setlistMusicRepository.findBySetlist(setlist);
+        List<SetlistMusicEditDto> musicDtos = musics.stream()
+                .map(SetlistMusicEditDto::from)
+                .toList();
+
+        String redisKey = generateRedisKey(userId, setlistId);
+        redisTemplate.opsForValue().set(redisKey, musicDtos);
+    }
+
+    private String generateRedisKey(Long userId, Long setlistId) {
+        return "edit:setlist:" + userId + ":" + setlistId;
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -119,6 +119,7 @@ public class SetlistService {
         for (int i = 0; i < requests.size(); i++) {
             AddSetListMusicRequest req = requests.get(i);
             SetlistMusic music = SetlistMusic.builder()
+                    .trackId(req.trackId())
                     .artistName(req.artistName())
                     .trackName(req.trackName())
                     .artworkUrl(req.artworkUrl())

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/AddSetListMusicRequest.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/AddSetListMusicRequest.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.domain.setlist.application.dto.request;
 
 public record AddSetListMusicRequest(
+        String trackId,
         String artistName,
         String trackName,
         String artworkUrl,

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/SetlistMusicEditDto.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/SetlistMusicEditDto.java
@@ -1,0 +1,25 @@
+package org.sopt.confeti.domain.setlist.application.dto.request;
+
+import org.sopt.confeti.domain.setlist.SetlistMusic;
+
+public record SetlistMusicEditDto(
+        Long musicId,
+        String trackId,
+        String artistName,
+        String trackName,
+        String artworkUrl,
+        String previewUrl,
+        int orders
+) {
+    public static SetlistMusicEditDto from(SetlistMusic music) {
+        return new SetlistMusicEditDto(
+                music.getId(),
+                music.getTrackId(),
+                music.getArtistName(),
+                music.getTrackName(),
+                music.getArtworkUrl(),
+                music.getPreviewUrl(),
+                music.getOrders()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistMusicRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistMusicRepository.java
@@ -1,0 +1,12 @@
+package org.sopt.confeti.domain.setlist.infra.repository;
+
+import java.util.List;
+import org.sopt.confeti.domain.setlist.Setlist;
+import org.sopt.confeti.domain.setlist.SetlistMusic;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface SetlistMusicRepository extends JpaRepository<SetlistMusic, Long> {
+    List<SetlistMusic> findBySetlist(Setlist setlist);
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
@@ -1,16 +1,21 @@
 package org.sopt.confeti.domain.setlist.infra.repository;
 
 import java.util.List;
+import java.util.Optional;
 import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistType;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
 
+@Repository
 public interface SetlistRepository extends JpaRepository<Setlist, Long> {
 
     @Query("SELECT s FROM Setlist s WHERE s.user.id = :userId")
     List<Setlist> findAllByUserId(@Param("userId") Long userId);
 
     boolean existsByUserIdAndTypeAndTypeId(Long userId, SetlistType type, Long typeId);
+
+    Optional<Setlist> findByIdAndUserId(Long id, Long userId);
 }

--- a/src/main/java/org/sopt/confeti/global/config/RedisConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/RedisConfig.java
@@ -1,0 +1,21 @@
+package org.sopt.confeti.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(factory);
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        return template;
+    }
+}

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistEditServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistEditServiceTest.java
@@ -1,0 +1,90 @@
+package org.sopt.confeti.domain.setlist.application;
+
+import static org.assertj.core.api.AssertionsForInterfaceTypes.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.confeti.domain.setlist.Setlist;
+import org.sopt.confeti.domain.setlist.SetlistMusic;
+import org.sopt.confeti.domain.setlist.SetlistType;
+import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicEditDto;
+import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
+import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
+import org.sopt.confeti.domain.user.OAuthProvider;
+import org.sopt.confeti.domain.user.User;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class SetlistEditServiceTest {
+
+    @InjectMocks private SetlistEditService setlistEditService;
+    @Mock private SetlistRepository setlistRepository;
+    @Mock private SetlistMusicRepository setlistMusicRepository;
+    @Mock private RedisTemplate<String, Object> redisTemplate;
+    @Mock private ValueOperations<String, Object> valueOperations;
+
+    @Test
+    void startEdit_셋리스트_편집시작() {
+        // given
+        Long userId = 1L;
+        Long setlistId = 100L;
+
+        User user = User.builder()
+                .provider(OAuthProvider.KAKAO)
+                .socialId("kakao123")
+                .name("정교")
+                .profilePath(null)
+                .role(Role.GENERAL)
+                .build();
+
+        Setlist setlist = Setlist.builder()
+                .user(user)
+                .type(SetlistType.CONCERT)
+                .typeId(1L)
+                .build();
+
+        ReflectionTestUtils.setField(setlist, "id", setlistId);
+
+        SetlistMusic music = SetlistMusic.builder()
+                .trackId("203948575")
+                .artistName("NewJeans")
+                .trackName("Super Shy")
+                .artworkUrl("https://img")
+                .previewUrl("https://preview")
+                .orders(1)
+                .build();
+        music.setSetlist(setlist);
+
+        List<SetlistMusic> musics = List.of(music);
+
+        given(setlistRepository.findByIdAndUserId(setlistId, userId)).willReturn(Optional.of(setlist));
+        given(setlistMusicRepository.findBySetlist(setlist)).willReturn(musics);
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+
+        // when
+        setlistEditService.startEdit(userId, setlistId);
+
+        // then
+        String expectedKey = "edit:setlist:" + userId + ":" + setlistId;
+        ArgumentCaptor<List<SetlistMusicEditDto>> captor = ArgumentCaptor.forClass(List.class);
+        verify(valueOperations).set(eq(expectedKey), captor.capture());
+
+        List<SetlistMusicEditDto> captured = captor.getValue();
+        assertThat(captured).hasSize(1);
+        assertThat(captured.get(0).trackId()).isEqualTo("203948575");
+        assertThat(captured.get(0).trackName()).isEqualTo("Super Shy");
+        assertThat(captured.get(0).orders()).isEqualTo(1);
+    }
+}

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -230,8 +230,8 @@ class SetlistServiceTest {
         given(setlistRepository.findById(setlistId)).willReturn(Optional.of(setlist));
 
         List<AddSetListMusicRequest> requests = List.of(
-                new AddSetListMusicRequest("IU", "Love wins all", "url1", "preview1"),
-                new AddSetListMusicRequest("NewJeans", "Hype Boy", "url2", "preview2")
+                new AddSetListMusicRequest("01", "IU", "Love wins all", "url1", "preview1"),
+                new AddSetListMusicRequest("02", "NewJeans", "Hype Boy", "url2", "preview2")
         );
 
         // when


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #358 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] Redis 환경설정(로컬)
- [x] MY 셋리스트 > 편집 시작 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- Redis 설정
- 사용자가 편집을 시작할 때, 현재 셋리스트의 곡 목록을 Redis에 임시 저장해, 이후 곡 추가/삭제/순서 변경 등의 편집 작업을 DB에 영향을 주지 않고 진행할 수 있도록 구현했습니다. (로컬서버)
- 우선 로컬에만 반영한 상태이고, 운영서버에 반영하도록 별도의 서버를 추가해야 합니다.

### Redis를 사용하는 이유
요구사항 | 설명
-- | --
편집 중 DB에 반영하지 않음 | 편집 완료 전까지는 사용자의 편집 내용이 실제 DB에 저장되면 안 됨
빠른 임시 저장 필요 | 편집 중 추가/삭제/순서 변경이 빈번하게 발생하기 때문에, 응답 속도가 빠른 저장소가 필요함
롤백(편집 취소) 기능 | 편집을 취소할 경우, DB는 건드리지 않고 단순히 임시 데이터를 버리기만 하면 됨
세션처럼 사용자별로 분리 | userId, setlistId 기준으로 독립된 편집 세션을 관리할 수 있어야 함

</div></div>

### 테스트
<img width="458" alt="image" src="https://github.com/user-attachments/assets/21c2cd2f-93b2-4bc2-bf93-7d68f390ee39" />

- Redis 서버 로컬에 구축 
<img width="709" alt="image" src="https://github.com/user-attachments/assets/e7533efd-c9c6-48d0-b8d0-5632802a5beb" />

- Redis에 정상적으로 저장된 key
<img width="743" alt="image" src="https://github.com/user-attachments/assets/5d02b332-5afa-4437-b8c6-25eb0c4ef5c0" />

- Redis Insight GUI 툴을 사용해 JSON형식의 Redis Key 값을 확인했습니다.
<img width="1196" alt="image" src="https://github.com/user-attachments/assets/0b6e9a2b-f1db-413b-a314-f9471760d62c" />
