### PR TITLE
feat [#405] Apple Music API의 Rate Limit 해결을 위한 Redis 캐싱

### DIFF
--- a/src/main/java/org/sopt/confeti/domain/concert/Concert.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/Concert.java
@@ -40,7 +40,7 @@ public class Concert {
     @Column(length = 50, nullable = false)
     private String title;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 80, nullable = false)
     private String subtitle;
 
     @Column(nullable = false)

--- a/src/main/java/org/sopt/confeti/domain/festival/Festival.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/Festival.java
@@ -43,7 +43,7 @@ public class Festival {
     @Column(length = 50, nullable = false)
     private String title;
 
-    @Column(length = 50, nullable = false)
+    @Column(length = 80, nullable = false)
     private String subtitle;
 
     @Column(nullable = false)

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -1,5 +1,7 @@
 package org.sopt.confeti.global.util.music;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -11,9 +13,11 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.global.annotation.Handler;
 import org.sopt.confeti.global.annotation.RetryOnTokenExpire;
 import org.sopt.confeti.global.exception.ConfetiException;
@@ -31,9 +35,11 @@ import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicResponse;
 import org.sopt.confeti.global.util.music.dto.music.AppleMusicMusicsResponse;
 import org.sopt.confeti.global.util.music.dto.music.MusicPage;
 import org.sopt.confeti.global.util.music.dto.search.AppleMusicSearchResponse;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 
+@Slf4j
 @Handler
 @RequiredArgsConstructor
 public class AppleMusicAPIHandler implements MusicAPIHandler {
@@ -44,6 +50,20 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
 
     private static final String ARTISTS_RELATIONSHIP_SIMILAR_VIEW = "similar-artists";
 
+    // Redis
+    private static final int REDIS_TTL_DAY = 1;
+    private static final String REDIS_KEY_BASE = "apple-music-api:";
+    private static final String REDIS_KEY_ARTISTS = REDIS_KEY_BASE + "artists:";
+    private static final String REDIS_KEY_ARTISTS_RELATED = REDIS_KEY_BASE + "artists-related:";
+    private static final String REDIS_KEY_ARTISTS_TOP_MUSICS = REDIS_KEY_BASE + "artists:top-musics:";
+    private static final String REDIS_KEY_MUSICS = REDIS_KEY_BASE + "musics:";
+    private static final String REDIS_KEY_TOP_MUSICS = REDIS_KEY_BASE + "top-musics";
+    private static final String REDIS_KEY_MUSIC_PAGE_ARTIST_OFFSET_LIMIT =
+            REDIS_KEY_BASE + "music-page:artists:%s:%d:%d";
+    private static final String REDIS_KEY_MUSIC_PAGE_KEYWORD_OFFSET_LIMIT =
+            REDIS_KEY_BASE + "music-page:keyword:%s:%d:%d";
+    private static final String REDIS_KEY_ALBUMS = REDIS_KEY_BASE + "albums:";
+
     // Fetch Limit 목록
     private static final int ARTISTS_FETCH_LIMIT = 25;
     private static final int ALBUMS_FETCH_LIMIT = 100;
@@ -53,6 +73,8 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
     private final AppleMusicAPITokenGenerator tokenGenerator;
     private final AppleMusicAPIURL appleMusicAPIURL;
     private final ApiRestClientBuilder restClient;
+    private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     private final Map<String, String> headers = new ConcurrentHashMap<>();
     private String accessToken;
@@ -71,6 +93,34 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         generateToken();
     }
 
+    private List<ConfetiArtist> getCachedArtists(final Set<String> artistIds) {
+        Object raw = redisTemplate.opsForValue().multiGet(
+                artistIds.stream()
+                        .map(artistId -> REDIS_KEY_ARTISTS + artistId)
+                        .collect(Collectors.toSet())
+        );
+
+        List<ConfetiArtist> cachedArtists = objectMapper.convertValue(raw, new TypeReference<List<ConfetiArtist>>() {
+                }).stream()
+                .filter(Objects::nonNull)
+                .toList();
+
+        Set<String> cachedArtistIds = cachedArtists.stream()
+                .map(ConfetiArtist::getId)
+                .collect(Collectors.toSet());
+        ;
+
+        artistIds.removeIf(cachedArtistIds::contains);
+
+        return cachedArtists;
+    }
+
+    private void cachingArtists(final List<ConfetiArtist> artists) {
+        artists.forEach(artist -> {
+            redisTemplate.opsForValue().set(REDIS_KEY_ARTISTS + artist.getId(), artist, REDIS_TTL_DAY, TimeUnit.DAYS);
+        });
+    }
+
     @Override
     @RetryOnTokenExpire
     public List<ConfetiArtist> getArtistsByArtistIds(final Set<String> artistIds) {
@@ -78,13 +128,19 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
             return Collections.emptyList();
         }
 
+        List<ConfetiArtist> artists = new ArrayList<>(getCachedArtists(artistIds));
+
         AtomicInteger counter = new AtomicInteger();
-        return artistIds.stream()
+        List<ConfetiArtist> artistResults = artistIds.stream()
                 .collect(Collectors.groupingBy(artistId -> counter.getAndIncrement() / ARTISTS_FETCH_LIMIT))
                 .values().parallelStream()
                 .map(this::getArtistsByArtistIds)
                 .flatMap(List::stream)
                 .toList();
+        cachingArtists(artistResults);
+        artists.addAll(artistResults);
+
+        return artists;
     }
 
     private List<ConfetiArtist> getArtistsByArtistIds(final List<String> artistIds) {
@@ -103,13 +159,36 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         );
     }
 
