### PR TITLE
feat [#395] 인기 검색어 목록 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/artist/facade/ArtistFacade.java
@@ -6,6 +6,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.artist.facade.dto.response.SearchACArtistsDTO;
 import org.sopt.confeti.api.artist.facade.dto.response.SearchArtistDTO;
 import org.sopt.confeti.domain.artist_favorite.application.ArtistFavoriteService;
+import org.sopt.confeti.domain.elastic_search.application.SearchTermService;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
@@ -19,6 +20,7 @@ public class ArtistFacade {
 
     private final ArtistFavoriteService artistFavoriteService;
     private final MusicAPIHandler musicAPIHandler;
+    private final SearchTermService searchTermService;
 
     @Transactional(readOnly = true)
     public SearchArtistDTO search(Long userId, String term, String aid) {
@@ -27,6 +29,7 @@ public class ArtistFacade {
 
         if (isPresent(aid)) {
             artist = musicAPIHandler.findArtistByArtistId(aid);
+            searchTermService.write(artist);
         }
 
         if (isPresent(term)) {

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -1,7 +1,15 @@
 package org.sopt.confeti.api.performance.facade;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
 import java.util.stream.Collectors;
 import kr.co.shineware.nlp.komoran.model.KomoranResult;
 import lombok.RequiredArgsConstructor;
@@ -25,6 +33,7 @@ import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.application.ConcertService;
 import org.sopt.confeti.domain.concert_favorite.application.ConcertFavoriteService;
 import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
+import org.sopt.confeti.domain.elastic_search.application.SearchTermService;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.FestivalService;
 import org.sopt.confeti.domain.festival_favorite.application.FestivalFavoriteService;
@@ -70,6 +79,7 @@ public class PerformanceFacade {
     private final MusicAPIHandler musicAPIHandler;
     private final TimetableFestivalService timetableFestivalService;
     private final SetlistService setlistService;
+    private final SearchTermService searchTermService;
 
     @Transactional(readOnly = true)
     public ConcertDetailDTO getConcertDetailInfo(final Long userId, final long concertId) {
@@ -265,7 +275,9 @@ public class PerformanceFacade {
         List<PerformanceDTO> performances = new ArrayList<>();
 
         if (isPresent(pid)) {
-            performances.add(PerformanceDTO.from(performanceService.getPerformanceById(pid)));
+            PerformanceDTO performance = PerformanceDTO.from(performanceService.getPerformanceById(pid));
+            performances.add(performance);
+            searchTermService.write(performance.title());
         }
 
         if (isPresent(aid)) {
@@ -314,6 +326,8 @@ public class PerformanceFacade {
         PerformanceType performanceType = MorphemeAnalyzer.getFirstMatchingPerformanceType(analyzeResult);
         String processedTerm = MorphemeAnalyzer.getRemovedPerformanceTypesTerm(term, analyzeResult);
 
+        searchTermService.write(term);
+
         return AnalyzePerformanceTypeDTO.of(processedTerm, performanceType);
     }
 
@@ -350,7 +364,7 @@ public class PerformanceFacade {
         Set<String> existingMusicIds = (musicIds == null || musicIds.isEmpty())
                 ? Collections.emptySet()
                 : musicIds.stream().flatMap(ids -> Arrays.stream(ids.split(",")))
-                .map(String::trim).collect(Collectors.toSet());
+                        .map(String::trim).collect(Collectors.toSet());
 
         List<String> artistIdList = new ArrayList<>(selectedArtistIds);
         List<ConfetiMusic> recommendMusics = recommendMusicsByArtistCount(artistIdList, existingMusicIds);

--- a/src/main/java/org/sopt/confeti/api/search_term/controller/SearchTermController.java
+++ b/src/main/java/org/sopt/confeti/api/search_term/controller/SearchTermController.java
@@ -1,0 +1,35 @@
+package org.sopt.confeti.api.search_term.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.search_term.dto.response.PopularTermsResponse;
+import org.sopt.confeti.api.search_term.facade.SearchTermFacade;
+import org.sopt.confeti.api.search_term.facade.dto.response.PopularTermsDTO;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/search/terms")
+public class SearchTermController {
+
+    private final SearchTermFacade searchTermFacade;
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/popular")
+    public ResponseEntity<BaseResponse<?>> getPopularSearchTerms(
+            @UserId(require = false) Long userId,
+            @RequestParam(required = false, defaultValue = "10") int limit
+    ) {
+        PopularTermsDTO terms = searchTermFacade.getPopularSearchTerms(limit);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS, PopularTermsResponse.from(terms));
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/search_term/dto/response/PopularTermResponse.java
+++ b/src/main/java/org/sopt/confeti/api/search_term/dto/response/PopularTermResponse.java
@@ -1,0 +1,15 @@
+package org.sopt.confeti.api.search_term.dto.response;
+
+import org.sopt.confeti.api.search_term.facade.dto.response.PopularTermDTO;
+
+public record PopularTermResponse(
+        int rank,
+        String popularTerm
+) {
+    public static PopularTermResponse from(PopularTermDTO popularTermDTO) {
+        return new PopularTermResponse(
+                popularTermDTO.rank(),
+                popularTermDTO.popularTerm()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/search_term/dto/response/PopularTermsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/search_term/dto/response/PopularTermsResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.search_term.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.api.search_term.facade.dto.response.PopularTermsDTO;
+
+public record PopularTermsResponse(
+        List<PopularTermResponse> popularTerms
+) {
+    public static PopularTermsResponse from(PopularTermsDTO popularTermsDTO) {
+        return new PopularTermsResponse(
+                popularTermsDTO.popularTerms().stream()
+                        .map(PopularTermResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/search_term/facade/SearchTermFacade.java
+++ b/src/main/java/org/sopt/confeti/api/search_term/facade/SearchTermFacade.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.search_term.facade;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.search_term.facade.dto.response.PopularTermsDTO;
+import org.sopt.confeti.domain.elastic_search.application.SearchTermService;
+import org.sopt.confeti.global.annotation.Facade;
+
+@Facade
+@RequiredArgsConstructor
+public class SearchTermFacade {
+
+    private final SearchTermService searchTermService;
+
+    public PopularTermsDTO getPopularSearchTerms(int limit) {
+        return PopularTermsDTO.from(searchTermService.getPopularSearchTerms(limit));
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/search_term/facade/dto/response/PopularTermDTO.java
+++ b/src/main/java/org/sopt/confeti/api/search_term/facade/dto/response/PopularTermDTO.java
@@ -1,0 +1,15 @@
+package org.sopt.confeti.api.search_term.facade.dto.response;
+
+import org.sopt.confeti.domain.elastic_search.application.dto.response.PopularTermResult;
+
+public record PopularTermDTO(
+        int rank,
+        String popularTerm
+) {
+    public static PopularTermDTO from(PopularTermResult searchResult) {
+        return new PopularTermDTO(
+                searchResult.rank(),
+                searchResult.popularTerm()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/search_term/facade/dto/response/PopularTermsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/search_term/facade/dto/response/PopularTermsDTO.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.search_term.facade.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.domain.elastic_search.application.dto.response.PopularTermResult;
+
+public record PopularTermsDTO(
+        List<PopularTermDTO> popularTerms
+) {
+    public static PopularTermsDTO from(List<PopularTermResult> searchResults) {
+        return new PopularTermsDTO(
+                searchResults.stream()
+                        .map(PopularTermDTO::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/SearchTermDocument.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/SearchTermDocument.java
@@ -1,6 +1,8 @@
 package org.sopt.confeti.domain.elastic_search;
 
+import jakarta.persistence.Id;
 import java.time.LocalDateTime;
+import java.util.UUID;
 import lombok.Builder;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
@@ -10,6 +12,10 @@ import org.springframework.data.elasticsearch.annotations.FieldType;
 @Document(indexName = "search_terms")
 public record SearchTermDocument(
 
+        @Id
+        @Field(type = FieldType.Keyword)
+        String uuid,
+
         @Field(type = FieldType.Keyword)
         String searchTerm,
 
@@ -18,6 +24,7 @@ public record SearchTermDocument(
 ) {
     public static SearchTermDocument create(String searchTerm) {
         return SearchTermDocument.builder()
+                .uuid(UUID.randomUUID().toString())
                 .searchTerm(searchTerm)
                 .timestamp(LocalDateTime.now())
                 .build();

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/SearchTermDocument.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/SearchTermDocument.java
@@ -1,9 +1,9 @@
 package org.sopt.confeti.domain.elastic_search;
 
-import jakarta.persistence.Id;
-import java.time.LocalDateTime;
+import java.time.Instant;
 import java.util.UUID;
 import lombok.Builder;
+import org.springframework.data.annotation.Id;
 import org.springframework.data.elasticsearch.annotations.Document;
 import org.springframework.data.elasticsearch.annotations.Field;
 import org.springframework.data.elasticsearch.annotations.FieldType;
@@ -20,13 +20,13 @@ public record SearchTermDocument(
         String searchTerm,
 
         @Field(type = FieldType.Date)
-        LocalDateTime timestamp
+        Instant timestamp
 ) {
     public static SearchTermDocument create(String searchTerm) {
         return SearchTermDocument.builder()
                 .uuid(UUID.randomUUID().toString())
                 .searchTerm(searchTerm)
-                .timestamp(LocalDateTime.now())
+                .timestamp(Instant.now())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
@@ -9,7 +9,6 @@ import org.sopt.confeti.domain.elastic_search.infra.PerformanceSearchRepository;
 import org.sopt.confeti.global.common.constant.PerformanceStatus;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
@@ -18,17 +17,14 @@ public class PerformanceSearchService {
     private final PerformanceSearchRepository performanceSearchRepository;
     private final PerformanceSearchOperator performanceSearchOperator;
 
-    @Transactional
     public void deleteAll() {
         performanceSearchRepository.deleteAll();
     }
 
-    @Transactional
     public void save(List<PerformanceDocument> performanceDocuments) {
         performanceSearchRepository.saveAll(performanceDocuments);
     }
 
-    @Transactional(readOnly = true)
     public List<SearchPerformanceResult> getPerformancesByTitleAndTypePartialMatched(String ptitle,
                                                                                      PerformanceType ptype) {
         List<PerformanceDocument> performances = performanceSearchOperator.searchByTitleAndTypePartialMatch(
@@ -39,7 +35,6 @@ public class PerformanceSearchService {
                 .toList();
     }
 
-    @Transactional(readOnly = true)
     public List<SearchPerformanceResult> getPerformancesByTitle(String title, int limit, PerformanceStatus status) {
         List<PerformanceDocument> performances = performanceSearchOperator.searchByTitleAndTypePartialMatch(title,
                 PerformanceType.PERFORMANCE, status);

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/SearchTermService.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/SearchTermService.java
@@ -1,9 +1,11 @@
 package org.sopt.confeti.domain.elastic_search.application;
 
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.elastic_search.SearchTermDocument;
 import org.sopt.confeti.domain.elastic_search.infra.SearchTermOperator;
 import org.sopt.confeti.domain.elastic_search.infra.SearchTermRepository;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,5 +17,11 @@ public class SearchTermService {
 
     public void write(String searchTerm) {
         searchTermRepository.save(SearchTermDocument.create(searchTerm));
+    }
+
+    public void write(Optional<ConfetiArtist> artist) {
+        artist.ifPresent(
+                confetiArtist -> searchTermRepository.save(SearchTermDocument.create(confetiArtist.getName()))
+        );
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/SearchTermService.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/SearchTermService.java
@@ -1,8 +1,10 @@
 package org.sopt.confeti.domain.elastic_search.application;
 
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.elastic_search.SearchTermDocument;
+import org.sopt.confeti.domain.elastic_search.application.dto.response.PopularTermResult;
 import org.sopt.confeti.domain.elastic_search.infra.SearchTermOperator;
 import org.sopt.confeti.domain.elastic_search.infra.SearchTermRepository;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
@@ -23,5 +25,9 @@ public class SearchTermService {
         artist.ifPresent(
                 confetiArtist -> searchTermRepository.save(SearchTermDocument.create(confetiArtist.getName()))
         );
+    }
+
+    public List<PopularTermResult> getPopularSearchTerms(int limit) {
+        return searchTermOperator.getPopularSearchTerms(limit);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/SearchTermService.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/SearchTermService.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.domain.elastic_search.application;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.elastic_search.SearchTermDocument;
+import org.sopt.confeti.domain.elastic_search.infra.SearchTermOperator;
+import org.sopt.confeti.domain.elastic_search.infra.SearchTermRepository;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class SearchTermService {
+
+    private final SearchTermOperator searchTermOperator;
+    private final SearchTermRepository searchTermRepository;
+
+    public void write(String searchTerm) {
+        searchTermRepository.save(SearchTermDocument.create(searchTerm));
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/dto/response/PopularTermResult.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/dto/response/PopularTermResult.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.domain.elastic_search.application.dto.response;
+
+public record PopularTermResult(
+        int rank,
+        String popularTerm
+) {
+    public static PopularTermResult of(int rank, String popularTerm) {
+        return new PopularTermResult(
+                rank,
+                popularTerm
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/infra/SearchTermOperator.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/infra/SearchTermOperator.java
@@ -1,12 +1,85 @@
 package org.sopt.confeti.domain.elastic_search.infra;
 
+import co.elastic.clients.elasticsearch._types.aggregations.Aggregation;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsAggregate;
+import co.elastic.clients.elasticsearch._types.aggregations.StringTermsBucket;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Objects;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.elastic_search.SearchTermDocument;
+import org.sopt.confeti.domain.elastic_search.application.dto.response.PopularTermResult;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregation;
+import org.springframework.data.elasticsearch.client.elc.ElasticsearchAggregations;
+import org.springframework.data.elasticsearch.client.elc.NativeQuery;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.SearchHits;
+import org.springframework.data.elasticsearch.core.query.Query;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
 public class SearchTermOperator {
 
+    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss");
+    private static final long POPULAR_SEARCH_TERMS_DATE_BEFORE = 30L;
+    private static final String FIELD_TIMESTAMP = "timestamp";
+    private static final String FIELD_SEARCH_TERM = "searchTerm";
+    private static final String AGGREGATION_NAME = "popular_search_terms";
+
     private final ElasticsearchOperations elasticsearchOperations;
+
+    public List<PopularTermResult> getPopularSearchTerms(int limit) {
+        LocalDateTime endAt = LocalDateTime.now();
+        LocalDateTime startAt = endAt.minusDays(POPULAR_SEARCH_TERMS_DATE_BEFORE);
+
+        Query query = NativeQuery.builder()
+                .withQuery(q -> q
+                        .range(r -> r
+                                .date(d -> d
+                                        .field(FIELD_TIMESTAMP)
+                                        .gte(startAt.format(dateTimeFormatter))
+                                        .lte(endAt.format(dateTimeFormatter))
+                                )
+                        )
+                )
+                .withAggregation(AGGREGATION_NAME, Aggregation.of(a -> a
+                                .terms(t -> t
+                                        .field(FIELD_SEARCH_TERM)
+                                        .size(limit)
+                                )
+                        )
+                )
+                .build();
+
+        SearchHits<SearchTermDocument> searchHits = elasticsearchOperations.search(query, SearchTermDocument.class);
+
+        // Aggregation 결과 추출 (공식 API)
+        ElasticsearchAggregations aggregations = (ElasticsearchAggregations) searchHits.getAggregations();
+        if (Objects.isNull(aggregations)) {
+            return List.of();
+        }
+
+        ElasticsearchAggregation agg = aggregations.get(AGGREGATION_NAME);
+        if (Objects.isNull(agg)) {
+            return List.of();
+        }
+
+        StringTermsAggregate termsAgg = agg.aggregation().getAggregate().sterms();
+        if (Objects.isNull(termsAgg)) {
+            return List.of();
+        }
+
+        List<StringTermsBucket> buckets = termsAgg.buckets().array();
+
+        // 순위 매기면서 결과 변환 (예시: SearchTermResult에 rank, keyword, count 포함)
+        return IntStream.range(0, buckets.size())
+                .mapToObj(i -> {
+                    StringTermsBucket bucket = buckets.get(i);
+                    return PopularTermResult.of(i + 1, bucket.key().stringValue());
+                })
+                .toList();
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/infra/SearchTermRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/infra/SearchTermRepository.java
@@ -1,0 +1,7 @@
+package org.sopt.confeti.domain.elastic_search.infra;
+
+import org.sopt.confeti.domain.elastic_search.SearchTermDocument;
+import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
+
+public interface SearchTermRepository extends ElasticsearchRepository<SearchTermDocument, String> {
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #395 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 인기 검색어 목록 조회 API 구현


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1063" alt="image" src="https://github.com/user-attachments/assets/9dda1f6d-cf21-404d-b7c3-1cb437bdc1f9" />
인기 검색어 목록 조회 API를 구현했습니다. limit 쿼리 파라미터를 통해 몇 개를 가져올지 선택할 수 있도록 구성했습니다. 기획 변경사항에 유연하게 대응하기 위함입니다.

그리고 인기 검색어를 조회하기 위해서는 집계가 되어야하는데, Elastic Search에 새로운 index를 생성해 저장하는 방식을 선택했습니다. 데이터의 정합성이 크게 요구되지 않기 때문에 RDBMS 보다는 NoSQL 방식의 저장 방식이 더 나은 선택이라고 생각했습니다.
인기 검색어 목록을 조회할 때는 Elastic Search의 Aggregation 집계 메트릭스 기능을 이용했습니다. 또한, 인기 검색 "키워드"가 아니기 때문에, 저장 시에 키워드가 분석되는 "text" 타입이 아닌 "keyword" 타입으로 index mappings를 설정해주었습니다.
지난 한 달 간의 인기 검색어를 조회해야하는데, `timestamp`를 기준으로 집계해서 가져왔습니다.

정확한 문서는 스프린트 기간 이후에 작성하도록 하겠습니다! (기대하시라)
