### PR TITLE
feat [#363] MY 셋리스트 > 항목 순서 변경 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistEditController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistEditController.java
@@ -1,14 +1,19 @@
 package org.sopt.confeti.api.setlist;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.domain.setlist.application.SetlistEditService;
+import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicOrderUpdateRequest;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -26,5 +31,15 @@ public class SetlistEditController {
     ) {
         setlistEditService.startEdit(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.CREATED);
+    }
+
+    @PatchMapping("/{setlistId}/edit/musics/order")
+    public ResponseEntity<BaseResponse<?>> updateMusicOrder(
+            @UserId(require = false) Long userId,
+            @PathVariable Long setlistId,
+            @RequestBody List<SetlistMusicOrderUpdateRequest> request
+    ) {
+        setlistEditService.updateMusicOrder(userId, setlistId, request);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
@@ -1,10 +1,17 @@
 package org.sopt.confeti.domain.setlist.application;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistMusic;
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicEditDto;
+import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicOrderUpdateRequest;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
@@ -18,7 +25,8 @@ public class SetlistEditService {
 
     private final SetlistRepository setlistRepository;
     private final SetlistMusicRepository setlistMusicRepository;
-    private final RedisTemplate<String, Object> redisTemplate;
+    private final RedisTemplate<String, List<SetlistMusicEditDto>> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     public void startEdit(Long userId, Long setlistId) {
         Setlist setlist = setlistRepository.findByIdAndUserId(setlistId, userId)
@@ -31,6 +39,38 @@ public class SetlistEditService {
 
         String redisKey = generateRedisKey(userId, setlistId);
         redisTemplate.opsForValue().set(redisKey, musicDtos);
+    }
+
+    public void updateMusicOrder(Long userId, Long setlistId, List<SetlistMusicOrderUpdateRequest> requests) {
+        String key = generateRedisKey(userId, setlistId);
+        Object raw = redisTemplate.opsForValue().get(key);
+        if (raw == null) throw new NotFoundException(ErrorMessage.NOT_FOUND);
+
+        List<SetlistMusicEditDto> musics = objectMapper.convertValue(raw, new TypeReference<>() {});
+        if (musics.isEmpty()) throw new NotFoundException(ErrorMessage.NOT_FOUND);
+
+        Map<String, SetlistMusicEditDto> musicMap = musics.stream()
+                .collect(Collectors.toMap(SetlistMusicEditDto::trackId, dto -> dto));
+
+        if (requests.size() == 2) {
+            SetlistMusicEditDto a = musicMap.get(requests.get(0).trackId());
+            SetlistMusicEditDto b = musicMap.get(requests.get(1).trackId());
+
+            if (a != null && b != null) {
+                int tmpOrder = a.orders();
+                a = new SetlistMusicEditDto(a.musicId(), a.trackId(), a.artistName(), a.trackName(), a.artworkUrl(), a.previewUrl(), b.orders());
+                b = new SetlistMusicEditDto(b.musicId(), b.trackId(), b.artistName(), b.trackName(), b.artworkUrl(), b.previewUrl(), tmpOrder);
+
+                musicMap.put(a.trackId(), a);
+                musicMap.put(b.trackId(), b);
+            }
+        }
+
+        List<SetlistMusicEditDto> updated = new ArrayList<>(musicMap.values()).stream()
+                .sorted(Comparator.comparing(SetlistMusicEditDto::orders))
+                .toList();
+
+        redisTemplate.opsForValue().set(key, updated);
     }
 
     private String generateRedisKey(Long userId, Long setlistId) {

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/SetlistMusicOrderUpdateRequest.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/SetlistMusicOrderUpdateRequest.java
@@ -1,0 +1,7 @@
+package org.sopt.confeti.domain.setlist.application.dto.request;
+
+public record SetlistMusicOrderUpdateRequest(
+        String trackId,
+        int orders
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/config/JacksonConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/JacksonConfig.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.global.config;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+
+@Configuration
+public class JacksonConfig {
+
+    @Bean
+    @Primary
+    public ObjectMapper objectMapper() {
+        return new ObjectMapper();
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/config/RedisConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/RedisConfig.java
@@ -1,5 +1,8 @@
 package org.sopt.confeti.global.config;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicEditDto;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -11,11 +14,20 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
     @Bean
-    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory factory) {
-        RedisTemplate<String, Object> template = new RedisTemplate<>();
+    public RedisTemplate<String, List<SetlistMusicEditDto>> redisTemplate(
+            RedisConnectionFactory factory,
+            ObjectMapper objectMapper
+    ) {
+        RedisTemplate<String, List<SetlistMusicEditDto>> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
+
+        GenericJackson2JsonRedisSerializer serializer =
+                new GenericJackson2JsonRedisSerializer(objectMapper);
+
         template.setKeySerializer(new StringRedisSerializer());
-        template.setValueSerializer(new GenericJackson2JsonRedisSerializer());
+        template.setValueSerializer(serializer);
+        template.afterPropertiesSet();
+
         return template;
     }
 }

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistEditServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistEditServiceTest.java
@@ -5,8 +5,10 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.List;
 import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -17,6 +19,7 @@ import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistMusic;
 import org.sopt.confeti.domain.setlist.SetlistType;
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicEditDto;
+import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicOrderUpdateRequest;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.OAuthProvider;
@@ -35,8 +38,13 @@ class SetlistEditServiceTest {
     @Mock private RedisTemplate<String, Object> redisTemplate;
     @Mock private ValueOperations<String, Object> valueOperations;
 
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(setlistEditService, "objectMapper", new ObjectMapper());
+    }
+
     @Test
-    void startEdit_셋리스트_편집시작() {
+    void startEdit_편집_시작() {
         // given
         Long userId = 1L;
         Long setlistId = 100L;
@@ -86,5 +94,44 @@ class SetlistEditServiceTest {
         assertThat(captured.get(0).trackId()).isEqualTo("203948575");
         assertThat(captured.get(0).trackName()).isEqualTo("Super Shy");
         assertThat(captured.get(0).orders()).isEqualTo(1);
+    }
+
+    @Test
+    void updateMusicOrder_곡_순서_변경() {
+        // given
+        Long userId = 1L;
+        Long setlistId = 100L;
+        String redisKey = "edit:setlist:" + userId + ":" + setlistId;
+
+        List<SetlistMusicEditDto> originalList = List.of(
+                new SetlistMusicEditDto(1L, "track1", "Artist A", "Song A", "url1", "preview1", 1),
+                new SetlistMusicEditDto(2L, "track2", "Artist B", "Song B", "url2", "preview2", 2)
+        );
+
+        List<SetlistMusicOrderUpdateRequest> requestList = List.of(
+                new SetlistMusicOrderUpdateRequest("track1", 1),
+                new SetlistMusicOrderUpdateRequest("track2", 2)
+        );
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(redisKey)).willReturn(originalList);
+
+        // when
+        setlistEditService.updateMusicOrder(userId, setlistId, requestList);
+
+        // then
+        ArgumentCaptor<List<SetlistMusicEditDto>> captor = ArgumentCaptor.forClass(List.class);
+        verify(valueOperations).set(eq(redisKey), captor.capture());
+
+        List<SetlistMusicEditDto> updated = captor.getValue();
+
+        assertThat(updated).hasSize(2);
+        assertThat(updated).anySatisfy(dto -> {
+            if (dto.trackId().equals("track1")) {
+                assertThat(dto.orders()).isEqualTo(2);
+            } else if (dto.trackId().equals("track2")) {
+                assertThat(dto.orders()).isEqualTo(1);
+            }
+        });
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #363 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 항목 순서 변경 API 구현
- [x] 역직렬화 조회 문제 해결


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- Redis에서 곡 순서를 변경하는 API (DB 반영 X) 를 구현했습니다.
- 예를들어, 아래의 요청을 보내면
```json
[
	{ "trackId": "01", "orders": 1 },
	{ "trackId": "02", "orders": 2}
]
```
  - 01은 기존에 orders = 1이였는데 → 2로 변경
  - 02는 기존에 orders = 2였는데 → 1로 변경
  → 단순히 요청에 들어있는 orders 값을 반영하는 게 아니라, `trackId`끼리 `orders`를 서로 바꾸도록 구현했습니다.

- Redis의 데이터를 생성할때와 조회할때의 직렬화 형식이 달라 오류가 발생했는데요. 이를 위해 RedisConfig 파일을 수정했습니다.

## 테스트
### 1. 순서 변경 전
<img width="696" alt="image" src="https://github.com/user-attachments/assets/61449ff7-d448-446d-86f1-4de14b5ae890" />

### 2. 순서 변경 후
<img width="701" alt="image" src="https://github.com/user-attachments/assets/3a5b77e1-346d-41a3-a43e-c487007fe99c" />

<img width="695" alt="image" src="https://github.com/user-attachments/assets/4b89ead0-0951-47de-b9d0-c5afd9abfd79" />