+    private List<ConfetiArtist> getCachedRelatedArtists(final String artistId, final int limit) {
+        Object raw = redisTemplate.opsForValue().get(REDIS_KEY_ARTISTS_RELATED + artistId);
+        if (Objects.isNull(raw)) {
+            return List.of();
+        }
+
+        List<ConfetiArtist> artists = objectMapper.convertValue(raw, new TypeReference<>() {
+        });
+
+        return artists.stream()
+                .limit(limit)
+                .toList();
+    }
+
+    private void cachingRelatedArtists(final String artistId, final List<ConfetiArtist> artists) {
+        redisTemplate.opsForValue().set(REDIS_KEY_ARTISTS_RELATED + artistId, artists, REDIS_TTL_DAY, TimeUnit.DAYS);
+    }
+
     @Override
     @RetryOnTokenExpire
     public List<ConfetiArtist> getRelatedArtists(final String artistId, final int limit) {
+        List<ConfetiArtist> cachedArtists = new ArrayList<>(getCachedRelatedArtists(artistId, limit));
+        if (!cachedArtists.isEmpty()) {
+            return cachedArtists;
+        }
+
         Map<String, String> params = new HashMap<>();
         params.put("limit", String.valueOf(limit));
 
-        return convertToConfetiArtists(
+        List<ConfetiArtist> artists = convertToConfetiArtists(
                 restClient.request()
                         .get()
                         .baseUrl(appleMusicAPIURL.getBaseUrl())
@@ -120,6 +199,9 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                         .connect(headers)
                         .retrieve(AppleMusicArtistsResponse.class)
         );
+        cachingRelatedArtists(artistId, artists);
+
+        return artists;
     }
 
     public List<ConfetiArtist> findArtistsByKeyword(final String keyword, final int limit) {
@@ -141,10 +223,29 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         );
     }
 
