### PR TITLE
fix [#403] 셋리스트 관련 API 응답 형태 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -25,6 +25,7 @@ import org.sopt.confeti.domain.user.infra.repository.UserRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
+import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -38,6 +39,7 @@ public class SetlistService {
     private final FestivalRepository festivalRepository;
     private final UserRepository userRepository;
     private final SetlistMusicRepository setlistMusicRepository;
+    private final S3FileHandler s3FileHandler;
 
     @Transactional(readOnly = true)
     public GetAllSetlistsResponse getAllMySetlists(Long userId, SetlistSortType sortType) {
@@ -49,12 +51,12 @@ public class SetlistService {
                         Concert concert = concertRepository.findById(setlist.getTypeId())
                                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
                         return SetlistSummaryDto.of(
-                                setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt());
+                                setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt(), s3FileHandler);
                     } else {
                         Festival festival = festivalRepository.findById(setlist.getTypeId())
                                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
                         return SetlistSummaryDto.of(
-                                setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt());
+                                setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt(), s3FileHandler);
                     }
                 })
                 .toList();
@@ -82,12 +84,12 @@ public class SetlistService {
                         Concert concert = concertRepository.findById(setlist.getTypeId())
                                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
                         return SetlistSummaryDto.of(
-                                setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt());
+                                setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt(), s3FileHandler);
                     } else {
                         Festival festival = festivalRepository.findById(setlist.getTypeId())
                                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
                         return SetlistSummaryDto.of(
-                                setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt());
+                                setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt(), s3FileHandler);
                     }
                 })
                 .sorted(Comparator.comparing(SetlistSummaryDto::endAt))
