### PR TITLE
feat [#375] MY 셋리스트 > 편집 완료 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/SetlistEditController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/SetlistEditController.java
@@ -53,4 +53,13 @@ public class SetlistEditController {
         String deleteTrackId = setlistEditService.deleteMusic(userId, setlistId, orders);
         return ApiResponseUtil.success(SuccessMessage.DELETED, deleteTrackId);
     }
+
+    @PatchMapping("/{setlistId}/edit/complete")
+    public ResponseEntity<BaseResponse<?>> completeEdit(
+            @UserId(require = false) Long userId,
+            @PathVariable Long setlistId
+    ) {
+        setlistEditService.completeEdit(userId, setlistId);
+        return ApiResponseUtil.success(SuccessMessage.UPDATED);
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
@@ -108,6 +108,47 @@ public class SetlistEditService {
         return deleted.trackId();
     }
 
+    @Transactional
+    public void completeEdit(Long userId, Long setlistId) {
+        String key = generateRedisKey(userId, setlistId);
+        Object raw = redisTemplate.opsForValue().get(key);
+        if (raw == null) throw new NotFoundException(ErrorMessage.NOT_FOUND);
+
+        List<SetlistMusicEditDto> edited = objectMapper.convertValue(raw, new TypeReference<>() {});
+        if (edited.isEmpty()) throw new NotFoundException(ErrorMessage.NOT_FOUND);
+
+        Setlist setlist = setlistRepository.findByIdAndUserId(setlistId, userId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+
+        List<SetlistMusic> original = setlistMusicRepository.findBySetlist(setlist);
+
+        Map<Long, SetlistMusicEditDto> editedMap = edited.stream()
+                .collect(Collectors.toMap(SetlistMusicEditDto::musicId, dto -> dto));
+
+        List<SetlistMusic> toUpdate = new ArrayList<>();
+        List<SetlistMusic> toDelete = new ArrayList<>();
+
+        for (SetlistMusic music : original) {
+            SetlistMusicEditDto dto = editedMap.get(music.getId());
+            if (dto != null) {
+                music.changeOrder(dto.orders());
+                toUpdate.add(music);
+            } else {
+                toDelete.add(music);
+            }
+        }
+
+        if (!toUpdate.isEmpty()) {
+            setlistMusicRepository.saveAll(toUpdate);
+        }
+        if (!toDelete.isEmpty()) {
+            setlistMusicRepository.deleteAll(toDelete);
+        }
+
+        redisTemplate.delete(key);
+    }
+
+
     private String generateRedisKey(Long userId, Long setlistId) {
         return "edit:setlist:" + userId + ":" + setlistId;
     }

--- a/src/main/java/org/sopt/confeti/global/message/SuccessMessage.java
+++ b/src/main/java/org/sopt/confeti/global/message/SuccessMessage.java
@@ -9,7 +9,8 @@ import org.springframework.http.HttpStatus;
 public enum SuccessMessage {
     SUCCESS(HttpStatus.OK, "요청이 성공했습니다."),
     CREATED(HttpStatus.CREATED, "생성되었습니다."),
-    DELETED(HttpStatus.OK, "삭제가 완료되었습니다.")
+    DELETED(HttpStatus.OK, "삭제가 완료되었습니다."),
+    UPDATED(HttpStatus.OK, "업데이트가 완료되었습니다.")
     ;
 
     private final HttpStatus httpStatus;


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #375 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 편집 완료 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- MY 셋리스트 > 편집 완료 기능을 구현했습니다.
- Redis에 저장된 편집 중인 셋리스트 데이터를 기반으로
  - 남아있는 항목들의 `순서를 DB에 반영`,
  - 삭제된 항목은` DB에서 제거`,
  - 반영이 완료되면 `Redis의 해당 데이터를 삭제`하도록 로직을 구현했습니다.
- 이후에 `saveAll`, `deleteAll`을 통해 DB에 일괄적으로 반영하도록 구현했습니다!

## 테스트
### 편집 전
<img width="700" alt="image" src="https://github.com/user-attachments/assets/e625a4ec-5527-4975-ab7b-0eb141b583ca" />

### 편집 중 (trackId “01” <> “03” 항목 순서 변경 이후 3번째 항목 “01” 삭제)
<img width="695" alt="image" src="https://github.com/user-attachments/assets/9b72b950-67d2-4669-ad32-85c04c9ae914" />

### 편집 완료
<img width="701" alt="image" src="https://github.com/user-attachments/assets/4c2dcebc-e716-426f-8b71-5421bd96b81f" />

(1) 편집완료 후 redis는 삭제
<img width="637" alt="image" src="https://github.com/user-attachments/assets/fa05d839-624e-40f7-92c1-812057b5ad0b" />

(2) 편집완료 후 DB에 반영완료
<img width="702" alt="image" src="https://github.com/user-attachments/assets/25e92602-79f2-441e-a255-7be7282a223b" />
