### PR TITLE
refactor [#371] 셋리스트 전체목록 조회 파라미터 값 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistController.java
@@ -37,9 +37,9 @@ public class SetlistController {
     @GetMapping("/all")
     public ResponseEntity<BaseResponse<?>> getAllMySetlists(
             @UserId(require = false) Long userId,
-            @RequestParam(required = false) String sort
+            @RequestParam(name = "sortBy", required = false) String sortBy
     ) {
-        SetlistSortType sortType = SetlistSortType.from(sort);
+        SetlistSortType sortType = SetlistSortType.from(sortBy);
         GetAllSetlistsResponse data = setlistService.getAllMySetlists(userId, sortType);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
     }

--- a/src/main/java/org/sopt/confeti/domain/setlist/SetlistSortType.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/SetlistSortType.java
@@ -3,8 +3,8 @@ package org.sopt.confeti.domain.setlist;
 import java.util.Arrays;
 
 public enum SetlistSortType {
-    OLDEST("oldest"),
-    LATEST("latest");
+    OLDEST("oldestFirst"),
+    LATEST("createdAt");
 
     private final String value;
 

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -57,6 +57,9 @@ public class SetlistService {
                                 setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt());
                     }
                 })
+                .toList();
+
+        dtoList = dtoList.stream()
                 .sorted((a, b) -> {
                     if (sortType == SetlistSortType.OLDEST) {
                         return a.endAt().compareTo(b.endAt());


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #371 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 셋리스트 전체목록 조회 파라미터 값 수정
- [x] 정렬 로직 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- 클라이언트 요청에 따라 셋리스트 전체목록 조회 파라미터 값을 수정했습니다.
  - ordest -> `ordestFirst` 
  - latest -> `createdAt` 
  - sort -> `sortBy`
- 정렬 시 콘서트 따로, 페스티벌 따로 정렬하는 것이 아닌 전체 목록을 조회 후 정렬기준에 따라 정렬되도록 수정했습니다.

## 테스트
### 정렬기준 `oldestFirst` 오래된 순 (default)
<img width="786" alt="image" src="https://github.com/user-attachments/assets/805f2d09-71c8-43ac-92ae-9196d81c643a" />

### 정렬기준 `createdAt` 최신 순
<img width="773" alt="image" src="https://github.com/user-attachments/assets/d1a39dc4-94a1-41cd-8f5c-c63b2f08d4d7" />