@@ -154,22 +156,20 @@ public class SetlistService {
         if (setlist.getType() == SetlistType.CONCERT) {
             Concert concert = concertRepository.findById(setlist.getTypeId())
                     .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-            return new GetSetlistDetailResponse(
-                    setlist.getId(), "CONCERT", concert.getId(),
+            return GetSetlistDetailResponse.of(
+                    setlist, concert.getTitle(), concert.getSubtitle(),
                     concert.getPosterPath(), concert.getPosterBgPath(),
-                    concert.getTitle(), concert.getSubtitle(),
                     concert.getStartAt(), concert.getEndAt(),
-                    musics
+                    musics, setlist.getType(), s3FileHandler
             );
         } else {
             Festival festival = festivalRepository.findById(setlist.getTypeId())
                     .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-            return new GetSetlistDetailResponse(
-                    setlist.getId(), "FESTIVAL", festival.getId(),
+            return GetSetlistDetailResponse.of(
+                    setlist, festival.getTitle(), festival.getSubtitle(),
                     festival.getPosterPath(), festival.getPosterBgPath(),
-                    festival.getTitle(), festival.getSubtitle(),
                     festival.getStartAt(), festival.getEndAt(),
-                    musics
+                    musics, setlist.getType(), s3FileHandler
             );
         }
     }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/GetSetlistDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/GetSetlistDetailResponse.java
@@ -2,6 +2,10 @@ package org.sopt.confeti.domain.setlist.application.dto.response;
 
 import java.time.LocalDate;
 import java.util.List;
+import org.sopt.confeti.domain.setlist.Setlist;
+import org.sopt.confeti.domain.setlist.SetlistType;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.util.S3FileHandler;
 
 public record GetSetlistDetailResponse(
         Long setlistId,
@@ -15,4 +19,41 @@ public record GetSetlistDetailResponse(
         LocalDate endAt,
         List<SetlistMusicResponseDto> musics
 ) {
+    public static GetSetlistDetailResponse of(
+            Setlist setlist,
+            String title,
+            String subtitle,
+            String posterPath,
+            String posterBgPath,
+            LocalDate startAt,
+            LocalDate endAt,
+            List<SetlistMusicResponseDto> musics,
+            SetlistType type,
+            S3FileHandler s3FileHandler
+    ) {
+        String posterUrl = s3FileHandler.getFileUrl(
+                FolderPath.combine(
+                        type == SetlistType.CONCERT ? FolderPath.CONCERT : FolderPath.FESTIVAL,
+                        FolderPath.POSTER
+                ), posterPath).toString();
+
+        String posterBgUrl = s3FileHandler.getFileUrl(
+                FolderPath.combine(
+                        type == SetlistType.CONCERT ? FolderPath.CONCERT : FolderPath.FESTIVAL,
+                        FolderPath.POSTER_BG
+                ), posterBgPath).toString();
+
+        return new GetSetlistDetailResponse(
+                setlist.getId(),
+                type.name(),
+                setlist.getTypeId(),
+                posterUrl,
+                posterBgUrl,
+                title,
+                subtitle,
+                startAt,
+                endAt,
+                musics
+        );
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistSummaryDto.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistSummaryDto.java
@@ -24,9 +24,7 @@ public record SetlistSummaryDto(
         String posterUrl =  s3FileHandler.getFileUrl(
                 FolderPath.combine(
                         setlist.getType() == SetlistType.CONCERT ? FolderPath.CONCERT : FolderPath.FESTIVAL, FolderPath.POSTER
-                ),
-                posterPath
-        ).toString();
+                ), posterPath).toString();
         return new SetlistSummaryDto(
                 setlist.getId(),
                 setlist.getType().name(),

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistSummaryDto.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/SetlistSummaryDto.java
@@ -2,6 +2,9 @@ package org.sopt.confeti.domain.setlist.application.dto.response;
 
 import java.time.LocalDate;
 import org.sopt.confeti.domain.setlist.Setlist;
+import org.sopt.confeti.domain.setlist.SetlistType;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.util.S3FileHandler;
 
 public record SetlistSummaryDto(
         Long setlistId,
@@ -11,7 +14,19 @@ public record SetlistSummaryDto(
         String posterUrl,
         LocalDate endAt
 ) {
-    public static SetlistSummaryDto of(Setlist setlist, String title, String posterUrl, LocalDate endAt) {
+    public static SetlistSummaryDto of(
+            Setlist setlist,
+            String title,
+            String posterPath,
+            LocalDate endAt,
+            S3FileHandler s3FileHandler
+            ) {
+        String posterUrl =  s3FileHandler.getFileUrl(
+                FolderPath.combine(
+                        setlist.getType() == SetlistType.CONCERT ? FolderPath.CONCERT : FolderPath.FESTIVAL, FolderPath.POSTER
+                ),
+                posterPath
+        ).toString();
         return new SetlistSummaryDto(
                 setlist.getId(),
                 setlist.getType().name(),

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -3,12 +3,15 @@ package org.sopt.confeti.domain.setlist.application;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.lenient;
 
+import java.net.URL;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -29,6 +32,7 @@ import org.sopt.confeti.domain.user.OAuthProvider;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
+import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
@@ -42,9 +46,16 @@ class SetlistServiceTest {
     @Mock private FestivalRepository festivalRepository;
     @Mock private UserRepository userRepository;
     @Mock private SetlistMusicRepository setlistMusicRepository;
+    @Mock private S3FileHandler s3FileHandler;
 
     private final Long userId = 1L;
     private final User user = mockUser(userId);
+
+    @BeforeEach
+    void setup() throws Exception {
+        lenient().when(s3FileHandler.getFileUrl(any(), any()))
+                .thenReturn(new URL("https://mock-s3-url.com/poster.png"));
+    }
 
     @Test
     void 셋리스트_전체조회_OLDEST() {
@@ -101,6 +112,118 @@ class SetlistServiceTest {
         assertThat(result).extracting(SetlistSummaryDto::title).containsExactly("F2", "F1", "C1");
     }
 
+    @Test
+    void 여러개의_공연을_셋리스트로_생성() {
+        SetlistCreateRequest request1 = new SetlistCreateRequest(SetlistType.CONCERT, 100L);
+        SetlistCreateRequest request2 = new SetlistCreateRequest(SetlistType.FESTIVAL, 200L);
+        List<SetlistCreateRequest> requests = List.of(request1, request2);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+
+        Setlist savedSetlist1 = createSetlist(SetlistType.CONCERT, 100L);
+        Setlist savedSetlist2 = createSetlist(SetlistType.FESTIVAL, 200L);
+        ReflectionTestUtils.setField(savedSetlist1, "id", 1L);
+        ReflectionTestUtils.setField(savedSetlist2, "id", 2L);
+
+        given(setlistRepository.save(any(Setlist.class)))
+                .willReturn(savedSetlist1)
+                .willReturn(savedSetlist2);
+
+        List<Long> result = setlistService.createSetLists(userId, requests);
+
+        assertThat(result).hasSize(2).containsExactly(1L, 2L);
+    }
+
+    @Test
+    void 이미_생성된_셋리스트는_중복_생성되지_않는다() {
+        SetlistCreateRequest request1 = new SetlistCreateRequest(SetlistType.CONCERT, 100L);
+        SetlistCreateRequest request2 = new SetlistCreateRequest(SetlistType.FESTIVAL, 200L);
+        List<SetlistCreateRequest> requests = List.of(request1, request2);
+
+        given(userRepository.findById(userId)).willReturn(Optional.of(user));
+        given(setlistRepository.existsByUserIdAndTypeAndTypeId(userId, SetlistType.CONCERT, 100L)).willReturn(true);
+        given(setlistRepository.existsByUserIdAndTypeAndTypeId(userId, SetlistType.FESTIVAL, 200L)).willReturn(false);
+
+        Setlist newSetlist = createSetlist(SetlistType.FESTIVAL, 200L);
+        ReflectionTestUtils.setField(newSetlist, "id", 999L);
+        given(setlistRepository.save(any(Setlist.class))).willReturn(newSetlist);
+
+        List<Long> result = setlistService.createSetLists(userId, requests);
+
+        assertThat(result).containsExactly(999L);
+    }
+
+    @Test
+    void 셋리스트에_여러_곡을_추가하면_순서가_자동으로_부여된다() {
+        Long setlistId = 100L;
+        Setlist setlist = createSetlist(SetlistType.CONCERT, 1L);
+
+        SetlistMusic existing1 = SetlistMusic.builder().artistName("EXO").trackName("Love Shot").orders(1).build();
+        SetlistMusic existing2 = SetlistMusic.builder().artistName("BTS").trackName("Dynamite").orders(2).build();
+        setlist.addMusics(existing1);
+        setlist.addMusics(existing2);
+
+        given(setlistRepository.findById(setlistId)).willReturn(Optional.of(setlist));
+
+        List<AddSetListMusicRequest> requests = List.of(
+                new AddSetListMusicRequest("01", "IU", "Love wins all", "url1", "preview1"),
+                new AddSetListMusicRequest("02", "NewJeans", "Hype Boy", "url2", "preview2")
+        );
+
+        int result = setlistService.addMusics(userId, setlistId, requests);
+
+        assertThat(result).isEqualTo(2);
+        assertThat(setlist.getMusics()).hasSize(4);
+    }
+
+    @Test
+    void 셋리스트_상세조회_CONCERT_타입일_경우_정상조회() {
+        Long setlistId = 10L;
+        Long concertId = 100L;
+
+        Setlist setlist = createSetlist(SetlistType.CONCERT, concertId);
+        ReflectionTestUtils.setField(setlist, "id", setlistId);
+
+        SetlistMusic music = createMusic("01", "IU", "Love wins all", 1);
+        music.setSetlist(setlist);
+
+        Concert concert = mockConcert("아이유 콘서트", LocalDate.of(2024, 5, 10));
+
+        given(setlistRepository.findByIdAndUserId(setlistId, userId)).willReturn(Optional.of(setlist));
+        given(concertRepository.findById(concertId)).willReturn(Optional.of(concert));
+        given(setlistMusicRepository.findBySetlist(setlist)).willReturn(List.of(music));
+
+        var result = setlistService.getSetlistDetail(userId, setlistId);
+
+        assertThat(result.type()).isEqualTo("CONCERT");
+        assertThat(result.posterUrl()).isEqualTo("https://mock-s3-url.com/poster.png");
+        assertThat(result.posterBgUrl()).isEqualTo("https://mock-s3-url.com/poster.png");
+    }
+
+    @Test
+    void 셋리스트_상세조회_FESTIVAL_타입일_경우_정상조회() {
+        Long setlistId = 20L;
+        Long festivalId = 200L;
+
+        Setlist setlist = createSetlist(SetlistType.FESTIVAL, festivalId);
+        ReflectionTestUtils.setField(setlist, "id", setlistId);
+
+        SetlistMusic music = createMusic("02", "NewJeans", "ETA", 1);
+        music.setSetlist(setlist);
+
+        Festival festival = mockFestival("부산 록 페스티벌", LocalDate.of(2024, 8, 20));
+
+        given(setlistRepository.findByIdAndUserId(setlistId, userId)).willReturn(Optional.of(setlist));
+        given(festivalRepository.findById(festivalId)).willReturn(Optional.of(festival));
+        given(setlistMusicRepository.findBySetlist(setlist)).willReturn(List.of(music));
+
+        var result = setlistService.getSetlistDetail(userId, setlistId);
+
+        assertThat(result.type()).isEqualTo("FESTIVAL");
+        assertThat(result.posterUrl()).isEqualTo("https://mock-s3-url.com/poster.png");
+        assertThat(result.posterBgUrl()).isEqualTo("https://mock-s3-url.com/poster.png");
+    }
+
     private static User mockUser(Long id) {
         User user = User.builder()
                 .provider(OAuthProvider.KAKAO)
@@ -119,219 +242,36 @@ class SetlistServiceTest {
 
     private Concert mockConcert(String title, LocalDate endAt) {
         Concert concert = Concert.builder()
-                .title(title)
-                .subtitle("sub")
-                .startAt(endAt.minusDays(2))
-                .endAt(endAt)
-                .area("서울")
-                .posterPath(title + ".jpg")
-                .posterBgPath("bg.jpg")
-                .concertInfoImgPath("info.jpg")
-                .reserveAt(LocalDateTime.now())
-                .reservationUrl("url")
-                .reservationOffice("office")
-                .ageRating("ALL")
-                .time("18:00")
-                .price("10000")
-                .address("서울시")
-                .artists(List.of())
-                .musics(List.of())
-                .reservationUrls(List.of())
+                .title(title).subtitle("sub")
+                .startAt(endAt.minusDays(2)).endAt(endAt)
+                .area("서울").posterPath(title + ".jpg").posterBgPath("bg.jpg")
+                .concertInfoImgPath("info.jpg").reserveAt(LocalDateTime.now())
+                .reservationUrl("url").reservationOffice("office")
+                .ageRating("ALL").time("18:00").price("10000").address("서울시")
+                .artists(List.of()).musics(List.of()).reservationUrls(List.of())
                 .build();
-
         ReflectionTestUtils.setField(concert, "id", 100L);
         return concert;
     }
 
     private Festival mockFestival(String title, LocalDate endAt) {
         Festival festival = Festival.builder()
-                .title(title)
-                .subtitle("sub")
-                .startAt(endAt.minusDays(2))
-                .endAt(endAt)
-                .area("부산")
-                .posterPath(title + ".jpg")
-                .posterBgPath("bg.jpg")
-                .festivalInfoImgPath("info.jpg")
-                .logoPath("logo.jpg")
-                .reserveAt(LocalDateTime.now())
-                .reservationUrl("url")
-                .reservationOffice("office")
-                .ageRating("ALL")
-                .time("16:00")
-                .price("8000")
-                .address("부산시")
-                .dates(List.of())
-                .musics(List.of())
-                .reservationUrls(List.of())
+                .title(title).subtitle("sub")
+                .startAt(endAt.minusDays(2)).endAt(endAt)
+                .area("부산").posterPath(title + ".jpg").posterBgPath("bg.jpg")
+                .festivalInfoImgPath("info.jpg").logoPath("logo.jpg")
+                .reserveAt(LocalDateTime.now()).reservationUrl("url")
+                .reservationOffice("office").ageRating("ALL").time("16:00")
+                .price("8000").address("부산시").dates(List.of()).musics(List.of()).reservationUrls(List.of())
                 .build();
-
         ReflectionTestUtils.setField(festival, "id", 200L);
         return festival;
     }
 
-    @Test
-    void 여러개의_공연을_셋리스트로_생성() {
-        // given
-        SetlistCreateRequest request1 = new SetlistCreateRequest(SetlistType.CONCERT, 100L);
-        SetlistCreateRequest request2 = new SetlistCreateRequest(SetlistType.FESTIVAL, 200L);
-        List<SetlistCreateRequest> requests = List.of(request1, request2);
-
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
-
-        Setlist savedSetlist1 = createSetlist(SetlistType.CONCERT, 100L);
-        Setlist savedSetlist2 = createSetlist(SetlistType.FESTIVAL, 200L);
-        ReflectionTestUtils.setField(savedSetlist1, "id", 1L);
-        ReflectionTestUtils.setField(savedSetlist2, "id", 2L);
-
-        given(setlistRepository.save(any(Setlist.class)))
-                .willReturn(savedSetlist1)
-                .willReturn(savedSetlist2);
-
-        // when
-        List<Long> result = setlistService.createSetLists(userId, requests);
-
-        // then
-        assertThat(result).hasSize(2);
-        assertThat(result).containsExactly(1L, 2L);
-    }
-
-    @Test
-    void 이미_생성된_셋리스트는_중복_생성되지_않는다() {
-        // given
-        SetlistCreateRequest request1 = new SetlistCreateRequest(SetlistType.CONCERT, 100L);
-        SetlistCreateRequest request2 = new SetlistCreateRequest(SetlistType.FESTIVAL, 200L);
-        List<SetlistCreateRequest> requests = List.of(request1, request2);
-
-        given(userRepository.findById(userId)).willReturn(Optional.of(user));
-        given(setlistRepository.existsByUserIdAndTypeAndTypeId(userId, SetlistType.CONCERT, 100L)).willReturn(true); // 이미 존재
-        given(setlistRepository.existsByUserIdAndTypeAndTypeId(userId, SetlistType.FESTIVAL, 200L)).willReturn(false);
-
-        Setlist newSetlist = createSetlist(SetlistType.FESTIVAL, 200L);
-        ReflectionTestUtils.setField(newSetlist, "id", 999L);
-        given(setlistRepository.save(any(Setlist.class))).willReturn(newSetlist);
-
-        // when
-        List<Long> result = setlistService.createSetLists(userId, requests);
-
-        // then
-        assertThat(result).containsExactly(999L);
-    }
-
-    @Test
-    void 셋리스트에_여러_곡을_추가하면_순서가_자동으로_부여된다() {
-        // given
-        Long setlistId = 100L;
-        Setlist setlist = Setlist.builder()
-                .user(user)
-                .type(SetlistType.CONCERT)
-                .typeId(1L)
+    private SetlistMusic createMusic(String trackId, String artistName, String trackName, int orders) {
+        return SetlistMusic.builder()
+                .trackId(trackId).artistName(artistName)
+                .trackName(trackName).orders(orders)
                 .build();
-
-        SetlistMusic existing1 = SetlistMusic.builder()
-                .artistName("EXO").trackName("Love Shot").orders(1).build();
-        SetlistMusic existing2 = SetlistMusic.builder()
-                .artistName("BTS").trackName("Dynamite").orders(2).build();
-        setlist.addMusics(existing1);
-        setlist.addMusics(existing2);
-
-        given(setlistRepository.findById(setlistId)).willReturn(Optional.of(setlist));
-
-        List<AddSetListMusicRequest> requests = List.of(
-                new AddSetListMusicRequest("01", "IU", "Love wins all", "url1", "preview1"),
-                new AddSetListMusicRequest("02", "NewJeans", "Hype Boy", "url2", "preview2")
-        );
-
-        // when
-        int result = setlistService.addMusics(userId, setlistId, requests);
-
-        // then
-        assertThat(result).isEqualTo(2);
-        List<SetlistMusic> allMusics = setlist.getMusics();
-        assertThat(allMusics).hasSize(4);
-        assertThat(allMusics.get(2).getOrders()).isEqualTo(3);
-        assertThat(allMusics.get(2).getArtistName()).isEqualTo("IU");
-        assertThat(allMusics.get(3).getOrders()).isEqualTo(4);
-        assertThat(allMusics.get(3).getArtistName()).isEqualTo("NewJeans");
-    }
-
-    @Test
-    void 셋리스트_상세조회_CONCERT_타입일_경우_정상조회() {
-        // given
-        Long setlistId = 10L;
-        Long concertId = 100L;
-
-        Setlist setlist = Setlist.builder()
-                .user(user)
-                .type(SetlistType.CONCERT)
-                .typeId(concertId)
-                .build();
-        ReflectionTestUtils.setField(setlist, "id", setlistId);
-
-        SetlistMusic music = SetlistMusic.builder()
-                .trackId("01")
-                .artistName("IU")
-                .trackName("Love wins all")
-                .artworkUrl("art.jpg")
-                .previewUrl("prev.mp3")
-                .orders(1)
-                .build();
-        music.setSetlist(setlist);
-
-        Concert concert = mockConcert("아이유 콘서트", LocalDate.of(2024, 5, 10));
-        given(setlistRepository.findByIdAndUserId(setlistId, userId)).willReturn(Optional.of(setlist));
-        given(concertRepository.findById(concertId)).willReturn(Optional.of(concert));
-        given(setlistMusicRepository.findBySetlist(setlist)).willReturn(List.of(music));
-
-        // when
-        var result = setlistService.getSetlistDetail(userId, setlistId);
-
-        // then
-        assertThat(result.type()).isEqualTo("CONCERT");
-        assertThat(result.typeId()).isEqualTo(concertId);
-        assertThat(result.title()).isEqualTo("아이유 콘서트");
-        assertThat(result.musics()).hasSize(1);
-        assertThat(result.musics().get(0).trackId()).isEqualTo("01");
-        assertThat(result.musics().get(0).artistName()).isEqualTo("IU");
-    }
-
-    @Test
-    void 셋리스트_상세조회_FESTIVAL_타입일_경우_정상조회() {
-        // given
-        Long setlistId = 20L;
-        Long festivalId = 200L;
-
-        Setlist setlist = Setlist.builder()
-                .user(user)
-                .type(SetlistType.FESTIVAL)
-                .typeId(festivalId)
-                .build();
-        ReflectionTestUtils.setField(setlist, "id", setlistId);
-
-        SetlistMusic music = SetlistMusic.builder()
-                .trackId("02")
-                .artistName("NewJeans")
-                .trackName("ETA")
-                .artworkUrl("art2.jpg")
-                .previewUrl("prev2.mp3")
-                .orders(1)
-                .build();
-        music.setSetlist(setlist);
-
-        Festival festival = mockFestival("부산 록 페스티벌", LocalDate.of(2024, 8, 20));
-        given(setlistRepository.findByIdAndUserId(setlistId, userId)).willReturn(Optional.of(setlist));
-        given(festivalRepository.findById(festivalId)).willReturn(Optional.of(festival));
-        given(setlistMusicRepository.findBySetlist(setlist)).willReturn(List.of(music));
-
-        // when
-        var result = setlistService.getSetlistDetail(userId, setlistId);
-
-        // then
-        assertThat(result.type()).isEqualTo("FESTIVAL");
-        assertThat(result.typeId()).isEqualTo(festivalId);
-        assertThat(result.title()).isEqualTo("부산 록 페스티벌");
-        assertThat(result.musics()).hasSize(1);
-        assertThat(result.musics().get(0).trackId()).isEqualTo("02");
-        assertThat(result.musics().get(0).artistName()).isEqualTo("NewJeans");
     }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #403 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 셋리스트 관련 API 응답 형태 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
- 현재 셋리스트 API는 `posterUrl`을 "파일명+확장자(.png)" 형태만 넘기고 있었습니다!
- 다른 API들은 `S3FileHandler.getFileUrl()` 을 이용해 `S3 Presigned URL`을 만들어서 보내주고 있어 api마다 형식이 다르게 전달되고 있어 이를 해결했습니다.
- 셋리스트 전체보기 목록조회, 미리보기 목록조회, 셋리스트 상세조회 API 로직이 모두 수정되었습니다.

## 테스트
<img width="463" alt="image" src="https://github.com/user-attachments/assets/d63d9afd-ac7f-4ea8-901a-3db4c6304b3a" />
