### PR TITLE
refactor [#440] S3 Signed URL 제거

### DIFF
--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -6,6 +6,9 @@ import java.io.File;
 import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.MalformedURLException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.net.URL;
 import java.nio.file.Files;
 import java.time.Duration;
@@ -29,6 +32,9 @@ public class S3FileHandler {
     private final S3Operations s3Operations;
     private final S3Client s3Client;
     private final FileNameGenerator fileNameGenerator;
+
+    @Value("${spring.cloud.aws.s3.host}")
+    private String host;
 
     @Value("${spring.cloud.aws.s3.bucket-name}")
     private String bucket;
@@ -108,9 +114,22 @@ public class S3FileHandler {
     }
 
     /**
-     * 파일 조회 URL 생성
+     * Public 설정이 된 파일 조회 URL 생성
      */
     public URL getFileUrl(String folderPath, String key) {
+        checkFileExist(folderPath, key);
+
+        try {
+            return new URI(host + folderPath + key).toURL();
+        } catch (URISyntaxException | MalformedURLException e) {
+            throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+    }
+
+    /**
+     * Public 설정이 되지 않은 파일 조회 URL 생성
+     */
+    public URL getFileSignedUrl(String folderPath, String key) {
         checkFileExist(folderPath, key);
 
         return s3Operations.createSignedGetURL(bucket, folderPath + key, urlDuration);


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #440

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] Unsigned URL을 반환하는 S3 getFileUrl 함수 작성


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1064" alt="image" src="https://github.com/user-attachments/assets/1cdda471-8a8a-46ae-aaba-35e32e856cbb" />

기존의 Signed URL을 생성하는 함수는 추후에 사용될 수 있기 때문에 제거하지 않았어요.
Unsigned URL을 기본 구성으로 가져갈 생각이라 `getFileUrl` 함수가 Unsigned URL을 생성하도록 변경했습니다.
`application-cloud.yml` 설정이 변경되었으니 로컬에 반영 부탁드려요. (노션 반영 완료)