### PR TITLE
feat [#396] MY 셋리스트 > 편집 취소 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistEditController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistEditController.java
@@ -61,4 +61,13 @@ public class SetlistEditController {
         setlistEditService.completeEdit(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.UPDATED);
     }
+
+    @DeleteMapping("/{setlistId}/edit/cancel")
+    public ResponseEntity<BaseResponse<?>> cancelEdit(
+            @UserId(require = false) Long userId,
+            @PathVariable Long setlistId
+    ) {
+        setlistEditService.cancelEdit(userId, setlistId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
@@ -8,6 +8,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistMusic;
 import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicEditDto;
@@ -26,7 +27,7 @@ public class SetlistEditService {
 
     private final SetlistRepository setlistRepository;
     private final SetlistMusicRepository setlistMusicRepository;
-    private final RedisTemplate<String, List<SetlistMusicEditDto>> redisTemplate;
+    private final RedisTemplate<String, Object> redisTemplate;
     private final ObjectMapper objectMapper;
 
     @Transactional
@@ -148,6 +149,16 @@ public class SetlistEditService {
         redisTemplate.delete(key);
     }
 
+    @Transactional
+    public void cancelEdit(Long userId, Long setlistId) {
+        String key = generateRedisKey(userId, setlistId);
+        Boolean existed = redisTemplate.hasKey(key);
+        System.out.println(existed);
+        if (Boolean.FALSE.equals(existed)) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+        redisTemplate.delete(key);
+    }
 
     private String generateRedisKey(Long userId, Long setlistId) {
         return "edit:setlist:" + userId + ":" + setlistId;

--- a/src/main/java/org/sopt/confeti/global/config/RedisConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/RedisConfig.java
@@ -14,11 +14,11 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 public class RedisConfig {
 
     @Bean
-    public RedisTemplate<String, List<SetlistMusicEditDto>> redisTemplate(
+    public RedisTemplate<String, Object> redisTemplate(
             RedisConnectionFactory factory,
             ObjectMapper objectMapper
     ) {
-        RedisTemplate<String, List<SetlistMusicEditDto>> template = new RedisTemplate<>();
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
         template.setConnectionFactory(factory);
 
         GenericJackson2JsonRedisSerializer serializer =


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #396 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] MY 셋리스트 > 편집 취소 API 구현


## ✨ Description ✨
<!-- 본인이 한 작업을 설명해주세요 -->

- MY 셋리스트 > 편집 취소 기능을 구현했습니다.
- 편집 중 뒤로가기 또는 다른 화면으로 이동 시 Redis에 저장된 데이터를 삭제하여 편집 내용을 적용하지 않도록 구현했습니다!
- Redis 키 형식: `edit:setlist:{userId}:{setlistId}`
- 편집 데이터가 존재하지 않을 경우 `NotFoundException`을 반환하도록 하였습니다.

## 테스트
### 편집 시작
<img width="692" alt="image" src="https://github.com/user-attachments/assets/7b6408f8-517f-413f-9bff-03a32011c04e" />

### 편집 중 (TrackID “03” <> TrackID “02” 순서 변경)
<img width="693" alt="image" src="https://github.com/user-attachments/assets/5df59eca-ccc9-4ca4-8ceb-9a88eae31fe7" />

### 편집 중 (TrackID “03” 삭제) *DB에는 반영 X
<img width="722" alt="image" src="https://github.com/user-attachments/assets/39e04b04-e160-4f04-ae7e-7b1b070d0967" />
<img width="693" alt="image" src="https://github.com/user-attachments/assets/17fe5b72-a2d5-4e20-adbc-7b652733d5b6" />

### 편집 취소 (Key 삭제되고 DB 반영 안됨)
<img width="715" alt="image" src="https://github.com/user-attachments/assets/5f00221b-1ad9-4329-8ae1-a45a00892c45" />
<img width="559" alt="image" src="https://github.com/user-attachments/assets/ee4fd980-5201-4774-b9cc-277ecd6f844a" />
<img width="696" alt="image" src="https://github.com/user-attachments/assets/1194846b-796b-44d0-9f65-66ebef1b2210" />
