### PR TITLE
feat [#369] MY 셋리스트 > 항목 삭제 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistEditController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistEditController.java
@@ -10,6 +10,7 @@ import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -41,5 +42,15 @@ public class SetlistEditController {
     ) {
         setlistEditService.updateMusicOrder(userId, setlistId, request);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
+    @DeleteMapping("/{setlistId}/musics/{orders}")
+    public ResponseEntity<BaseResponse<?>> deleteMusic(
+            @UserId(require = false) Long userId,
+            @PathVariable Long setlistId,
+            @PathVariable int orders
+    ) {
+        String deleteTrackId = setlistEditService.deleteMusic(userId, setlistId, orders);
+        return ApiResponseUtil.success(SuccessMessage.DELETED, deleteTrackId);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
@@ -18,6 +18,7 @@ import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @RequiredArgsConstructor
 @Service
@@ -28,6 +29,7 @@ public class SetlistEditService {
     private final RedisTemplate<String, List<SetlistMusicEditDto>> redisTemplate;
     private final ObjectMapper objectMapper;
 
+    @Transactional
     public void startEdit(Long userId, Long setlistId) {
         Setlist setlist = setlistRepository.findByIdAndUserId(setlistId, userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
@@ -41,6 +43,7 @@ public class SetlistEditService {
         redisTemplate.opsForValue().set(redisKey, musicDtos);
     }
 
+    @Transactional
     public void updateMusicOrder(Long userId, Long setlistId, List<SetlistMusicOrderUpdateRequest> requests) {
         String key = generateRedisKey(userId, setlistId);
         Object raw = redisTemplate.opsForValue().get(key);
@@ -71,6 +74,38 @@ public class SetlistEditService {
                 .toList();
 
         redisTemplate.opsForValue().set(key, updated);
+    }
+
+    @Transactional
+    public String deleteMusic(Long userId, Long setlistId, int orders) {
+        String key = generateRedisKey(userId, setlistId);
+        Object raw = redisTemplate.opsForValue().get(key);
+        if(raw == null) throw new NotFoundException(ErrorMessage.NOT_FOUND);
+
+        List<SetlistMusicEditDto> musics = objectMapper.convertValue(raw, new TypeReference<>() {});
+        if(musics.isEmpty()) throw new NotFoundException(ErrorMessage.NOT_FOUND);
+
+        SetlistMusicEditDto deleted = musics.stream()
+                .filter(m -> m.orders() == orders)
+                .findFirst()
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+
+        musics = musics.stream()
+                .filter(m -> m.orders() != orders)
+                .sorted(Comparator.comparing(SetlistMusicEditDto::orders))
+                .toList();
+
+        List<SetlistMusicEditDto> reordered = new ArrayList<>();
+        for (int i = 0; i < musics.size(); i++) {
+            SetlistMusicEditDto m = musics.get(i);
+            reordered.add(new SetlistMusicEditDto(
+                    m.musicId(), m.trackId(), m.artistName(), m.trackName(),
+                    m.artworkUrl(), m.previewUrl(), i + 1
+            ));
+        }
+
+        redisTemplate.opsForValue().set(key, reordered);
+        return deleted.trackId();
     }
 
     private String generateRedisKey(Long userId, Long setlistId) {

--- a/src/main/java/org/sopt/confeti/global/message/SuccessMessage.java
+++ b/src/main/java/org/sopt/confeti/global/message/SuccessMessage.java
@@ -9,6 +9,7 @@ import org.springframework.http.HttpStatus;
 public enum SuccessMessage {
     SUCCESS(HttpStatus.OK, "요청이 성공했습니다."),
     CREATED(HttpStatus.CREATED, "생성되었습니다."),
+    DELETED(HttpStatus.OK, "삭제가 완료되었습니다.")
     ;
 
     private final HttpStatus httpStatus;

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistEditServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistEditServiceTest.java
@@ -134,4 +134,36 @@ class SetlistEditServiceTest {
             }
         });
     }
+
+    @Test
+    void deleteMusic_곡_삭제_및_순서_재정렬() {
+        // given
+        Long userId = 1L;
+        Long setlistId = 100L;
+        String redisKey = "edit:setlist:" + userId + ":" + setlistId;
+
+        List<SetlistMusicEditDto> originalList = List.of(
+                new SetlistMusicEditDto(1L, "track1", "Artist A", "Song A", "url1", "preview1", 1),
+                new SetlistMusicEditDto(2L, "track2", "Artist B", "Song B", "url2", "preview2", 2),
+                new SetlistMusicEditDto(3L, "track3", "Artist C", "Song C", "url3", "preview3", 3)
+        );
+
+        given(redisTemplate.opsForValue()).willReturn(valueOperations);
+        given(valueOperations.get(redisKey)).willReturn(originalList);
+
+        // when
+        String deletedTrackId = setlistEditService.deleteMusic(userId, setlistId, 2);
+
+        // then
+        assertThat(deletedTrackId).isEqualTo("track2");
+
+        ArgumentCaptor<List<SetlistMusicEditDto>> captor = ArgumentCaptor.forClass(List.class);
+        verify(valueOperations).set(eq(redisKey), captor.capture());
+
+        List<SetlistMusicEditDto> updated = captor.getValue();
+        assertThat(updated).hasSize(2);
+        assertThat(updated.get(0).orders()).isEqualTo(1);
+        assertThat(updated.get(1).orders()).isEqualTo(2);
+        assertThat(updated).extracting(SetlistMusicEditDto::trackId).containsExactly("track1", "track3");
+    }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #369 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] Redis에 임시 저장된 편집 셋리스트에서 특정 순서의 곡을 삭제하는 로직을 구현했습니다.
- [x] 삭제 이후 나머지 곡들의 순서를 재정렬하는 로직을 추가했습니다.


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- MY 셋리스트 편집 기능 중 단일 곡 삭제 API를 구현했습니다.
- Redis에 임시 저장된 편집 목록에서 지정된 orders 값을 가진 곡을 삭제하고, 나머지 곡들의 순서를 재정렬하도록 구현했습니다.
- 삭제된 곡의 trackId를 응답 값으로 반환하도록 하였습니다.
- 테스트 코드(`SetlistEditServiceTest`)에서 편집 시작(`startEdit`) 및 순서 변경(`updateMusicOrder`) 기능과 함께 삭제 기능(`deleteMusic`) 테스트를 추가로 작성하여 기능 검증을 완료했습니다!

## 테스트
### 삭제 전
<img width="701" alt="image" src="https://github.com/user-attachments/assets/37477897-f103-4a21-8287-fefe8f731c10" />

### 삭제 후 (order == 3 해당 데이터 삭제 후 재정렬 됨)
<img width="705" alt="image" src="https://github.com/user-attachments/assets/3270031d-a8ca-4349-b02b-deba73b85c67" />
<img width="696" alt="image" src="https://github.com/user-attachments/assets/e6e07b2d-3505-43c1-8ec0-a10ca26b086d" />

### DB에는 반영되지 않음(track_id == “05” 삭제 안됨)
<img width="707" alt="image" src="https://github.com/user-attachments/assets/5b03bede-2f42-42b6-8a3c-1fa05c9ebb28" />


