### PR TITLE
feat [#387] MY 셋리스트 > 아티스트 곡 검색 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicResponse.java
@@ -6,7 +6,7 @@ public record RecommendMusicResponse(
         String musicId,
         String artistName,
         String title,
-        String artWorkUrl,
+        String artworkUrl,
         String previewUrl
 ) {
     public static RecommendMusicResponse from(RecommendMusicDTO recommendMusicDTO) {
@@ -14,7 +14,7 @@ public record RecommendMusicResponse(
                 recommendMusicDTO.id(),
                 recommendMusicDTO.artistName(),
                 recommendMusicDTO.title(),
-                recommendMusicDTO.artWorkUrl(),
+                recommendMusicDTO.artworkUrl(),
                 recommendMusicDTO.previewUrl()
         );
     }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicsResponse.java
@@ -1,10 +1,10 @@
 package org.sopt.confeti.api.performance.dto.response;
 
-import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsDTO;
 import java.util.List;
+import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsDTO;
 
 public record RecommendMusicsResponse(
-        List<RecommendMusicResponse> musicList
+        List<RecommendMusicResponse> musics
 ) {
     public static RecommendMusicsResponse from(RecommendMusicsDTO musicListDTO) {
         return new RecommendMusicsResponse(

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicDTO.java
@@ -6,7 +6,7 @@ public record RecommendMusicDTO(
         String id,
         String artistName,
         String title,
-        String artWorkUrl,
+        String artworkUrl,
         String previewUrl
 ) {
     public static RecommendMusicDTO from(ConfetiMusic music) {

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
@@ -2,9 +2,6 @@ package org.sopt.confeti.api.setlist.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.api.setlist.dto.response.SetlistSearchPerformancesResponse;
-import org.sopt.confeti.api.setlist.facade.SetlistFacade;
-import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformancesDTO;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.application.SetlistService;
 import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRequest;
@@ -20,7 +17,6 @@ import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
-import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -36,8 +32,6 @@ import org.springframework.web.bind.annotation.RestController;
 public class SetlistController {
 
     private final SetlistService setlistService;
-    private final SetlistFacade setlistFacade;
-    private final S3FileHandler s3FileHandler;
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/all")
@@ -88,18 +82,5 @@ public class SetlistController {
     ) {
         GetSetlistDetailResponse data = setlistService.getSetlistDetail(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
-    }
-
-    @Permission(role = {Role.GENERAL})
-    @GetMapping("/performances/search")
-    public ResponseEntity<BaseResponse<?>> searchPerformances(
-            @UserId(require = false) Long userId,
-            @RequestParam(required = false) String aid,
-            @RequestParam(required = false) Long pid,
-            @RequestParam(required = false) String term
-    ) {
-        SearchPerformancesDTO searchResult = setlistFacade.searchPerformances(aid, pid, term);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                SetlistSearchPerformancesResponse.of(searchResult, s3FileHandler));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
@@ -1,0 +1,40 @@
+package org.sopt.confeti.api.setlist.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSearchPerformancesResponse;
+import org.sopt.confeti.api.setlist.facade.SetlistFacade;
+import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformancesDTO;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.sopt.confeti.global.util.S3FileHandler;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/my/setlists")
+public class SetlistSearchController {
+
+    private final SetlistFacade setlistFacade;
+    private final S3FileHandler s3FileHandler;
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/performances/search")
+    public ResponseEntity<BaseResponse<?>> searchPerformances(
+            @UserId(require = false) Long userId,
+            @RequestParam(required = false) String aid,
+            @RequestParam(required = false) Long pid,
+            @RequestParam(required = false) String term
+    ) {
+        SearchPerformancesDTO searchResult = setlistFacade.searchPerformances(aid, pid, term);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                SetlistSearchPerformancesResponse.of(searchResult, s3FileHandler));
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
@@ -35,7 +35,7 @@ public class SetlistSearchController {
     @Permission(role = {Role.GENERAL})
     @GetMapping("/performances")
     public ResponseEntity<BaseResponse<?>> searchPerformances(
-            @UserId(require = false) Long userId,
+            @UserId Long userId,
             @RequestParam(required = false) String aid,
             @RequestParam(required = false) Long pid,
             @RequestParam(required = false) String term
@@ -48,7 +48,7 @@ public class SetlistSearchController {
     @Permission(role = {Role.GENERAL})
     @GetMapping("/artist-musics")
     public ResponseEntity<BaseResponse<?>> searchArtistMusics(
-            @UserId(require = false) Long userId,
+            @UserId Long userId,
             @RequestParam(required = false) String aid,
             @RequestParam(required = false) String term,
             @RequestParam(required = false, defaultValue = "0") @Min(0) int offset,

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
@@ -1,13 +1,20 @@
 package org.sopt.confeti.api.setlist.controller;
 
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import java.util.Objects;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.api.setlist.dto.response.SetlistSearchPerformancesResponse;
-import org.sopt.confeti.api.setlist.facade.SetlistFacade;
-import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformancesDTO;
+import org.sopt.confeti.api.setlist.dto.response.search.SetlistSearchArtistMusicsResponse;
+import org.sopt.confeti.api.setlist.dto.response.search.SetlistSearchPerformancesResponse;
+import org.sopt.confeti.api.setlist.facade.SetlistSearchFacade;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SearchPerformancesDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchArtistMusicsDTO;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.sopt.confeti.global.util.S3FileHandler;
@@ -19,22 +26,39 @@ import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/my/setlists")
+@RequestMapping("/my/setlists/search")
 public class SetlistSearchController {
 
-    private final SetlistFacade setlistFacade;
+    private final SetlistSearchFacade setlistSearchFacade;
     private final S3FileHandler s3FileHandler;
 
     @Permission(role = {Role.GENERAL})
-    @GetMapping("/performances/search")
+    @GetMapping("/performances")
     public ResponseEntity<BaseResponse<?>> searchPerformances(
             @UserId(require = false) Long userId,
             @RequestParam(required = false) String aid,
             @RequestParam(required = false) Long pid,
             @RequestParam(required = false) String term
     ) {
-        SearchPerformancesDTO searchResult = setlistFacade.searchPerformances(aid, pid, term);
+        SearchPerformancesDTO searchResult = setlistSearchFacade.searchPerformances(aid, pid, term);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 SetlistSearchPerformancesResponse.of(searchResult, s3FileHandler));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/artist-musics")
+    public ResponseEntity<BaseResponse<?>> searchArtistMusics(
+            @UserId(require = false) Long userId,
+            @RequestParam(required = false) String aid,
+            @RequestParam(required = false) String term,
+            @RequestParam(required = false, defaultValue = "0") @Min(0) int offset,
+            @RequestParam(required = false, defaultValue = "5") @Min(1) @Max(20) int limit
+    ) {
+        if (Objects.isNull(aid) && Objects.isNull(term)) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
+
+        SetlistSearchArtistMusicsDTO artistMusics = setlistSearchFacade.searchArtistMusics(aid, term, offset, limit);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, SetlistSearchArtistMusicsResponse.from(artistMusics));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchArtistMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchArtistMusicResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.confeti.api.setlist.dto.response.search;
+
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchArtistMusicDTO;
+
+public record SetlistSearchArtistMusicResponse(
+        String musicId,
+        String title,
+        String artistName,
+        String artworkUrl,
+        String previewUrl
+) {
+    public static SetlistSearchArtistMusicResponse from(SetlistSearchArtistMusicDTO artistMusic) {
+        return new SetlistSearchArtistMusicResponse(
+                artistMusic.id(),
+                artistMusic.title(),
+                artistMusic.artistName(),
+                artistMusic.artworkUrl(),
+                artistMusic.previewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchArtistMusicsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchArtistMusicsResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.confeti.api.setlist.dto.response.search;
+
+import java.util.List;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchArtistMusicsDTO;
+
+public record SetlistSearchArtistMusicsResponse(
+        int nextOffset,
+        boolean isLast,
+        List<SetlistSearchArtistMusicResponse> musics
+) {
+    public static SetlistSearchArtistMusicsResponse from(SetlistSearchArtistMusicsDTO artistMusics) {
+        return new SetlistSearchArtistMusicsResponse(
+                artistMusics.nextOffset(),
+                artistMusics.isLast(),
+                artistMusics.musics().stream()
+                        .map(SetlistSearchArtistMusicResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchPerformanceResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchPerformanceResponse.java
@@ -1,6 +1,6 @@
-package org.sopt.confeti.api.setlist.dto.response;
+package org.sopt.confeti.api.setlist.dto.response.search;
 
-import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformanceDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SearchPerformanceDTO;
 import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.util.S3FileHandler;
 

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchPerformancesResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchPerformancesResponse.java
@@ -1,7 +1,7 @@
-package org.sopt.confeti.api.setlist.dto.response;
+package org.sopt.confeti.api.setlist.dto.response.search;
 
 import java.util.List;
-import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformancesDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SearchPerformancesDTO;
 import org.sopt.confeti.global.util.S3FileHandler;
 
 public record SetlistSearchPerformancesResponse(

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistSearchFacade.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistSearchFacade.java
@@ -9,21 +9,25 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import kr.co.shineware.nlp.komoran.model.KomoranResult;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.api.setlist.facade.dto.response.SearchPerformancesDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SearchPerformancesDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchArtistMusicsDTO;
 import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.common.AnalyzeSearchTermResult;
 import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.util.MorphemeAnalyzer;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.sopt.confeti.global.util.music.dto.music.MusicPage;
 import org.springframework.transaction.annotation.Transactional;
 
 @Facade
 @RequiredArgsConstructor
-public class SetlistFacade {
+public class SetlistSearchFacade {
 
     private static final int SEARCH_ARTIST_BY_KEYWORD_LIMIT = 1;
 
@@ -33,6 +37,31 @@ public class SetlistFacade {
 
     private boolean isPresent(Object that) {
         return Objects.nonNull(that);
+    }
+
+    private boolean isNotPresent(Object that) {
+        return Objects.isNull(that);
+    }
+
+    public SetlistSearchArtistMusicsDTO searchArtistMusics(String aid, String term, int offset, int limit) {
+        String artistId = null;
+
+        if (isPresent(aid)) {
+            artistId = aid;
+        }
+
+        if (isNotPresent(artistId)) {
+            Optional<String> searchedArtistId = getArtistId(term);
+
+            if (searchedArtistId.isEmpty()) {
+                throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+            }
+
+            artistId = searchedArtistId.get();
+        }
+
+        MusicPage musics = musicAPIHandler.getArtistMusics(aid, offset, limit);
+        return SetlistSearchArtistMusicsDTO.from(musics);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistSearchFacade.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistSearchFacade.java
@@ -60,7 +60,7 @@ public class SetlistSearchFacade {
             artistId = searchedArtistId.get();
         }
 
-        MusicPage musics = musicAPIHandler.getArtistMusics(aid, offset, limit);
+        MusicPage musics = musicAPIHandler.getArtistMusics(artistId, offset, limit);
         return SetlistSearchArtistMusicsDTO.from(musics);
     }
 

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SearchPerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SearchPerformanceDTO.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.api.setlist.facade.dto.response;
+package org.sopt.confeti.api.setlist.facade.dto.response.search;
 
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.common.constant.PerformanceType;

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SearchPerformancesDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SearchPerformancesDTO.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.api.setlist.facade.dto.response;
+package org.sopt.confeti.api.setlist.facade.dto.response.search;
 
 import java.util.List;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchArtistMusicDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchArtistMusicDTO.java
@@ -1,0 +1,21 @@
+package org.sopt.confeti.api.setlist.facade.dto.response.search;
+
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+
+public record SetlistSearchArtistMusicDTO(
+        String id,
+        String title,
+        String artistName,
+        String artworkUrl,
+        String previewUrl
+) {
+    public static SetlistSearchArtistMusicDTO from(ConfetiMusic music) {
+        return new SetlistSearchArtistMusicDTO(
+                music.getId(),
+                music.getTitle(),
+                music.getArtistName(),
+                music.getArtworkUrl(),
+                music.getPreviewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchArtistMusicsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchArtistMusicsDTO.java
@@ -1,0 +1,20 @@
+package org.sopt.confeti.api.setlist.facade.dto.response.search;
+
+import java.util.List;
+import org.sopt.confeti.global.util.music.dto.music.MusicPage;
+
+public record SetlistSearchArtistMusicsDTO(
+        int nextOffset,
+        boolean isLast,
+        List<SetlistSearchArtistMusicDTO> musics
+) {
+    public static SetlistSearchArtistMusicsDTO from(MusicPage musicPage) {
+        return new SetlistSearchArtistMusicsDTO(
+                musicPage.getNextOffset(),
+                musicPage.isLast(),
+                musicPage.getMusics().stream()
+                        .map(SetlistSearchArtistMusicDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -1,8 +1,15 @@
 package org.sopt.confeti.global.util.music;
 
 import jakarta.annotation.PostConstruct;
-
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
@@ -19,8 +26,10 @@ import org.sopt.confeti.global.util.music.dto.album.AppleMusicAlbumsResponse;
 import org.sopt.confeti.global.util.music.dto.artist.AppleMusicArtistsResponse;
 import org.sopt.confeti.global.util.music.dto.chart.AppleMusicChartSongResponse;
 import org.sopt.confeti.global.util.music.dto.chart.AppleMusicChartsResponse;
+import org.sopt.confeti.global.util.music.dto.music.AppleMusicArtistMusicsResponse;
 import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicResponse;
 import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicsResponse;
+import org.sopt.confeti.global.util.music.dto.music.MusicPage;
 import org.sopt.confeti.global.util.music.dto.search.AppleMusicSearchResponse;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
@@ -160,7 +169,7 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         if (Objects.isNull(searchResult)) {
             return List.of();
         }
-        
+
         return convertToConfetiArtists(searchResult.results().artists());
     }
 
@@ -316,7 +325,9 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                 .filter(song -> !excludedMusicIds.contains(song.getId()))
                 .collect(Collectors.toList());
 
-        if (filteredSongs.isEmpty()) return Collections.emptyList();
+        if (filteredSongs.isEmpty()) {
+            return Collections.emptyList();
+        }
 
         List<ConfetiMusic> result = new ArrayList<>();
         Random random = new Random();
@@ -328,5 +339,33 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         }
 
         return result;
+    }
+
+    @Override
+    @RetryOnTokenExpire
+    public MusicPage getArtistMusics(String artistId, int offset, int limit) {
+        Map<String, String> params = new HashMap<>();
+        params.put("offset", String.valueOf(offset));
+        params.put("limit", String.valueOf(limit));
+
+        return convertToConfetiMusicPage(
+                restClient.request()
+                        .get()
+                        .baseUrl(appleMusicAPIURL.getBaseUrl())
+                        .path(appleMusicAPIURL.getArtistSongsPath(artistId))
+                        .params(MultiValueMap.fromSingleValue(params))
+                        .build()
+                        .connect(headers)
+                        .retrieve(AppleMusicArtistMusicsResponse.class)
+        );
+    }
+
+    private MusicPage convertToConfetiMusicPage(AppleMusicArtistMusicsResponse artistMusics) {
+        return MusicPage.of(
+                artistMusics.next(),
+                artistMusics.data().stream()
+                        .map(ConfetiMusic::from)
+                        .toList()
+        );
     }
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIURL.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIURL.java
@@ -33,6 +33,9 @@ public class AppleMusicAPIURL {
     @Value("${apple-music.api.endpoints.artists-path.relationship-view-by-name}")
     private String artistsPathRelationshipViewByName;
 
+    @Value("${apple-music.api.endpoints.artists-path.songs}")
+    private String artistsPathSongs;
+
     @Value("${apple-music.api.endpoints.albums-path.base}")
     private String albumsPathBase;
 
@@ -115,6 +118,12 @@ public class AppleMusicAPIURL {
     public String getArtistRelationshipViewByNamePath(String id, String view) {
         return UriComponentsBuilder.fromUriString(getArtistsBasePath() + artistsPathRelationshipViewByName)
                 .buildAndExpand(id, view)
+                .toUriString();
+    }
+
+    public String getArtistSongsPath(String id) {
+        return UriComponentsBuilder.fromUriString(getArtistsBasePath() + artistsPathSongs)
+                .buildAndExpand(id)
                 .toUriString();
     }
 

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -6,6 +6,7 @@ import java.util.Set;
 import org.sopt.confeti.global.resolver.music_api.album.vo.ConfetiAlbum;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+import org.sopt.confeti.global.util.music.dto.music.MusicPage;
 
 public interface MusicAPIHandler {
 
@@ -24,4 +25,6 @@ public interface MusicAPIHandler {
     List<ConfetiMusic> getTopMusics(final int fetchSize);
 
     List<ConfetiMusic> getFilteredTopSongsByArtist(String artistId, int limit, Set<String> excludedMusicIds);
+
+    MusicPage getArtistMusics(String artistId, int offset, int limit);
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicArtistMusicsResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicArtistMusicsResponse.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.global.util.music.dto.music;
+
+import java.util.List;
+
+public record AppleMusicArtistMusicsResponse(
+        String next,
+        List<AppleMusicMusicResponse> data
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/MusicPage.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/MusicPage.java
@@ -1,0 +1,38 @@
+package org.sopt.confeti.global.util.music.dto.music;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+
+@Getter
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
+public class MusicPage {
+
+    private static final Pattern offsetPattern = Pattern.compile("offset=(\\d+)");
+    private static final int FIRST_ITEM = 1;
+    private static final int DEFAULT_NEXT_OFFSET = -1;
+
+    private final int nextOffset;
+    private final boolean isLast;
+    private final List<ConfetiMusic> musics;
+
+    public static MusicPage of(String next, List<ConfetiMusic> musics) {
+        boolean isLast = Objects.isNull(next);
+        int nextOffset = DEFAULT_NEXT_OFFSET;
+
+        if (!isLast) {
+            Matcher offsetMatcher = offsetPattern.matcher(next);
+
+            if (offsetMatcher.find()) {
+                nextOffset = Integer.parseInt(offsetMatcher.group(FIRST_ITEM));
+            }
+        }
+
+        return new MusicPage(nextOffset, isLast, musics);
+    }
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #387 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 아티스트 곡 검색 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/5031bc63-2c82-45df-82a0-1f92e3891cc4" />
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/65d9f9cf-bb42-4783-89af-5b9190b7cf4c" />


아티스트 아이디와 검색어로 아티스트의 곡 목록을 조회할 수 있는 API를 개발했습니다. Apple Music API에서 제공하는 페이지네이션 방식을 따랐습니다. 그리고 Apple Music API 자체에서 마지막 페이지인지의 여부를 `next` 변수를 통해 간접적으로 알려주기 때문에 커스텀 `MusicPage` 를 만들었습니다.

Apple Music 커스텀 Page는 Apple Music API 전반적인 페이지네이션 방식에 활용될 것 같아 추후에 리펙토링을 통해 확장성있게 설계하도록 하겠습니다.

+) 유저 애플 뮤직 구독 여부에 따른 추가 정보가 필요할 수도 있어 API가 변경될 수 있습니다.