+    private Optional<ConfetiArtist> getCachedArtist(final String artistId) {
+        Object raw = redisTemplate.opsForValue().get(REDIS_KEY_ARTISTS + artistId);
+
+        if (Objects.isNull(raw)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(objectMapper.convertValue(raw, ConfetiArtist.class));
+    }
+
+    private void cachingArtist(final ConfetiArtist artist) {
+        redisTemplate.opsForValue().set(REDIS_KEY_ARTISTS + artist.getId(), artist, REDIS_TTL_DAY, TimeUnit.DAYS);
+    }
+
     @Override
     @RetryOnTokenExpire
     public Optional<ConfetiArtist> findArtistByArtistId(final String artistId) {
-        return convertToConfetiArtist(
+        Optional<ConfetiArtist> cachedArtist = getCachedArtist(artistId);
+        if (cachedArtist.isPresent()) {
+            return cachedArtist;
+        }
+
+        Optional<ConfetiArtist> artist = convertToConfetiArtist(
                 restClient.request()
                         .get()
                         .baseUrl(appleMusicAPIURL.getBaseUrl())
@@ -153,6 +254,10 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                         .connect(headers)
                         .retrieve(AppleMusicArtistsResponse.class)
         );
+
+        artist.ifPresent(this::cachingArtist);
+
+        return artist;
     }
 
     private List<ConfetiArtist> convertToConfetiArtists(final AppleMusicArtistsResponse artists) {
@@ -186,19 +291,53 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         );
     }
 
+    private List<ConfetiAlbum> getCachedAlbums(final Set<String> albumIds) {
+        Object raw = redisTemplate.opsForValue().multiGet(
+                albumIds.stream()
+                        .map(albumId -> REDIS_KEY_ALBUMS + albumId)
+                        .collect(Collectors.toSet())
+        );
+
+        List<ConfetiAlbum> cachedAlbums = objectMapper.convertValue(raw, new TypeReference<List<ConfetiAlbum>>() {
+                }).stream()
+                .filter(Objects::nonNull)
+                .toList();
+
+        Set<String> cachedAlbumIds = cachedAlbums.stream()
+                .map(ConfetiAlbum::getId)
+                .collect(Collectors.toSet());
+        ;
+
+        albumIds.removeIf(cachedAlbumIds::contains);
+
+        return cachedAlbums;
+    }
+
+    private void cachingAlbums(List<ConfetiAlbum> albums) {
+        albums.forEach(album -> {
+            redisTemplate.opsForValue().set(REDIS_KEY_ALBUMS + album.getId(), album, REDIS_TTL_DAY, TimeUnit.DAYS);
+        });
+    }
+
     @Override
     public List<ConfetiAlbum> getAlbumsByAlbumIds(final Set<String> albumIds) {
         if (albumIds.isEmpty()) {
             return Collections.emptyList();
         }
 
+        List<ConfetiAlbum> albums = new ArrayList<>(getCachedAlbums(albumIds));
+
         AtomicInteger counter = new AtomicInteger();
-        return albumIds.stream()
+        List<ConfetiAlbum> cacheMissedAlbums = albumIds.stream()
                 .collect(Collectors.groupingBy(albumId -> counter.getAndIncrement() / ALBUMS_FETCH_LIMIT))
                 .values().parallelStream()
                 .map(this::getAlbumsByAlbumIds)
                 .flatMap(List::stream)
                 .toList();
+        cachingAlbums(cacheMissedAlbums);
+        albums.addAll(cacheMissedAlbums);
+
+        return albums;
     }
 
     @RetryOnTokenExpire
@@ -224,6 +363,34 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                 .toList();
     }
 
+    private List<ConfetiMusic> getCachedMusics(final Set<String> musicIds) {
+        Object raw = redisTemplate.opsForValue().multiGet(
+                musicIds.stream()
+                        .map(musicId -> REDIS_KEY_MUSICS + musicId)
+                        .collect(Collectors.toSet())
+        );
+
+        List<ConfetiMusic> cachedMusics = objectMapper.convertValue(raw, new TypeReference<List<ConfetiMusic>>() {
+                }).stream()
+                .filter(Objects::nonNull)
+                .toList();
+
+        Set<String> cachedMusicIds = cachedMusics.stream()
+                .map(ConfetiMusic::getId)
+                .collect(Collectors.toSet());
+        ;
+
+        musicIds.removeIf(cachedMusicIds::contains);
+
+        return cachedMusics;
+    }
+
+    private void cachingMusics(final List<ConfetiMusic> musics) {
+        musics.forEach(music -> {
+            redisTemplate.opsForValue().set(REDIS_KEY_MUSICS + music.getId(), music, REDIS_TTL_DAY, TimeUnit.DAYS);
+        });
+    }
+
     @Override
     @RetryOnTokenExpire
     public List<ConfetiMusic> getMusicsByMusicIds(final Set<String> musicIds) {
@@ -231,13 +398,19 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
             return Collections.emptyList();
         }
 
+        List<ConfetiMusic> musics = new ArrayList<>(getCachedMusics(musicIds));
+
         AtomicInteger counter = new AtomicInteger();
-        return musicIds.stream()
+        List<ConfetiMusic> cacheMissedMusics = musicIds.stream()
                 .collect(Collectors.groupingBy(musicId -> counter.getAndIncrement() / MUSICS_FETCH_LIMIT))
                 .values().parallelStream()
                 .map(this::getMusicsByMusicIds)
                 .flatMap(List::stream)
                 .toList();
+        cachingMusics(cacheMissedMusics);
+        musics.addAll(cacheMissedMusics);
+
+        return musics;
     }
 
     private List<ConfetiMusic> getMusicsByMusicIds(final List<String> musicIds) {
@@ -262,16 +435,44 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                 .toList();
     }
 
