### PR TITLE
refactor [#420] 유저가 선호하는 공연의 예매일 검증 로직 추가

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -136,8 +136,8 @@ public class PerformanceFacade {
     @Transactional(readOnly = true)
     public PerformanceReservationDTO getPerformReservationInfo(final Long userId) {
         boolean isUserExist = userId != null && userService.existsById(userId);
-        boolean isCFExist = isUserExist && concertFavoriteService.existsByUserId(userId);
-        boolean isFFExist = isUserExist && festivalFavoriteService.existsByUserId(userId);
+        boolean isCFExist = isUserExist && concertFavoriteService.existsUpcomingReservationByUserId(userId);
+        boolean isFFExist = isUserExist && festivalFavoriteService.existsUpcomingReservationByUserId(userId);
 
         if (isCFExist || isFFExist) {
             List<PerformanceTicketDTO> performanceReserve = performanceService.getFavoritePerformancesReservation(

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ConcertArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ConcertArtistDTO.java
@@ -1,14 +1,12 @@
 package org.sopt.confeti.api.performance.facade.dto.response;
 
-import java.time.LocalDate;
 import org.sopt.confeti.domain.concert_artist.ConcertArtist;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 
 public record ConcertArtistDTO(
         String artistId,
         String name,
-        String profileUrl,
-        LocalDate latestReleaseAt
+        String profileUrl
 ) {
     public static ConcertArtistDTO of(final ConcertArtist concertArtist) {
         ConfetiArtist confetiArtist = concertArtist.getArtist();
@@ -16,8 +14,7 @@ public record ConcertArtistDTO(
         return new ConcertArtistDTO(
                 confetiArtist.getId(),
                 confetiArtist.getName(),
-                confetiArtist.getProfileUrl(),
-                confetiArtist.getLatestReleaseAlbum().getReleaseAt()
+                confetiArtist.getProfileUrl()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailArtistDTO.java
@@ -1,22 +1,19 @@
 package org.sopt.confeti.api.performance.facade.dto.response;
 
-import java.time.LocalDate;
 import org.sopt.confeti.domain.festival_artist.FestivalArtist;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 
 public record FestivalDetailArtistDTO(
         String artistId,
         String name,
-        String profileUrl,
-        LocalDate latestReleaseAt
+        String profileUrl
 ) {
     public static FestivalDetailArtistDTO from(final FestivalArtist festivalArtist) {
         ConfetiArtist confetiArtist = festivalArtist.getArtist();
         return new FestivalDetailArtistDTO(
                 confetiArtist.getId(),
                 confetiArtist.getName(),
-                confetiArtist.getProfileUrl(),
-                confetiArtist.getLatestReleaseAlbum().getReleaseAt()
+                confetiArtist.getProfileUrl()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/concert_favorite/application/ConcertFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/concert_favorite/application/ConcertFavoriteService.java
@@ -34,8 +34,8 @@ public class ConcertFavoriteService {
     }
 
     @Transactional(readOnly = true)
-    public boolean existsByUserId(final Long userId) {
-        return concertFavoriteRepository.existsByUserId(userId);
+    public boolean existsUpcomingReservationByUserId(final Long userId) {
+        return concertFavoriteRepository.existsUpcomingReservationByUserId(userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/domain/concert_favorite/infra/repository/ConcertFavoriteRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/concert_favorite/infra/repository/ConcertFavoriteRepository.java
@@ -12,7 +12,11 @@ public interface ConcertFavoriteRepository extends JpaRepository<ConcertFavorite
 
     void deleteByUserIdAndConcertId(final long userId, final long concertId);
 
-    boolean existsByUserId(final Long userId);
+    @Query("SELECT CASE WHEN COUNT(cf) > 0 THEN true ELSE false END " +
+            "FROM ConcertFavorite cf " +
+            "WHERE cf.user.id = :userId " +
+            "AND cf.concert.reserveAt >= CURRENT_DATE ")
+    boolean existsUpcomingReservationByUserId(@Param("userId") Long userId);
 
     @Query("SELECT cf.concert.id FROM ConcertFavorite cf WHERE cf.user.id = :userId AND cf.concert.id IN :concertIds")
     List<Long> findFavoriteConcertIds(@Param("userId") Long userId, @Param("concertIds") Set<Long> concertIds);

--- a/src/main/java/org/sopt/confeti/domain/festival_favorite/application/FestivalFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival_favorite/application/FestivalFavoriteService.java
@@ -40,8 +40,8 @@ public class FestivalFavoriteService {
         return festivalFavoriteRepository.existsByUserIdAndFestivalId(userId, festivalId);
     }
 
-    public boolean existsByUserId(final Long userId) {
-        return festivalFavoriteRepository.existsByUserId(userId);
+    public boolean existsUpcomingReservationByUserId(final Long userId) {
+        return festivalFavoriteRepository.existsUpcomingReservationByUserId(userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/domain/festival_favorite/infra/repository/FestivalFavoriteRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/festival_favorite/infra/repository/FestivalFavoriteRepository.java
@@ -13,7 +13,11 @@ public interface FestivalFavoriteRepository extends JpaRepository<FestivalFavori
 
     boolean existsByUserIdAndFestivalId(long userId, long festivalId);
 
-    boolean existsByUserId(Long userId);
+    @Query("SELECT CASE WHEN COUNT(ff) > 0 THEN true ELSE false END " +
+            "FROM FestivalFavorite ff " +
+            "WHERE ff.user.id = :userId " +
+            "AND ff.festival.reserveAt >= CURRENT_DATE ")
+    boolean existsUpcomingReservationByUserId(@Param("userId") Long userId);
 
     @Query("SELECT ff.festival.id FROM FestivalFavorite ff WHERE ff.user.id = :userId AND ff.festival.id IN :festivalIds")
     List<Long> findFavoriteFestivalIds(@Param("userId") Long userId, @Param("festivalIds") Set<Long> festivalIds);

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/album/AlbumResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/album/AlbumResolver.java
@@ -86,7 +86,6 @@ public class AlbumResolver extends AbstractMusicAPISpecificResolver {
                 ConfetiAlbum mappedConfetiAlbum = mappedConfetiAlbums.poll();
 
                 mappedConfetiAlbum.setName(confetiAlbum.getName());
-                mappedConfetiAlbum.setReleaseAt(confetiAlbum.getReleaseAt());
             }
         }));
     }

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/album/vo/ConfetiAlbum.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/album/vo/ConfetiAlbum.java
@@ -1,6 +1,5 @@
 package org.sopt.confeti.global.resolver.music_api.album.vo;
 
-import java.time.LocalDate;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Getter;
@@ -19,30 +18,24 @@ public class ConfetiAlbum {
     @Setter
     private String name;
 
-    @Setter
-    private LocalDate releaseAt;
-
     public static ConfetiAlbum from(final AppleMusicArtistAlbumResponse album) {
         return new ConfetiAlbum(
                 album.id(),
-                "",
-                null
+                ""
         );
     }
 
     public static ConfetiAlbum from(final String albumId) {
         return new ConfetiAlbum(
                 albumId,
-                "",
-                null
+                ""
         );
     }
 
     public static ConfetiAlbum from(final AppleMusicAlbumResponse album) {
         return new ConfetiAlbum(
                 album.id(),
-                album.attributes().name(),
-                album.attributes().releaseDate()
+                album.attributes().name()
         );
     }
 

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/album/AppleMusicAlbumAttributesResponse.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/album/AppleMusicAlbumAttributesResponse.java
@@ -1,9 +1,6 @@
 package org.sopt.confeti.global.util.music.dto.album;
 
-import java.time.LocalDate;
-
 public record AppleMusicAlbumAttributesResponse(
-        LocalDate releaseDate,
         String name
 ) {
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #420

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x]  유저가 선호하는 공연의 예매일 검증 로직 추가


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
최신 공연 티켓팅 정보 조회 api에서 현재 유저가 좋아하는 페스티벌/콘서트의 예매일 경과 여부를 확인하고 있지 않아 해당 부분을 추가했습니다. 

```java
    @Query("SELECT CASE WHEN COUNT(cf) > 0 THEN true ELSE false END " +
            "FROM ConcertFavorite cf " +
            "WHERE cf.user.id = :userId " +
            "AND cf.concert.reserveAt >= CURRENT_DATE ")
    boolean existsUpcomingReservationByUserId(@Param("userId") Long userId);
```
