### PR TITLE
feat [#380] 공연 연관 검색 API에 공연 상태 쿼리 추가

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -1,6 +1,8 @@
 package org.sopt.confeti.api.performance.controller;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.dto.request.PatchRecommendMusics;
 import org.sopt.confeti.api.performance.dto.response.AnalyzePerformanceTypeResponse;
@@ -33,6 +35,7 @@ import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.common.constant.Default;
+import org.sopt.confeti.global.common.constant.PerformanceStatus;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.common.constant.RequestConstraint;
 import org.sopt.confeti.global.message.SuccessMessage;
@@ -123,12 +126,14 @@ public class PerformanceController {
     @GetMapping("/search/ac")
     public ResponseEntity<BaseResponse<?>> searchAutoComplete(
             @UserId(require = false) Long userId,
-            @RequestParam String term,
-            @RequestParam(required = false, defaultValue = "1") Integer limit
+            @RequestParam @NotBlank String term,
+            @RequestParam(required = false, defaultValue = "1") @Min(1) @Max(10) Integer limit,
+            @RequestParam(required = false, defaultValue = Default.PERFORMANCE_STATUS) String status
     ) {
-        SearchACPerformancesDTO performacnesDTO = performanceFacade.searchACPerformances(term, limit);
+        SearchACPerformancesDTO performancesDTO = performanceFacade.searchACPerformances(term, limit,
+                PerformanceStatus.convert(status));
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                SearchACPerformancesResponse.of(performacnesDTO, s3FileHandler));
+                SearchACPerformancesResponse.of(performancesDTO, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -46,6 +46,7 @@ import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.common.constant.PerformanceStatus;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.exception.NotFoundException;
@@ -257,9 +258,9 @@ public class PerformanceFacade {
     }
 
     @Transactional(readOnly = true)
-    public SearchACPerformancesDTO searchACPerformances(String term, int limit) {
+    public SearchACPerformancesDTO searchACPerformances(String term, int limit, PerformanceStatus status) {
         return SearchACPerformancesDTO.from(
-                performanceSearchService.getPerformancesByTitle(term, limit)
+                performanceSearchService.getPerformancesByTitle(term, limit, status)
         );
     }
 

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
@@ -6,6 +6,7 @@ import org.sopt.confeti.domain.elastic_search.PerformanceDocument;
 import org.sopt.confeti.domain.elastic_search.application.dto.response.SearchPerformanceResult;
 import org.sopt.confeti.domain.elastic_search.infra.PerformanceSearchOperator;
 import org.sopt.confeti.domain.elastic_search.infra.PerformanceSearchRepository;
+import org.sopt.confeti.global.common.constant.PerformanceStatus;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -31,7 +32,7 @@ public class PerformanceSearchService {
     public List<SearchPerformanceResult> getPerformancesByTitleAndTypePartialMatched(String ptitle,
                                                                                      PerformanceType ptype) {
         List<PerformanceDocument> performances = performanceSearchOperator.searchByTitleAndTypePartialMatch(
-                clearSentence(ptitle), ptype);
+                clearSentence(ptitle), ptype, PerformanceStatus.ALL);
 
         return performances.stream()
                 .map(SearchPerformanceResult::from)
@@ -39,9 +40,9 @@ public class PerformanceSearchService {
     }
 
     @Transactional(readOnly = true)
-    public List<SearchPerformanceResult> getPerformancesByTitle(String title, int limit) {
-        List<PerformanceDocument> performances = performanceSearchRepository.findPerformanceDocumentsByTitleStartingWith(
-                clearSentence(title));
+    public List<SearchPerformanceResult> getPerformancesByTitle(String title, int limit, PerformanceStatus status) {
+        List<PerformanceDocument> performances = performanceSearchOperator.searchByTitleAndTypePartialMatch(title,
+                PerformanceType.PERFORMANCE, status);
 
         return performances.stream()
                 .map(SearchPerformanceResult::from)

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/infra/PerformanceSearchOperator.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/infra/PerformanceSearchOperator.java
@@ -1,8 +1,12 @@
 package org.sopt.confeti.domain.elastic_search.infra;
 
+import co.elastic.clients.elasticsearch._types.query_dsl.BoolQuery;
+import co.elastic.clients.elasticsearch._types.query_dsl.QueryBuilders;
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.elastic_search.PerformanceDocument;
+import org.sopt.confeti.global.common.constant.PerformanceStatus;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
@@ -17,31 +21,99 @@ public class PerformanceSearchOperator {
 
     private static final String TITLE_PARTIAL = "title.partial";
     private static final String TYPE = "type";
+    private static final String END_AT = "type";
+    private static final String CURRENT_DATE = LocalDate.now().toString();
 
     private final ElasticsearchOperations elasticsearchOperations;
 
-    public List<PerformanceDocument> searchByTitleAndTypePartialMatch(String term, PerformanceType type) {
+    private static class BoolQueryBuilder {
+
+        private final BoolQuery.Builder boolQueryBuilder;
+        private boolean isNotPerformanceType;
+        private boolean isUpcomingStatus;
+
+        private BoolQueryBuilder() {
+            this.boolQueryBuilder = QueryBuilders.bool();
+            isNotPerformanceType = isUpcomingStatus = true;
+        }
+
+        public static BoolQueryBuilder builder() {
+            return new BoolQueryBuilder();
+        }
+
+        public BoolQueryBuilder ifNotPerformanceType(PerformanceType type) {
+            if (type == PerformanceType.PERFORMANCE) {
+                isNotPerformanceType = false;
+            }
+
+            return this;
+        }
+
+        public BoolQueryBuilder ifUpcomingStatus(PerformanceStatus status) {
+            if (status != PerformanceStatus.UPCOMING) {
+                isUpcomingStatus = false;
+            }
+
+            return this;
+        }
+
+        public BoolQueryBuilder match(String field, String value) {
+            boolQueryBuilder.must(must -> must
+                    .match(match -> match
+                            .field(field)
+                            .query(value)
+                    )
+            );
+
+            return this;
+        }
+
+        public BoolQueryBuilder matchType(PerformanceType type) {
+            if (isNotPerformanceType) {
+                boolQueryBuilder.must(must -> must
+                        .match(match -> match
+                                .field(TYPE)
+                                .query(type.getType())
+                        )
+                );
+            }
+
+            return this;
+        }
+
+        public BoolQueryBuilder rangeDateGte(String field, String value) {
+            if (isUpcomingStatus) {
+                boolQueryBuilder.must(must -> must
+                        .range(range -> range
+                                .date(date -> date
+                                        .field(field)
+                                        .gte(value)
+                                )
+                        )
+                );
+
+            }
+
+            return this;
+        }
+
+        public BoolQuery build() {
+            return this.boolQueryBuilder.build();
+        }
+    }
+
+    public List<PerformanceDocument> searchByTitleAndTypePartialMatch(String term, PerformanceType type,
+                                                                      PerformanceStatus status) {
         Query partialMatchedQuery = NativeQuery.builder()
-                .withQuery(query -> query
-                        .bool(bool -> {
-                            bool.must(must -> must
-                                    .match(match -> match
-                                            .field(TITLE_PARTIAL)
-                                            .query(term)
-                                    )
-                            );
-
-                            if (type != PerformanceType.PERFORMANCE) {
-                                bool.must(must -> must
-                                        .match(match -> match
-                                                .field(TYPE)
-                                                .query(type.getType())
-                                        )
-                                );
-                            }
-
-                            return bool;
-                        })
+                .withQuery(query -> query.bool(
+                                BoolQueryBuilder.builder()
+                                        .match(TITLE_PARTIAL, term)
+                                        .ifNotPerformanceType(type)
+                                        .matchType(type)
+                                        .ifUpcomingStatus(status)
+                                        .rangeDateGte(END_AT, CURRENT_DATE)
+                                        .build()
+                        )
                 )
                 .build();
 

--- a/src/main/java/org/sopt/confeti/global/common/constant/Default.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/Default.java
@@ -11,4 +11,5 @@ public class Default {
     public static final String TEXT = "CONFETI";
     public static final String PROFILE_IMG_NAME = "user-profile.svg";
     public static final String PERFORMANCE_TYPE = "performance";
+    public static final String PERFORMANCE_STATUS = "all";
 }

--- a/src/main/java/org/sopt/confeti/global/common/constant/PerformanceStatus.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/PerformanceStatus.java
@@ -1,0 +1,24 @@
+package org.sopt.confeti.global.common.constant;
+
+import java.util.Arrays;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
+
+@Getter
+@RequiredArgsConstructor
+public enum PerformanceStatus {
+    UPCOMING("upcoming"), ALL("all");
+    
+    private final String status;
+
+    public static PerformanceStatus convert(final String input) {
+        return Arrays.stream(PerformanceStatus.values())
+                .filter(performanceType -> performanceType.getStatus().equalsIgnoreCase(input))
+                .findFirst()
+                .orElseThrow(
+                        () -> new ConfetiException(ErrorMessage.BAD_REQUEST)
+                );
+    }
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #380 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 공연 연관 검색 API에 공연 상태 쿼리 추가


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
![image](https://github.com/user-attachments/assets/52a9a6ca-4dff-41a3-9c8d-9363b74511a8)
셋리스트에서도 해당 API를 재사용하기 위해 status 값을 추가했어요.
셋리스트에서는 공연 종료 여부와 상관없이 모든 공연을 대상으로 검색이 가능해야합니다!