+    private List<ConfetiMusic> getCachedTopMusics(final int fetchSize) {
+        Object raw = redisTemplate.opsForValue().get(REDIS_KEY_TOP_MUSICS);
+
+        if (Objects.isNull(raw)) {
+            return List.of();
+        }
+
+        List<ConfetiMusic> musics = objectMapper.convertValue(raw, new TypeReference<>() {
+        });
+
+        if (musics.size() < fetchSize) {
+            return List.of();
+        }
+
+        return musics.stream()
+                .limit(fetchSize)
+                .toList();
+    }
+
+    private void cachingTopMusics(final List<ConfetiMusic> musics) {
+        redisTemplate.opsForValue().set(REDIS_KEY_TOP_MUSICS, musics, REDIS_TTL_DAY, TimeUnit.DAYS);
+    }
+
     @Override
     @RetryOnTokenExpire
     public List<ConfetiMusic> getTopMusics(final int fetchSize) {
         validateFetchSize(fetchSize);
 
+        List<ConfetiMusic> topMusics = new ArrayList<>(getCachedTopMusics(fetchSize));
+        if (!topMusics.isEmpty()) {
+            return topMusics;
+        }
+
         Map<String, String> params = new HashMap<>();
         params.put("types", SONGS_TYPE);
         params.put("limit", String.valueOf(fetchSize));
 
-        return convertToConfetiMusics(
+        topMusics.addAll(convertToConfetiMusics(
                 restClient.request()
                         .get()
                         .baseUrl(appleMusicAPIURL.getBaseUrl())
@@ -280,7 +481,10 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                         .build()
                         .connect(headers)
                         .retrieve(AppleMusicChartsResponse.class)
-        );
+        ));
+        cachingTopMusics(topMusics);
+
+        return topMusics;
     }
 
     private List<ConfetiMusic> convertToConfetiMusics(final AppleMusicChartsResponse charts) {
@@ -300,11 +504,39 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         }
     }
 
+    private List<ConfetiMusic> getCachedTopMusicsByArtistId(final String artistId, final int fetchSize) {
+        Object raw = redisTemplate.opsForValue().get(REDIS_KEY_ARTISTS_TOP_MUSICS + artistId);
+
+        if (Objects.isNull(raw)) {
+            return List.of();
+        }
+
+        List<ConfetiMusic> musics = objectMapper.convertValue(raw, new TypeReference<>() {
+        });
+
+        if (musics.size() < fetchSize) {
+            return List.of();
+        }
+
+        return musics.stream()
+                .limit(fetchSize)
+                .toList();
+    }
+
+    private void cachingTopMusicsByArtistId(final String artistId, final List<ConfetiMusic> musics) {
+        redisTemplate.opsForValue().set(REDIS_KEY_ARTISTS_TOP_MUSICS + artistId, musics, REDIS_TTL_DAY, TimeUnit.DAYS);
+    }
+
     public List<ConfetiMusic> getTopSongsByArtistId(final String artistId, final int fetchSize) {
+        List<ConfetiMusic> topMusics = new ArrayList<>(getCachedTopMusicsByArtistId(artistId, fetchSize));
+        if (!topMusics.isEmpty()) {
+            return topMusics;
+        }
+
         Map<String, String> params = new HashMap<>();
         params.put("limit", String.valueOf(fetchSize));
 
-        return convertToConfetiMusics(
+        topMusics.addAll(convertToConfetiMusics(
                 restClient.request()
                         .get()
                         .baseUrl(appleMusicAPIURL.getBaseUrl())
@@ -313,7 +545,10 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                         .build()
                         .connect(headers)
                         .retrieve(AppleMusicMusicsResponse.class)
-        );
+        ));
+        cachingTopMusicsByArtistId(artistId, topMusics);
+
+        return topMusics;
     }
 
     @Override
@@ -341,14 +576,37 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         return result;
     }
 
