### PR TITLE
feat [#385] 셋리스트 공연 추가를 위한 공연 검색 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -22,8 +22,8 @@ import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.IntendedPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsPerformanceDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsPerformanceDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.SearchACPerformancesDTO;
 import org.sopt.confeti.domain.artist_favorite.ArtistFavorite;
@@ -190,7 +190,7 @@ public class PerformanceFacade {
 
     @Transactional(readOnly = true)
     public ArtistPerformancesDTO getPerformancesByArtistId(final Long userId, final String artistId) {
-        List<PerformanceDTO> performances = performanceService.findPerformancesByArtistId(artistId);
+        List<PerformanceDTO> performances = performanceService.getPerformancesByArtistId(artistId);
 
         Map<String, Boolean> favoriteMap = getFavoriteMap(userId, performances);
         List<ArtistPerformancesDetailDTO> performanceList = performances.stream()
@@ -272,7 +272,7 @@ public class PerformanceFacade {
         List<PerformanceDTO> performances = new ArrayList<>();
 
         if (isPresent(pid)) {
-            performances.add(performanceService.getPerformance(pid));
+            performances.add(PerformanceDTO.from(performanceService.getPerformanceById(pid)));
         }
 
         if (isPresent(aid)) {

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
@@ -2,6 +2,9 @@ package org.sopt.confeti.api.setlist.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSearchPerformancesResponse;
+import org.sopt.confeti.api.setlist.facade.SetlistFacade;
+import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformancesDTO;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.application.SetlistService;
 import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRequest;
@@ -17,6 +20,7 @@ import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -32,6 +36,8 @@ import org.springframework.web.bind.annotation.RestController;
 public class SetlistController {
 
     private final SetlistService setlistService;
+    private final SetlistFacade setlistFacade;
+    private final S3FileHandler s3FileHandler;
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/all")
@@ -82,5 +88,18 @@ public class SetlistController {
     ) {
         GetSetlistDetailResponse data = setlistService.getSetlistDetail(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/performances/search")
+    public ResponseEntity<BaseResponse<?>> searchPerformances(
+            @UserId(require = false) Long userId,
+            @RequestParam(required = false) String aid,
+            @RequestParam(required = false) Long pid,
+            @RequestParam(required = false) String term
+    ) {
+        SearchPerformancesDTO searchResult = setlistFacade.searchPerformances(aid, pid, term);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                SetlistSearchPerformancesResponse.of(searchResult, s3FileHandler));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.api.setlist;
+package org.sopt.confeti.api.setlist.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistEditController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistEditController.java
@@ -1,8 +1,7 @@
-package org.sopt.confeti.api.setlist;
+package org.sopt.confeti.api.setlist.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.domain.setlist.application.SetlistEditService;
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicOrderUpdateRequest;
 import org.sopt.confeti.global.annotation.UserId;

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSearchPerformanceResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSearchPerformanceResponse.java
@@ -1,0 +1,23 @@
+package org.sopt.confeti.api.setlist.dto.response;
+
+import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformanceDTO;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record SetlistSearchPerformanceResponse(
+        long performanceId,
+        String title,
+        String posterUrl
+) {
+    public static SetlistSearchPerformanceResponse of(SearchPerformanceDTO performanceDTO,
+                                                      S3FileHandler s3FileHandler) {
+        return new SetlistSearchPerformanceResponse(
+                performanceDTO.id(),
+                performanceDTO.title(),
+                s3FileHandler.getFileUrl(
+                        FolderPath.combine(FolderPath.getFolderPathByPerformanceType(performanceDTO.type()),
+                                FolderPath.POSTER),
+                        performanceDTO.posterPath()).toString()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSearchPerformancesResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSearchPerformancesResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.confeti.api.setlist.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformancesDTO;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record SetlistSearchPerformancesResponse(
+        int performanceCount,
+        List<SetlistSearchPerformanceResponse> performances
+) {
+    public static SetlistSearchPerformancesResponse of(SearchPerformancesDTO performancesDTO,
+                                                       S3FileHandler s3FileHandler) {
+        return new SetlistSearchPerformancesResponse(
+                performancesDTO.performances().size(),
+                performancesDTO.performances().stream()
+                        .map(performanceDTO -> SetlistSearchPerformanceResponse.of(performanceDTO, s3FileHandler))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistFacade.java
@@ -1,0 +1,93 @@
+package org.sopt.confeti.api.setlist.facade;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import kr.co.shineware.nlp.komoran.model.KomoranResult;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformancesDTO;
+import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
+import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
+import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.common.AnalyzeSearchTermResult;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+import org.sopt.confeti.global.util.MorphemeAnalyzer;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.springframework.transaction.annotation.Transactional;
+
+@Facade
+@RequiredArgsConstructor
+public class SetlistFacade {
+
+    private static final int SEARCH_ARTIST_BY_KEYWORD_LIMIT = 1;
+
+    private final PerformanceService performanceService;
+    private final MusicAPIHandler musicAPIHandler;
+    private final PerformanceSearchService performanceSearchService;
+
+    private boolean isPresent(Object that) {
+        return Objects.nonNull(that);
+    }
+
+    @Transactional(readOnly = true)
+    public SearchPerformancesDTO searchPerformances(String aid, Long pid, String term) {
+        List<PerformanceDTO> performances = new ArrayList<>();
+        AnalyzeSearchTermResult analyzeResult = AnalyzeSearchTermResult.empty();
+
+        if (isPresent(aid)) {
+            performances.addAll(performanceService.getAllPerformancesByArtistId(aid));
+        }
+
+        if (isPresent(pid)) {
+            performances.add(PerformanceDTO.from(performanceService.getPerformanceById(pid)));
+        }
+
+        if (isPresent(term)) {
+            analyzeResult = analyzeSearchTerm(term);
+            Optional<String> artistId = getArtistId(analyzeResult.processedTerm());
+
+            artistId.ifPresent(s -> performances.addAll(performanceService.getAllPerformancesByArtistId(s)));
+
+            performances.addAll(
+                    performanceSearchService.getPerformancesByTitleAndTypePartialMatched(analyzeResult.processedTerm(),
+                                    analyzeResult.performanceType()).stream()
+                            .map(PerformanceDTO::from)
+                            .toList()
+            );
+        }
+
+        AnalyzeSearchTermResult finalAnalyzeResult = analyzeResult;
+        Set<PerformanceDTO> searchedPerformances = performances.stream()
+                .filter(
+                        performance -> finalAnalyzeResult.performanceType() == PerformanceType.PERFORMANCE ||
+                                performance.type() == finalAnalyzeResult.performanceType()
+                )
+                .collect(Collectors.toSet());
+
+        return SearchPerformancesDTO.from(
+                searchedPerformances.stream()
+                        .sorted(Comparator.comparing(PerformanceDTO::startAt).reversed())
+                        .toList()
+        );
+    }
+
+    private AnalyzeSearchTermResult analyzeSearchTerm(String term) {
+        KomoranResult analyzeResult = MorphemeAnalyzer.getAnalyzeResult(term);
+        String processedTerm = MorphemeAnalyzer.getRemovedPerformanceTypesTerm(term, analyzeResult);
+        PerformanceType performanceType = MorphemeAnalyzer.getFirstMatchingPerformanceType(analyzeResult);
+
+        return AnalyzeSearchTermResult.of(processedTerm, performanceType);
+    }
+
+    private Optional<String> getArtistId(String processedTerm) {
+        return musicAPIHandler.findArtistsByKeyword(processedTerm, SEARCH_ARTIST_BY_KEYWORD_LIMIT).stream()
+                .findFirst()
+                .map(ConfetiArtist::getId);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SearchPerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SearchPerformanceDTO.java
@@ -1,0 +1,20 @@
+package org.sopt.confeti.api.setlist.facade.dto.response;
+
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+public record SearchPerformanceDTO(
+        long id,
+        PerformanceType type,
+        String title,
+        String posterPath
+) {
+    public static SearchPerformanceDTO from(PerformanceDTO performance) {
+        return new SearchPerformanceDTO(
+                performance.id(),
+                performance.type(),
+                performance.title(),
+                performance.posterPath()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SearchPerformancesDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SearchPerformancesDTO.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.setlist.facade.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
+
+public record SearchPerformancesDTO(
+        List<SearchPerformanceDTO> performances
+) {
+    public static SearchPerformancesDTO from(List<PerformanceDTO> performances) {
+        return new SearchPerformancesDTO(
+                performances.stream()
+                        .map(SearchPerformanceDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -202,7 +202,7 @@ public class UserFavoriteFacade {
     public UpcomingPerformanceDTO getUpcomingPerformance(final long userId) {
         validateExistUser(userId);
 
-        Performance performance = performanceService.getUpcomingPerformance(userId);
+        Performance performance = performanceService.getUpcomingPerformanceByUserId(userId);
         if (performance == null) {
             return null;
         }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -75,8 +75,15 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceDTO> findPerformancesByArtistId(final String artistId) {
+    public List<PerformanceDTO> getPerformancesByArtistId(final String artistId) {
         return performanceRepository.findPerformancesByArtistId(artistId).stream()
+                .map(PerformanceDTO::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceDTO> getAllPerformancesByArtistId(final String artistId) {
+        return performanceRepository.findPerformancesByArtists_ArtistId(artistId).stream()
                 .map(PerformanceDTO::from)
                 .toList();
     }
@@ -100,15 +107,15 @@ public class PerformanceService {
     }
 
     @Transactional
-    public Performance getUpcomingPerformance(final Long userId) {
-        return performanceRepository.upcomingPerformance(userId)
+    public Performance getUpcomingPerformanceByUserId(final Long userId) {
+        return performanceRepository.upcomingPerformanceByUserId(userId)
                 .orElse(null);
     }
 
     @Transactional(readOnly = true)
     public List<PerformanceDTO> getAllPerformances() {
         return performanceRepository.findAll().stream()
-                .map(org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO::from)
+                .map(PerformanceDTO::from)
                 .toList();
     }
 
@@ -143,7 +150,7 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
-    public Performance getPerformanceByRand(){
+    public Performance getPerformanceByRand() {
         return performanceRepository.findPerformanceByRand();
     }
 

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -28,6 +28,8 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             PageRequest pageRequest
     );
 
+    List<Performance> findPerformancesByArtists_ArtistId(String artistId);
+
     @Query(value = "SELECT p" +
             " FROM Performance p " +
             " JOIN FETCH p.artists pa" +
@@ -72,7 +74,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             "        AND p.typeId IN (SELECT tf.festival.id FROM TimetableFestival tf WHERE tf.user.id = :userId))) " +
             "AND p.endAt >= CURRENT_DATE " +
             "ORDER BY p.startAt ASC LIMIT 1 ")
-    Optional<Performance> upcomingPerformance(final @Param("userId") long userId);
+    Optional<Performance> upcomingPerformanceByUserId(final @Param("userId") long userId);
 
     @Query(value = "SELECT p FROM Performance p WHERE p.endAt >= CURRENT_DATE ORDER BY RAND() LIMIT 5")
     List<Performance> findTop5ByRand();

--- a/src/main/java/org/sopt/confeti/global/common/AnalyzeSearchTermResult.java
+++ b/src/main/java/org/sopt/confeti/global/common/AnalyzeSearchTermResult.java
@@ -1,0 +1,21 @@
+package org.sopt.confeti.global.common;
+
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+public record AnalyzeSearchTermResult(
+        String processedTerm,
+        PerformanceType performanceType
+) {
+    public static AnalyzeSearchTermResult of(String processedTerm, PerformanceType performanceType) {
+        return new AnalyzeSearchTermResult(
+                processedTerm, performanceType
+        );
+    }
+
+    public static AnalyzeSearchTermResult empty() {
+        return new AnalyzeSearchTermResult(
+                "",
+                PerformanceType.PERFORMANCE
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/util/MorphemeAnalyzer.java
+++ b/src/main/java/org/sopt/confeti/global/util/MorphemeAnalyzer.java
@@ -8,11 +8,9 @@ import kr.co.shineware.nlp.komoran.model.KomoranResult;
 import kr.co.shineware.nlp.komoran.model.Token;
 import lombok.AccessLevel;
 import lombok.NoArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.global.common.constant.PerformanceKeyword;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 
-@Slf4j
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class MorphemeAnalyzer {
 
@@ -26,7 +24,6 @@ public class MorphemeAnalyzer {
         List<Token> tokens = analyzeResult.getTokenList();
 
         for (Token token : tokens) {
-            log.debug(token.getMorph());
             if (PerformanceKeyword.isValid(token.getMorph())) {
                 return PerformanceKeyword.getMatchingPerformanceType(token.getMorph());
             }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #385 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 셋리스트 공연 추가를 위한 공연 검색 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
![image](https://github.com/user-attachments/assets/bcbb309d-6b35-407c-850e-3ba1bfd125db)
아티스트 아이디, 공연 아이디, 검색어를 기준으로 공연을 가져오도록 구성했습니다.
검색어를 분석해서 원하는 공연 타입만 필터링해 검색할 수 있고, 중복 제거, 시작 일 기준 내림차순 정렬을 수행했습니다.