### PR TITLE
feat [#367] MY 셋리스트 > 상세 조회 API 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -87,6 +87,8 @@ dependencies {
 
     // Jackson
     implementation("com.fasterxml.jackson.core:jackson-databind")
+    implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
@@ -8,6 +8,7 @@ import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRe
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
 import org.sopt.confeti.domain.setlist.application.dto.response.AddSetListMusicResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.domain.setlist.application.dto.response.GetSetlistDetailResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistCreateResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
 import org.sopt.confeti.domain.user.constant.Role;
@@ -71,5 +72,15 @@ public class SetlistController {
     ) {
         int count = setlistService.addMusics(userId, setlistId, requests);
         return ApiResponseUtil.success(SuccessMessage.CREATED, new AddSetListMusicResponse(count));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/{setlistId}")
+    public ResponseEntity<BaseResponse<?>> getSetlistDetail(
+            @UserId(require = false) Long userId,
+            @PathVariable Long setlistId
+    ) {
+        GetSetlistDetailResponse data = setlistService.getSetlistDetail(userId, setlistId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -15,14 +15,16 @@ import org.sopt.confeti.domain.setlist.SetlistType;
 import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRequest;
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.domain.setlist.application.dto.response.GetSetlistDetailResponse;
+import org.sopt.confeti.domain.setlist.application.dto.response.SetlistMusicResponseDto;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.springframework.data.elasticsearch.ResourceNotFoundException;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -35,6 +37,7 @@ public class SetlistService {
     private final ConcertRepository concertRepository;
     private final FestivalRepository festivalRepository;
     private final UserRepository userRepository;
+    private final SetlistMusicRepository setlistMusicRepository;
 
     @Transactional(readOnly = true)
     public GetAllSetlistsResponse getAllMySetlists(Long userId, SetlistSortType sortType) {
@@ -131,5 +134,40 @@ public class SetlistService {
         }
 
         return requests.size();
+    }
+
+    public GetSetlistDetailResponse getSetlistDetail(Long userId, Long setlistId) {
+        Setlist setlist = setlistRepository.findByIdAndUserId(setlistId, userId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+
+        List<SetlistMusicResponseDto> musics = setlistMusicRepository.findBySetlist(setlist).stream()
+                .sorted(Comparator.comparing(SetlistMusic::getOrders))
+                .map(m -> new SetlistMusicResponseDto(
+                        m.getId(), m.getTrackId(), m.getArtistName(),
+                        m.getTrackName(), m.getArtworkUrl(), m.getPreviewUrl(), m.getOrders()
+                ))
+                .toList();
+
+        if (setlist.getType() == SetlistType.CONCERT) {
+            Concert concert = concertRepository.findById(setlist.getTypeId())
+                    .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+            return new GetSetlistDetailResponse(
+                    setlist.getId(), "CONCERT", concert.getId(),
+                    concert.getPosterPath(), concert.getPosterBgPath(),
+                    concert.getTitle(), concert.getSubtitle(),
+                    concert.getStartAt(), concert.getEndAt(),
+                    musics
+            );
+        } else {
+            Festival festival = festivalRepository.findById(setlist.getTypeId())
+                    .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+            return new GetSetlistDetailResponse(
+                    setlist.getId(), "FESTIVAL", festival.getId(),
+                    festival.getPosterPath(), festival.getPosterBgPath(),
+                    festival.getTitle(), festival.getSubtitle(),
+                    festival.getStartAt(), festival.getEndAt(),
+                    musics
+            );
+        }
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/GetSetlistDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/GetSetlistDetailResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.confeti.domain.setlist.application.dto.response;
+
+import java.time.LocalDate;
+import java.util.List;
+
+public record GetSetlistDetailResponse(
+        Long setlistId,
+        String type,
+        Long typeId,
+        String posterUrl,
+        String posterBgUrl,
+        String title,
+        String subTitle,
+        LocalDate startAt,
+        LocalDate endAt,
+        List<SetlistMusicResponseDto> musics
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistMusicResponseDto.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistMusicResponseDto.java
@@ -1,0 +1,12 @@
+package org.sopt.confeti.domain.setlist.application.dto.response;
+
+public record SetlistMusicResponseDto(
+        Long musicId,
+        String trackId,
+        String artistName,
+        String trackName,
+        String artworkUrl,
+        String previewUrl,
+        int orders
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/config/JacksonConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/JacksonConfig.java
@@ -1,6 +1,8 @@
 package org.sopt.confeti.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -11,6 +13,9 @@ public class JacksonConfig {
     @Bean
     @Primary
     public ObjectMapper objectMapper() {
-        return new ObjectMapper();
+        ObjectMapper objectMapper = new ObjectMapper();
+        objectMapper.registerModule(new JavaTimeModule());
+        objectMapper.disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS);
+        return objectMapper;
     }
 }

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -23,6 +23,7 @@ import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRe
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
 import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.OAuthProvider;
 import org.sopt.confeti.domain.user.User;
@@ -40,6 +41,7 @@ class SetlistServiceTest {
     @Mock private ConcertRepository concertRepository;
     @Mock private FestivalRepository festivalRepository;
     @Mock private UserRepository userRepository;
+    @Mock private SetlistMusicRepository setlistMusicRepository;
 
     private final Long userId = 1L;
     private final User user = mockUser(userId);
@@ -116,7 +118,7 @@ class SetlistServiceTest {
     }
 
     private Concert mockConcert(String title, LocalDate endAt) {
-        return Concert.builder()
+        Concert concert = Concert.builder()
                 .title(title)
                 .subtitle("sub")
                 .startAt(endAt.minusDays(2))
@@ -136,10 +138,13 @@ class SetlistServiceTest {
                 .musics(List.of())
                 .reservationUrls(List.of())
                 .build();
+
+        ReflectionTestUtils.setField(concert, "id", 100L);
+        return concert;
     }
 
     private Festival mockFestival(String title, LocalDate endAt) {
-        return Festival.builder()
+        Festival festival = Festival.builder()
                 .title(title)
                 .subtitle("sub")
                 .startAt(endAt.minusDays(2))
@@ -160,6 +165,9 @@ class SetlistServiceTest {
                 .musics(List.of())
                 .reservationUrls(List.of())
                 .build();
+
+        ReflectionTestUtils.setField(festival, "id", 200L);
+        return festival;
     }
 
     @Test
@@ -247,5 +255,83 @@ class SetlistServiceTest {
         assertThat(allMusics.get(3).getArtistName()).isEqualTo("NewJeans");
     }
 
+    @Test
+    void 셋리스트_상세조회_CONCERT_타입일_경우_정상조회() {
+        // given
+        Long setlistId = 10L;
+        Long concertId = 100L;
 
+        Setlist setlist = Setlist.builder()
+                .user(user)
+                .type(SetlistType.CONCERT)
+                .typeId(concertId)
+                .build();
+        ReflectionTestUtils.setField(setlist, "id", setlistId);
+
+        SetlistMusic music = SetlistMusic.builder()
+                .trackId("01")
+                .artistName("IU")
+                .trackName("Love wins all")
+                .artworkUrl("art.jpg")
+                .previewUrl("prev.mp3")
+                .orders(1)
+                .build();
+        music.setSetlist(setlist);
+
+        Concert concert = mockConcert("아이유 콘서트", LocalDate.of(2024, 5, 10));
+        given(setlistRepository.findByIdAndUserId(setlistId, userId)).willReturn(Optional.of(setlist));
+        given(concertRepository.findById(concertId)).willReturn(Optional.of(concert));
+        given(setlistMusicRepository.findBySetlist(setlist)).willReturn(List.of(music));
+
+        // when
+        var result = setlistService.getSetlistDetail(userId, setlistId);
+
+        // then
+        assertThat(result.type()).isEqualTo("CONCERT");
+        assertThat(result.typeId()).isEqualTo(concertId);
+        assertThat(result.title()).isEqualTo("아이유 콘서트");
+        assertThat(result.musics()).hasSize(1);
+        assertThat(result.musics().get(0).trackId()).isEqualTo("01");
+        assertThat(result.musics().get(0).artistName()).isEqualTo("IU");
+    }
+
+    @Test
+    void 셋리스트_상세조회_FESTIVAL_타입일_경우_정상조회() {
+        // given
+        Long setlistId = 20L;
+        Long festivalId = 200L;
+
+        Setlist setlist = Setlist.builder()
+                .user(user)
+                .type(SetlistType.FESTIVAL)
+                .typeId(festivalId)
+                .build();
+        ReflectionTestUtils.setField(setlist, "id", setlistId);
+
+        SetlistMusic music = SetlistMusic.builder()
+                .trackId("02")
+                .artistName("NewJeans")
+                .trackName("ETA")
+                .artworkUrl("art2.jpg")
+                .previewUrl("prev2.mp3")
+                .orders(1)
+                .build();
+        music.setSetlist(setlist);
+
+        Festival festival = mockFestival("부산 록 페스티벌", LocalDate.of(2024, 8, 20));
+        given(setlistRepository.findByIdAndUserId(setlistId, userId)).willReturn(Optional.of(setlist));
+        given(festivalRepository.findById(festivalId)).willReturn(Optional.of(festival));
+        given(setlistMusicRepository.findBySetlist(setlist)).willReturn(List.of(music));
+
+        // when
+        var result = setlistService.getSetlistDetail(userId, setlistId);
+
+        // then
+        assertThat(result.type()).isEqualTo("FESTIVAL");
+        assertThat(result.typeId()).isEqualTo(festivalId);
+        assertThat(result.title()).isEqualTo("부산 록 페스티벌");
+        assertThat(result.musics()).hasSize(1);
+        assertThat(result.musics().get(0).trackId()).isEqualTo("02");
+        assertThat(result.musics().get(0).artistName()).isEqualTo("NewJeans");
+    }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #367 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 상세 조회 API 구현
- [x] Jackson ISO 포맷 적용


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- 유저가 저장한 셋리스트 상세 정보를 조회하는 API를 구현했습니다.
- Setlist를 `userId`, `setlistId`로 조회하도록 했습니다.
- Setlist.type이 `FESTIVAL`인지 `CONCERT`인지에 따라 그에 해당하는 공연 정보 및 해당 셋리스트에 담긴 곡들을 함께 반환하도록 구현했습니다.
- SetlistMusics를 `orders` 순으로 정렬하여 함께 반환하도록 하였습니다.

### 1. 콘서트 조회
<img width="713" alt="image" src="https://github.com/user-attachments/assets/ea3a0a2a-905f-459e-b9ae-18c574a6643b" />

### 2. 페스티벌 조회
<img width="725" alt="image" src="https://github.com/user-attachments/assets/c2bc6c25-63ef-4429-9dde-76894c49ecde" />

### 3. 테스트 코드
<img width="463" alt="image" src="https://github.com/user-attachments/assets/43e7f430-41c9-4034-a7a0-2da0f7bae6b9" />
