### PR TITLE
feat [#389] MY 셋리스트 > 곡 검색 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
@@ -5,10 +5,12 @@ import jakarta.validation.constraints.Min;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.setlist.dto.response.search.SetlistSearchArtistMusicsResponse;
+import org.sopt.confeti.api.setlist.dto.response.search.SetlistSearchMusicsResponse;
 import org.sopt.confeti.api.setlist.dto.response.search.SetlistSearchPerformancesResponse;
 import org.sopt.confeti.api.setlist.facade.SetlistSearchFacade;
 import org.sopt.confeti.api.setlist.facade.dto.response.search.SearchPerformancesDTO;
 import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchArtistMusicsDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchMusicsDTO;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
@@ -60,5 +62,17 @@ public class SetlistSearchController {
 
         SetlistSearchArtistMusicsDTO artistMusics = setlistSearchFacade.searchArtistMusics(aid, term, offset, limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, SetlistSearchArtistMusicsResponse.from(artistMusics));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/musics")
+    public ResponseEntity<BaseResponse<?>> searchMusics(
+            @UserId Long userId,
+            @RequestParam String term,
+            @RequestParam(required = false, defaultValue = "0") @Min(0) int offset,
+            @RequestParam(required = false, defaultValue = "5") @Min(1) @Max(20) int limit
+    ) {
+        SetlistSearchMusicsDTO musics = setlistSearchFacade.searchMusics(term, offset, limit);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, SetlistSearchMusicsResponse.from(musics));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchMusicResponse.java
@@ -1,0 +1,21 @@
+package org.sopt.confeti.api.setlist.dto.response.search;
+
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchMusicDTO;
+
+public record SetlistSearchMusicResponse(
+        String musicId,
+        String title,
+        String artistName,
+        String artworkUrl,
+        String previewUrl
+) {
+    public static SetlistSearchMusicResponse from(SetlistSearchMusicDTO artistMusic) {
+        return new SetlistSearchMusicResponse(
+                artistMusic.id(),
+                artistMusic.title(),
+                artistMusic.artistName(),
+                artistMusic.artworkUrl(),
+                artistMusic.previewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchMusicsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchMusicsResponse.java
@@ -1,0 +1,20 @@
+package org.sopt.confeti.api.setlist.dto.response.search;
+
+import java.util.List;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchMusicsDTO;
+
+public record SetlistSearchMusicsResponse(
+        int nextOffset,
+        boolean isLast,
+        List<SetlistSearchMusicResponse> musics
+) {
+    public static SetlistSearchMusicsResponse from(SetlistSearchMusicsDTO artistMusics) {
+        return new SetlistSearchMusicsResponse(
+                artistMusics.nextOffset(),
+                artistMusics.isLast(),
+                artistMusics.musics().stream()
+                        .map(SetlistSearchMusicResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistSearchFacade.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistSearchFacade.java
@@ -11,6 +11,7 @@ import kr.co.shineware.nlp.komoran.model.KomoranResult;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.setlist.facade.dto.response.search.SearchPerformancesDTO;
 import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchArtistMusicsDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchMusicsDTO;
 import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
@@ -43,6 +44,12 @@ public class SetlistSearchFacade {
         return Objects.isNull(that);
     }
 
+    public SetlistSearchMusicsDTO searchMusics(String term, int offset, int limit) {
+        return SetlistSearchMusicsDTO.from(
+                musicAPIHandler.getMusicsByKeyword(term, offset, limit)
+        );
+    }
+
     public SetlistSearchArtistMusicsDTO searchArtistMusics(String aid, String term, int offset, int limit) {
         String artistId = null;
 
@@ -60,7 +67,7 @@ public class SetlistSearchFacade {
             artistId = searchedArtistId.get();
         }
 
-        MusicPage musics = musicAPIHandler.getArtistMusics(artistId, offset, limit);
+        MusicPage musics = musicAPIHandler.getArtistMusicsByArtistId(artistId, offset, limit);
         return SetlistSearchArtistMusicsDTO.from(musics);
     }
 

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchMusicDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchMusicDTO.java
@@ -1,0 +1,21 @@
+package org.sopt.confeti.api.setlist.facade.dto.response.search;
+
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+
+public record SetlistSearchMusicDTO(
+        String id,
+        String title,
+        String artistName,
+        String artworkUrl,
+        String previewUrl
+) {
+    public static SetlistSearchMusicDTO from(ConfetiMusic music) {
+        return new SetlistSearchMusicDTO(
+                music.getId(),
+                music.getTitle(),
+                music.getArtistName(),
+                music.getArtworkUrl(),
+                music.getPreviewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchMusicsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchMusicsDTO.java
@@ -1,0 +1,20 @@
+package org.sopt.confeti.api.setlist.facade.dto.response.search;
+
+import java.util.List;
+import org.sopt.confeti.global.util.music.dto.music.MusicPage;
+
+public record SetlistSearchMusicsDTO(
+        int nextOffset,
+        boolean isLast,
+        List<SetlistSearchMusicDTO> musics
+) {
+    public static SetlistSearchMusicsDTO from(MusicPage musicPage) {
+        return new SetlistSearchMusicsDTO(
+                musicPage.getNextOffset(),
+                musicPage.isLast(),
+                musicPage.getMusics().stream()
+                        .map(SetlistSearchMusicDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -343,7 +343,7 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
 
     @Override
     @RetryOnTokenExpire
-    public MusicPage getArtistMusics(String artistId, int offset, int limit) {
+    public MusicPage getArtistMusicsByArtistId(String artistId, int offset, int limit) {
         Map<String, String> params = new HashMap<>();
         params.put("offset", String.valueOf(offset));
         params.put("limit", String.valueOf(limit));
@@ -364,6 +364,38 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         return MusicPage.of(
                 artistMusics.next(),
                 artistMusics.data().stream()
+                        .map(ConfetiMusic::from)
+                        .toList()
+        );
+    }
+
+    @Override
+    @RetryOnTokenExpire
+    public MusicPage getMusicsByKeyword(String term, int offset, int limit) {
+        Map<String, String> params = new HashMap<>();
+        params.put("term", term);
+        params.put("offset", String.valueOf(offset));
+        params.put("limit", String.valueOf(limit));
+        params.put("types", SONGS_TYPE);
+
+        return convertToConfetiMusicPage(
+                restClient.request()
+                        .get()
+                        .baseUrl(appleMusicAPIURL.getBaseUrl())
+                        .path(appleMusicAPIURL.getSingleSearchPath())
+                        .params(MultiValueMap.fromSingleValue(params))
+                        .build()
+                        .connect(headers)
+                        .retrieve(AppleMusicSearchResponse.class)
+        );
+    }
+
+    private MusicPage convertToConfetiMusicPage(AppleMusicSearchResponse searchResult) {
+        AppleMusicMusicsResponse musics = searchResult.results().songs();
+
+        return MusicPage.of(
+                musics.next(),
+                musics.data().stream()
                         .map(ConfetiMusic::from)
                         .toList()
         );

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -26,5 +26,7 @@ public interface MusicAPIHandler {
 
     List<ConfetiMusic> getFilteredTopSongsByArtist(String artistId, int limit, Set<String> excludedMusicIds);
 
-    MusicPage getArtistMusics(String artistId, int offset, int limit);
+    MusicPage getMusicsByKeyword(String term, int offset, int limit);
+
+    MusicPage getArtistMusicsByArtistId(String artistId, int offset, int limit);
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicsResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/AppleMusicMusicsResponse.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.global.util.music.dto.music;
 import java.util.List;
 
 public record AppleMusicMusicsResponse(
+        String next,
         List<AppleMusicMusicResponse> data
 ) {
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/search/AppleMusicSearchResultsResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/search/AppleMusicSearchResultsResponse.java
@@ -1,8 +1,10 @@
 package org.sopt.confeti.global.util.music.dto.search;
 
 import org.sopt.confeti.global.util.music.dto.artist.AppleMusicArtistsResponse;
+import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicsResponse;
 
 public record AppleMusicSearchResultsResponse(
-        AppleMusicArtistsResponse artists
+        AppleMusicArtistsResponse artists,
+        AppleMusicMusicsResponse songs
 ) {
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #389 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 곡 검색 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1065" alt="image" src="https://github.com/user-attachments/assets/2b95e9fb-59fa-41c9-8039-411ddaf07190" />
검색어로 음악 목록을 조회할 수 있도록 구현했습니다. Apple Music API의 페이지네이션 방식을 따랐습니다.