### PR TITLE
fix [#434] 예정된 공연 조회 API에서 날짜가 지난 공연과 중복된 공연이 나오지 않도록 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -150,7 +150,7 @@ public class PerformanceController {
             @RequestParam(required = false) String ptitle,
             @RequestParam(required = false, defaultValue = Default.PERFORMANCE_TYPE) PerformanceType ptype
     ) {
-        IntendedPerformancesDTO performancesDTO = performanceFacade.getPerformances(userId, pid, aid, ptitle, ptype);
+        IntendedPerformancesDTO performancesDTO = performanceFacade.searchPerformances(userId, pid, aid, ptitle, ptype);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 IntendedPerformancesResponse.of(performancesDTO, s3FileHandler));
     }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -268,8 +268,8 @@ public class PerformanceFacade {
     }
 
     @Transactional(readOnly = true)
-    public IntendedPerformancesDTO getPerformances(Long userId, Long pid, String aid, String ptitle,
-                                                   PerformanceType ptype) {
+    public IntendedPerformancesDTO searchPerformances(Long userId, Long pid, String aid, String ptitle,
+                                                      PerformanceType ptype) {
         if (!isPresent(pid) && !isPresent(aid) && !isPresent(ptitle)) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
@@ -277,7 +277,7 @@ public class PerformanceFacade {
         List<PerformanceDTO> performances = new ArrayList<>();
 
         if (isPresent(pid)) {
-            PerformanceDTO performance = PerformanceDTO.from(performanceService.getPerformanceById(pid));
+            PerformanceDTO performance = performanceService.getPerformance(pid);
             performances.add(performance);
             searchTermService.write(performance.title());
         }
@@ -287,7 +287,7 @@ public class PerformanceFacade {
         }
 
         if (isPresent(ptitle)) {
-            List<PerformanceDTO> searchedPerformances = performanceSearchService.getPerformancesByTitleAndTypePartialMatched(
+            List<PerformanceDTO> searchedPerformances = performanceSearchService.getExpectedPerformancesByTitleAndTypePartialMatched(
                             ptitle, ptype).stream()
                     .map(PerformanceDTO::from)
                     .toList();
@@ -295,9 +295,11 @@ public class PerformanceFacade {
             performances.addAll(searchedPerformances);
         }
 
-        Map<Long, Boolean> performanceFavorites = getPerformanceFavorites(userId, performances);
+        Set<PerformanceDTO> performancesResult = new HashSet<>(performances);
+
+        Map<Long, Boolean> performanceFavorites = getPerformanceFavorites(userId, performancesResult);
         return IntendedPerformancesDTO.of(
-                new HashSet<>(performances),
+                performancesResult,
                 performanceFavorites
         );
     }
@@ -306,7 +308,7 @@ public class PerformanceFacade {
         return Objects.nonNull(target);
     }
 
-    private Map<Long, Boolean> getPerformanceFavorites(Long userId, List<PerformanceDTO> performances) {
+    private Map<Long, Boolean> getPerformanceFavorites(Long userId, Set<PerformanceDTO> performances) {
         Map<Long, Boolean> performanceFavorites = new HashMap<>();
         performances.forEach(performance -> performanceFavorites.put(performance.id(), false));
 

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.domain.elastic_search.application;
 
+import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.elastic_search.PerformanceDocument;
@@ -32,6 +33,17 @@ public class PerformanceSearchService {
 
         return performances.stream()
                 .map(SearchPerformanceResult::from)
+                .toList();
+    }
+
+    public List<SearchPerformanceResult> getExpectedPerformancesByTitleAndTypePartialMatched(String ptitle,
+                                                                                             PerformanceType ptype) {
+        List<PerformanceDocument> performances = performanceSearchOperator.searchByTitleAndTypePartialMatch(
+                clearSentence(ptitle), ptype, PerformanceStatus.ALL);
+
+        return performances.stream()
+                .map(SearchPerformanceResult::from)
+                .filter(performance -> !performance.endAt().isBefore(LocalDate.now()))
                 .toList();
     }
 

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -137,7 +137,7 @@ public class PerformanceService {
 
     @Transactional(readOnly = true)
     public PerformanceDTO getPerformance(long performanceId) {
-        Performance performance = performanceRepository.findPerformanceByIdAndEndAtGreaterThanEqualOrderByStartAt(
+        Performance performance = performanceRepository.findPerformanceByIdAndEndAtGreaterThanEqual(
                         performanceId,
                         LocalDate.now())
                 .orElseThrow(

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceDTO.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.domain.view.performance.application.dto.response;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.Objects;
 import org.sopt.confeti.domain.elastic_search.application.dto.response.SearchPerformanceResult;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.global.common.constant.PerformanceType;
@@ -49,5 +50,22 @@ public record PerformanceDTO(
                 null,
                 null
         );
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+        PerformanceDTO that = (PerformanceDTO) o;
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hash(id);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -79,7 +79,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     @Query(value = "SELECT p FROM Performance p WHERE p.endAt >= CURRENT_DATE ORDER BY RAND() LIMIT 5")
     List<Performance> findTop5ByRand();
 
-    Optional<Performance> findPerformanceByIdAndEndAtGreaterThanEqualOrderByStartAt(long performanceId, LocalDate date);
+    Optional<Performance> findPerformanceByIdAndEndAtGreaterThanEqual(long performanceId, LocalDate date);
 
     @Query(value = "SELECT p FROM Performance p WHERE p.endAt >= CURRENT_DATE ORDER BY RAND() LIMIT 1")
     Performance findPerformanceByRand();

--- a/src/main/java/org/sopt/confeti/global/common/constant/Default.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/Default.java
@@ -11,5 +11,5 @@ public class Default {
     public static final String TEXT = "CONFETI";
     public static final String PROFILE_IMG_NAME = "user-profile.svg";
     public static final String PERFORMANCE_TYPE = "performance";
-    public static final String PERFORMANCE_STATUS = "all";
+    public static final String PERFORMANCE_STATUS = "upcoming";
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #434 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 예정된 공연 조회 API에서 날짜가 지난 공연이 뜨지 않도록 수정
- [x] 예정된 공연 조회 API에서 중복된 공연이 뜨지 않도록 수정
- [x] 홈 검색화면의 공연 연관 검색에서 예정된 공연이 뜨도록 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
`PerformanceDTO` 에 `equals`, `hashCode` 함수를 오버라이딩해서 중복을 제거했습니다.
그리고 공연 타입을 예정된 공연을 의미하는 `upcoming`으로 변경했습니다.

홈 검색의 예정된 공연 조회의 경우 엘라스틱 서치에서 전체 공연을 대상으로 조회한 뒤, 애플리케이션 상에서 날짜가 지나지 않은 공연을 필터링하는 방식으로 조회했습니다.
