### PR TITLE
feat [#438] 디스코드 회원가입 알림 연동

### DIFF
--- a/src/main/java/org/sopt/confeti/api/auth/facade/AuthFacade.java
+++ b/src/main/java/org/sopt/confeti/api/auth/facade/AuthFacade.java
@@ -5,12 +5,7 @@ import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.auth.facade.dto.request.OnboardArtistDTO;
 import org.sopt.confeti.api.auth.facade.dto.request.OnboardDTO;
-import org.sopt.confeti.auth.LoginService;
-import org.sopt.confeti.auth.LogoutService;
-import org.sopt.confeti.auth.OnboardService;
-import org.sopt.confeti.auth.ReissueService;
-import org.sopt.confeti.auth.Token;
-import org.sopt.confeti.auth.WithdrawService;
+import org.sopt.confeti.auth.*;
 import org.sopt.confeti.auth.command.LoginCommand;
 import org.sopt.confeti.auth.dto.LoginResult;
 import org.sopt.confeti.auth.dto.OAuthSocialInfoResult;
@@ -34,6 +29,7 @@ public class AuthFacade {
     private final ArtistFavoriteService artistFavoriteService;
     private final OnboardService onboardService;
     private final WithdrawService withdrawService;
+    private final WebhookService webhookService;
 
     @Transactional
     public LoginResult login(LoginCommand loginCommand) {
@@ -41,6 +37,7 @@ public class AuthFacade {
 
         if (userService.notExist(socialInfo.id(), loginCommand.provider())) {
             userService.create(loginService.getCreateUserDTO(loginCommand.provider(), socialInfo));
+            webhookService.sendDiscordNotification();
         }
 
         AuthUser authUser = userService.getAuthUser(socialInfo.id(), loginCommand.provider());

--- a/src/main/java/org/sopt/confeti/auth/WebhookService.java
+++ b/src/main/java/org/sopt/confeti/auth/WebhookService.java
@@ -11,7 +11,7 @@ import java.util.Map;
 
 @RequiredArgsConstructor
 @Service
-@Transactional
+@Transactional(readOnly = true)
 public class WebhookService {
 
     private final UserRepository userRepository;

--- a/src/main/java/org/sopt/confeti/auth/WebhookService.java
+++ b/src/main/java/org/sopt/confeti/auth/WebhookService.java
@@ -2,8 +2,8 @@ package org.sopt.confeti.auth;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.global.module.rest_client.builder.ApiRestClientBuilder;
-import org.springframework.beans.factory.annotation.Value;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
+import org.springframework.core.env.Environment;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import java.util.HashMap;
@@ -16,11 +16,16 @@ public class WebhookService {
 
     private final UserRepository userRepository;
     private final ApiRestClientBuilder restClient;
-
-    @Value("${discord.webhook.url}")
-    private String discordWebhookUrl;
+    private final Environment environment;
 
     public void sendDiscordNotification() {
+
+        for (String profile : environment.getActiveProfiles()) {
+            if (profile.equalsIgnoreCase("dev")) return;
+        }
+
+        String discordWebhookUrl = environment.getProperty("discord.webhook.url");
+        if (discordWebhookUrl == null || discordWebhookUrl.isBlank()) return;
 
         long totalMembers = userRepository.count();
 

--- a/src/main/java/org/sopt/confeti/auth/WebhookService.java
+++ b/src/main/java/org/sopt/confeti/auth/WebhookService.java
@@ -1,15 +1,11 @@
 package org.sopt.confeti.auth;
 
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.global.module.rest_client.builder.ApiRestClientBuilder;
 import org.springframework.beans.factory.annotation.Value;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.MediaType;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.client.RestTemplate;
-
 import java.util.HashMap;
 import java.util.Map;
 
@@ -19,26 +15,26 @@ import java.util.Map;
 public class WebhookService {
 
     private final UserRepository userRepository;
+    private final ApiRestClientBuilder restClient;
 
     @Value("${discord.webhook.url}")
     private String discordWebhookUrl;
 
     public void sendDiscordNotification() {
 
-        RestTemplate restTemplate = new RestTemplate();
-
         long totalMembers = userRepository.count();
 
         String message = "CONFETI에 " + totalMembers + "번째 유저가 가입했습니다!🎉\n";
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-
         Map<String, String> body = new HashMap<>();
         body.put("content", message);
 
-        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(body, headers);
-
-        restTemplate.postForEntity(discordWebhookUrl, requestEntity, String.class);
+        restClient.request()
+                .post()
+                .baseUrl(discordWebhookUrl)
+                .body(body)
+                .build()
+                .connect()
+                .retrieve();
     }
 }

--- a/src/main/java/org/sopt/confeti/auth/WebhookService.java
+++ b/src/main/java/org/sopt/confeti/auth/WebhookService.java
@@ -1,0 +1,44 @@
+package org.sopt.confeti.auth;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.sopt.confeti.domain.user.infra.repository.UserRepository;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@RequiredArgsConstructor
+@Service
+@Transactional
+public class WebhookService {
+
+    private final UserRepository userRepository;
+
+    @Value("${discord.webhook.url}")
+    private String discordWebhookUrl;
+
+    public void sendDiscordNotification() {
+
+        RestTemplate restTemplate = new RestTemplate();
+
+        long totalMembers = userRepository.count();
+
+        String message = "CONFETI에 " + totalMembers + "번째 유저가 가입했습니다!🎉\n";
+
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+
+        Map<String, String> body = new HashMap<>();
+        body.put("content", message);
+
+        HttpEntity<Map<String, String>> requestEntity = new HttpEntity<>(body, headers);
+
+        restTemplate.postForEntity(discordWebhookUrl, requestEntity, String.class);
+    }
+}


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #438 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 디스코드 웹훅 연동
- [x] WebhookService 작성


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="385" alt="스크린샷 2025-05-12 오후 9 49 08" src="https://github.com/user-attachments/assets/e5591de8-27bd-4bdd-aab2-841b1c351376" />

디스코드 웹훅 생성 후 회원가입 이벤트 발생 시마다 디스코드 서버에 알림을 보내는 WebhookService를 작성했습니다.

 ```java
// dev 프로필(로컬 환경)에서는 실행되지 않도록 설정
for (String profile : environment.getActiveProfiles()) {
    if (profile.equalsIgnoreCase("dev")) return;
}
 ```
로컬 환경에서는 Discord 알림이 가지 않도록 Environment 의존성을 주입해, 활성 프로필이 dev일 경우 알림 로직이 실행되지 않도록 설정했습니다. 
 ```java
// discordWebhookUrl이 없을 경우(배포 환경이 아닌 경우) 실행되지 않도록 설정
String discordWebhookUrl = environment.getProperty("discord.webhook.url");
if (discordWebhookUrl == null || discordWebhookUrl.isBlank()) return;
```
application.yml에 로컬 관련 환경 값을 따로 지정하지 않기 위해 environment.getProperty("discord.webhook.url")을 사용하여 상황에 따라 값을 동적으로 불러오도록 구성했습니다.

@Profile("!dev") 과 같이 어노테이션으로 특정 빈의 등록을 제한하는 방법도 고려해 보았는데, 해당 경우에서는 `application.yml`에 로컬 환경 값을 작성하지 않기 위해 별도의 주입이 필요해 `environment` 를 사용하는 환경으로 작성했습니다!