+    private Optional<MusicPage> getCachedMusicPageByArtistId(String artistId, int offset, int limit) {
+        // check exists artist
+        Object raw = redisTemplate.opsForValue()
+                .get(String.format(REDIS_KEY_MUSIC_PAGE_ARTIST_OFFSET_LIMIT, artistId, offset, limit));
+
+        if (Objects.isNull(raw)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(objectMapper.convertValue(raw, MusicPage.class));
+    }
+
+    private void cachingMusicPageByArtistId(String artistId, int offset, int limit, MusicPage musicPage) {
+        redisTemplate.opsForValue()
+                .set(String.format(REDIS_KEY_MUSIC_PAGE_ARTIST_OFFSET_LIMIT, artistId, offset, limit), musicPage,
+                        REDIS_TTL_DAY, TimeUnit.DAYS);
+    }
+
     @Override
     @RetryOnTokenExpire
     public MusicPage getArtistMusicsByArtistId(String artistId, int offset, int limit) {
+        Optional<MusicPage> optMusicPage = getCachedMusicPageByArtistId(artistId, offset, limit);
+        if (optMusicPage.isPresent()) {
+            return optMusicPage.get();
+        }
+
         Map<String, String> params = new HashMap<>();
         params.put("offset", String.valueOf(offset));
         params.put("limit", String.valueOf(limit));
 
-        return convertToConfetiMusicPage(
+        MusicPage musicPage = convertToConfetiMusicPage(
                 restClient.request()
                         .get()
                         .baseUrl(appleMusicAPIURL.getBaseUrl())
@@ -358,6 +616,9 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                         .connect(headers)
                         .retrieve(AppleMusicArtistMusicsResponse.class)
         );
+        cachingMusicPageByArtistId(artistId, offset, limit, musicPage);
+
+        return musicPage;
     }
 
     private MusicPage convertToConfetiMusicPage(AppleMusicArtistMusicsResponse artistMusics) {
@@ -369,16 +630,38 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         );
     }
 
+    private Optional<MusicPage> getCachedMusicPageByKeyword(String term, int offset, int limit) {
+        Object raw = redisTemplate.opsForValue()
+                .get(String.format(REDIS_KEY_MUSIC_PAGE_KEYWORD_OFFSET_LIMIT, term, offset, limit));
+
+        if (Objects.isNull(raw)) {
+            return Optional.empty();
+        }
+
+        return Optional.of(objectMapper.convertValue(raw, MusicPage.class));
+    }
+
+    private void cachingMusicPageByKeyword(String term, int offset, int limit, MusicPage musicPage) {
+        redisTemplate.opsForValue()
+                .set(String.format(REDIS_KEY_MUSIC_PAGE_KEYWORD_OFFSET_LIMIT, term, offset, limit), musicPage,
+                        REDIS_TTL_DAY, TimeUnit.DAYS);
+    }
+
     @Override
     @RetryOnTokenExpire
     public MusicPage getMusicsByKeyword(String term, int offset, int limit) {
+        Optional<MusicPage> optMusicPage = getCachedMusicPageByKeyword(term, offset, limit);
+        if (optMusicPage.isPresent()) {
+            return optMusicPage.get();
+        }
+
         Map<String, String> params = new HashMap<>();
         params.put("term", term);
         params.put("offset", String.valueOf(offset));
         params.put("limit", String.valueOf(limit));
         params.put("types", SONGS_TYPE);
 
-        return convertToConfetiMusicPage(
+        MusicPage musicPage = convertToConfetiMusicPage(
                 restClient.request()
                         .get()
                         .baseUrl(appleMusicAPIURL.getBaseUrl())
@@ -388,6 +671,9 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                         .connect(headers)
                         .retrieve(AppleMusicSearchResponse.class)
         );
+        cachingMusicPageByKeyword(term, offset, limit, musicPage);
+
+        return musicPage;
     }
 
     private MusicPage convertToConfetiMusicPage(AppleMusicSearchResponse searchResult) {

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/MusicPage.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/MusicPage.java
@@ -7,19 +7,21 @@ import java.util.regex.Pattern;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 
 @Getter
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
 public class MusicPage {
 
     private static final Pattern offsetPattern = Pattern.compile("offset=(\\d+)");
     private static final int FIRST_ITEM = 1;
     private static final int DEFAULT_NEXT_OFFSET = -1;
 
-    private final int nextOffset;
-    private final boolean isLast;
-    private final List<ConfetiMusic> musics;
+    private int nextOffset;
+    private boolean isLast;
+    private List<ConfetiMusic> musics;
 
     public static MusicPage of(String next, List<ConfetiMusic> musics) {
         boolean isLast = Objects.isNull(next);


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #405 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] Apple Music API Rate Limit 해결을 위해 캐싱
- [x] Concert, Festival subtitle 글자 수 80으로 변경

## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
![image](https://github.com/user-attachments/assets/740b15b2-a31e-44d9-960e-e34472d2f8d0)
잘 저장되었습니다!
스프린트 이후에 Redis AOP 관심사 분리 및 키 관리가 필요해보입니다.