### PR TITLE
refactor [#437] 셋리스트 관련 API Facade 패턴 적용

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,19 +1,19 @@
 <!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
 <!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
 <!-- Reviewer, Assignees, Label 붙이기 --> 
-## ✨Issue Number ✨
+## 🔗 Issue Number
 <!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
 closes #이슈번호
 
-## 🔁 Previous PR (선택) 🔁
+## 🔙 Previous PR
 <!-- 이어지는 PR이라면 이전 PR 링크를 남겨주세요 (ex: #123) -->
-이전 PR: #PR번호
+- #(이전 PR 번호)
 
-## ✨ To-do ✨
+## 📌  To-do
 <!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
 
 - [ ] todo!
 
 
-## ✨Description ✨ 
+## ✨Description 
 <!-- 본인이 한 작업을 설명해주세요 -->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,13 @@
 <!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
 <!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
 <!-- Reviewer, Assignees, Label 붙이기 --> 
-## ✨ Issue Number ✨
+## ✨Issue Number ✨
 <!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
 closes #이슈번호
+
+## 🔁 Previous PR (선택) 🔁
+<!-- 이어지는 PR이라면 이전 PR 링크를 남겨주세요 (ex: #123) -->
+이전 PR: #PR번호
 
 ## ✨ To-do ✨
 <!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->
@@ -11,5 +15,5 @@ closes #이슈번호
 - [ ] todo!
 
 
-## ✨ Description ✨  
+## ✨Description ✨ 
 <!-- 본인이 한 작업을 설명해주세요 -->

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
@@ -2,15 +2,14 @@ package org.sopt.confeti.api.setlist.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.domain.setlist.SetlistSortType;
-import org.sopt.confeti.domain.setlist.application.SetlistService;
-import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRequest;
-import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
-import org.sopt.confeti.domain.setlist.application.dto.response.AddSetListMusicResponse;
-import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
-import org.sopt.confeti.domain.setlist.application.dto.response.GetSetlistDetailResponse;
-import org.sopt.confeti.domain.setlist.application.dto.response.SetlistCreateResponse;
-import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.api.setlist.facade.SetlistFacade;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.SetlistAddMusicResponse;
+import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.api.setlist.dto.response.GetSetlistDetailResponse;
+import org.sopt.confeti.api.setlist.facade.dto.response.SetlistCreateResponse;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryDto;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
@@ -31,7 +30,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/my/setlists")
 public class SetlistController {
 
-    private final SetlistService setlistService;
+    private final SetlistFacade setlistFacade;
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/all")
@@ -39,8 +38,7 @@ public class SetlistController {
             @UserId(require = false) Long userId,
             @RequestParam(name = "sortBy", required = false) String sortBy
     ) {
-        SetlistSortType sortType = SetlistSortType.from(sortBy);
-        GetAllSetlistsResponse data = setlistService.getAllMySetlists(userId, sortType);
+        GetAllSetlistsResponse data = setlistFacade.getAllMySetlists(userId, sortBy);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
     }
 
@@ -49,7 +47,7 @@ public class SetlistController {
     public ResponseEntity<BaseResponse<?>> getPreviewMySetlists(
             @UserId(require = false) Long userId
     ) {
-        List<SetlistSummaryDto> data = setlistService.getPreviewMySetlists(userId);
+        List<SetlistSummaryDto> data = setlistFacade.getPreviewMySetlists(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
     }
 
@@ -57,10 +55,10 @@ public class SetlistController {
     @PostMapping
     public ResponseEntity<BaseResponse<?>> createSetlists(
             @UserId(require = false) Long userId,
-            @RequestBody List<SetlistCreateRequest> requests
+            @RequestBody List<SetlistCreateDTO> requests
     ) {
-        List<Long> ids = setlistService.createSetLists(userId, requests);
-        return ApiResponseUtil.success(SuccessMessage.CREATED, new SetlistCreateResponse(ids));
+        SetlistCreateResponse data = setlistFacade.createSetLists(userId, requests);
+        return ApiResponseUtil.success(SuccessMessage.CREATED, data);
     }
 
     @Permission(role = {Role.GENERAL})
@@ -68,10 +66,10 @@ public class SetlistController {
     public ResponseEntity<BaseResponse<?>> addMusicsToSetlist(
             @UserId(require = false) Long userId,
             @PathVariable Long setlistId,
-            @RequestBody List<AddSetListMusicRequest> requests
+            @RequestBody List<SetlistAddMusicDTO> requests
     ) {
-        int count = setlistService.addMusics(userId, setlistId, requests);
-        return ApiResponseUtil.success(SuccessMessage.CREATED, new AddSetListMusicResponse(count));
+        SetlistAddMusicResponse data = setlistFacade.addMusics(userId, setlistId, requests);
+        return ApiResponseUtil.success(SuccessMessage.CREATED, data);
     }
 
     @Permission(role = {Role.GENERAL})
@@ -80,7 +78,7 @@ public class SetlistController {
             @UserId(require = false) Long userId,
             @PathVariable Long setlistId
     ) {
-        GetSetlistDetailResponse data = setlistService.getSetlistDetail(userId, setlistId);
+        GetSetlistDetailResponse data = setlistFacade.getSetlistDetail(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
@@ -4,12 +4,12 @@ import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.setlist.facade.SetlistFacade;
 import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
-import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateDTO;
-import org.sopt.confeti.api.setlist.facade.dto.response.SetlistAddMusicResponse;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateRequestDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.SetlistAddMusicResponseDTO;
 import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.api.setlist.dto.response.GetSetlistDetailResponse;
-import org.sopt.confeti.api.setlist.facade.dto.response.SetlistCreateResponse;
-import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.api.setlist.facade.dto.response.SetlistCreateResponseDTO;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryResponse;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
@@ -47,7 +47,7 @@ public class SetlistController {
     public ResponseEntity<BaseResponse<?>> getPreviewMySetlists(
             @UserId(require = false) Long userId
     ) {
-        List<SetlistSummaryDto> data = setlistFacade.getPreviewMySetlists(userId);
+        List<SetlistSummaryResponse> data = setlistFacade.getPreviewMySetlists(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
     }
 
@@ -55,9 +55,9 @@ public class SetlistController {
     @PostMapping
     public ResponseEntity<BaseResponse<?>> createSetlists(
             @UserId(require = false) Long userId,
-            @RequestBody List<SetlistCreateDTO> requests
+            @RequestBody List<SetlistCreateRequestDTO> requests
     ) {
-        SetlistCreateResponse data = setlistFacade.createSetLists(userId, requests);
+        SetlistCreateResponseDTO data = setlistFacade.createSetLists(userId, requests);
         return ApiResponseUtil.success(SuccessMessage.CREATED, data);
     }
 
@@ -68,7 +68,7 @@ public class SetlistController {
             @PathVariable Long setlistId,
             @RequestBody List<SetlistAddMusicDTO> requests
     ) {
-        SetlistAddMusicResponse data = setlistFacade.addMusics(userId, setlistId, requests);
+        SetlistAddMusicResponseDTO data = setlistFacade.addMusics(userId, setlistId, requests);
         return ApiResponseUtil.success(SuccessMessage.CREATED, data);
     }
 

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistEditController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistEditController.java
@@ -2,8 +2,8 @@ package org.sopt.confeti.api.setlist.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
-import org.sopt.confeti.domain.setlist.application.SetlistEditService;
-import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicOrderUpdateRequest;
+import org.sopt.confeti.api.setlist.facade.SetlistFacade;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistUpdateMusicOrderDTO;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
@@ -22,14 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/my/setlists")
 public class SetlistEditController {
 
-    private final SetlistEditService setlistEditService;
+    private final SetlistFacade setlistFacade;
 
     @PostMapping("/{setlistId}/edit/start")
     public ResponseEntity<BaseResponse<?>> startEdit(
             @UserId(require = false) Long userId,
             @PathVariable Long setlistId
     ) {
-        setlistEditService.startEdit(userId, setlistId);
+        setlistFacade.startEdit(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.CREATED);
     }
 
@@ -37,9 +37,9 @@ public class SetlistEditController {
     public ResponseEntity<BaseResponse<?>> updateMusicOrder(
             @UserId(require = false) Long userId,
             @PathVariable Long setlistId,
-            @RequestBody List<SetlistMusicOrderUpdateRequest> request
+            @RequestBody List<SetlistUpdateMusicOrderDTO> request
     ) {
-        setlistEditService.updateMusicOrder(userId, setlistId, request);
+        setlistFacade.updateMusicOrder(userId, setlistId, request);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
@@ -49,7 +49,7 @@ public class SetlistEditController {
             @PathVariable Long setlistId,
             @PathVariable int orders
     ) {
-        String deleteTrackId = setlistEditService.deleteMusic(userId, setlistId, orders);
+        String deleteTrackId = setlistFacade.deleteMusic(userId, setlistId, orders);
         return ApiResponseUtil.success(SuccessMessage.DELETED, deleteTrackId);
     }
 
@@ -58,7 +58,7 @@ public class SetlistEditController {
             @UserId(require = false) Long userId,
             @PathVariable Long setlistId
     ) {
-        setlistEditService.completeEdit(userId, setlistId);
+        setlistFacade.completeEdit(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.UPDATED);
     }
 
@@ -67,7 +67,7 @@ public class SetlistEditController {
             @UserId(require = false) Long userId,
             @PathVariable Long setlistId
     ) {
-        setlistEditService.cancelEdit(userId, setlistId);
+        setlistFacade.cancelEdit(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/GetAllSetlistsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/GetAllSetlistsResponse.java
@@ -4,6 +4,6 @@ import java.util.List;
 
 public record GetAllSetlistsResponse(
         int totalCount,
-        List<SetlistSummaryDto> setlists
+        List<SetlistSummaryResponse> setlists
 ) {
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/GetAllSetlistsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/GetAllSetlistsResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.domain.setlist.application.dto.response;
+package org.sopt.confeti.api.setlist.dto.response;
 
 import java.util.List;
 

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/GetSetlistDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/GetSetlistDetailResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.domain.setlist.application.dto.response;
+package org.sopt.confeti.api.setlist.dto.response;
 
 import java.time.LocalDate;
 import java.util.List;
@@ -16,7 +16,7 @@ public record GetSetlistDetailResponse(
         String subTitle,
         LocalDate startAt,
         LocalDate endAt,
-        List<SetlistMusicResponseDto> musics
+        List<SetlistMusicResponse> musics
 ) {
     public static GetSetlistDetailResponse of(
             Setlist setlist,
@@ -25,7 +25,7 @@ public record GetSetlistDetailResponse(
             String posterPath,
             LocalDate startAt,
             LocalDate endAt,
-            List<SetlistMusicResponseDto> musics,
+            List<SetlistMusicResponse> musics,
             SetlistType type,
             S3FileHandler s3FileHandler
     ) {

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistMusicResponse.java
@@ -1,6 +1,6 @@
-package org.sopt.confeti.domain.setlist.application.dto.response;
+package org.sopt.confeti.api.setlist.dto.response;
 
-public record SetlistMusicResponseDto(
+public record SetlistMusicResponse(
         Long musicId,
         String trackId,
         String artistName,

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistMusicResponse.java
@@ -1,5 +1,7 @@
 package org.sopt.confeti.api.setlist.dto.response;
 
+import org.sopt.confeti.domain.setlist.SetlistMusic;
+
 public record SetlistMusicResponse(
         Long musicId,
         String trackId,
@@ -9,4 +11,15 @@ public record SetlistMusicResponse(
         String previewUrl,
         int orders
 ) {
+    public static SetlistMusicResponse create(SetlistMusic music) {
+        return new SetlistMusicResponse(
+                music.getId(),
+                music.getTrackId(),
+                music.getArtistName(),
+                music.getTrackName(),
+                music.getArtworkUrl(),
+                music.getPreviewUrl(),
+                music.getOrders()
+        );
+    }
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSummaryDto.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSummaryDto.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.domain.setlist.application.dto.response;
+package org.sopt.confeti.api.setlist.dto.response;
 
 import java.time.LocalDate;
 import org.sopt.confeti.domain.setlist.Setlist;

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSummaryResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSummaryResponse.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.api.setlist.dto.response;
 import java.time.LocalDate;
 import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistType;
+import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.util.S3FileHandler;
 
@@ -16,22 +17,21 @@ public record SetlistSummaryResponse(
 ) {
     public static SetlistSummaryResponse of(
             Setlist setlist,
-            String title,
-            String posterPath,
-            LocalDate endAt,
+            Performance performance,
             S3FileHandler s3FileHandler
-            ) {
-        String posterUrl =  s3FileHandler.getFileUrl(
+    ) {
+        String posterUrl = s3FileHandler.getFileUrl(
                 FolderPath.combine(
                         setlist.getType() == SetlistType.CONCERT ? FolderPath.CONCERT : FolderPath.FESTIVAL, FolderPath.POSTER
-                ), posterPath).toString();
+                ), performance.getPosterPath()).toString();
+
         return new SetlistSummaryResponse(
                 setlist.getId(),
                 setlist.getType().name(),
                 setlist.getTypeId(),
-                title,
+                performance.getTitle(),
                 posterUrl,
-                endAt
+                performance.getEndAt()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSummaryResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/SetlistSummaryResponse.java
@@ -6,7 +6,7 @@ import org.sopt.confeti.domain.setlist.SetlistType;
 import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.util.S3FileHandler;
 
-public record SetlistSummaryDto(
+public record SetlistSummaryResponse(
         Long setlistId,
         String type,
         Long typeId,
@@ -14,7 +14,7 @@ public record SetlistSummaryDto(
         String posterUrl,
         LocalDate endAt
 ) {
-    public static SetlistSummaryDto of(
+    public static SetlistSummaryResponse of(
             Setlist setlist,
             String title,
             String posterPath,
@@ -25,7 +25,7 @@ public record SetlistSummaryDto(
                 FolderPath.combine(
                         setlist.getType() == SetlistType.CONCERT ? FolderPath.CONCERT : FolderPath.FESTIVAL, FolderPath.POSTER
                 ), posterPath).toString();
-        return new SetlistSummaryDto(
+        return new SetlistSummaryResponse(
                 setlist.getId(),
                 setlist.getType().name(),
                 setlist.getTypeId(),

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistFacade.java
@@ -1,0 +1,65 @@
+package org.sopt.confeti.api.setlist.facade;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.setlist.SetlistSortType;
+import org.sopt.confeti.domain.setlist.application.SetlistEditService;
+import org.sopt.confeti.domain.setlist.application.SetlistService;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistUpdateMusicOrderDTO;
+import org.sopt.confeti.api.setlist.facade.dto.response.SetlistAddMusicResponse;
+import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.api.setlist.dto.response.GetSetlistDetailResponse;
+import org.sopt.confeti.api.setlist.facade.dto.response.SetlistCreateResponse;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.global.annotation.Facade;
+
+@Facade
+@RequiredArgsConstructor
+public class SetlistFacade {
+
+    private final SetlistService setlistService;
+    private final SetlistEditService setlistEditService;
+
+    public GetAllSetlistsResponse getAllMySetlists(Long userId, String sortBy) {
+        SetlistSortType sortType = SetlistSortType.from(sortBy);
+        return setlistService.getAllMySetlists(userId, sortType);
+    }
+
+    public List<SetlistSummaryDto> getPreviewMySetlists(Long userId) {
+        return setlistService.getPreviewMySetlists(userId);
+    }
+
+    public SetlistCreateResponse createSetLists(Long userId, List<SetlistCreateDTO> requests) {
+        return new SetlistCreateResponse(setlistService.createSetLists(userId, requests));
+    }
+
+    public SetlistAddMusicResponse addMusics(Long userId, Long setlistId, List<SetlistAddMusicDTO> requests) {
+        return new SetlistAddMusicResponse(setlistService.addMusics(userId, setlistId, requests));
+    }
+
+    public GetSetlistDetailResponse getSetlistDetail(Long userId, Long setlistId) {
+        return setlistService.getSetlistDetail(userId, setlistId);
+    }
+
+    public void startEdit(Long userId, Long setlistId) {
+        setlistEditService.startEdit(userId, setlistId);
+    }
+
+    public void updateMusicOrder(Long userId, Long setlistId, List<SetlistUpdateMusicOrderDTO> requests) {
+        setlistEditService.updateMusicOrder(userId, setlistId, requests);
+    }
+
+    public String deleteMusic(Long userId, Long setlistId, int orders) {
+        return setlistEditService.deleteMusic(userId, setlistId, orders);
+    }
+
+    public void completeEdit(Long userId, Long setlistId) {
+        setlistEditService.completeEdit(userId, setlistId);
+    }
+
+    public void cancelEdit(Long userId, Long setlistId) {
+        setlistEditService.cancelEdit(userId, setlistId);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistFacade.java
@@ -6,13 +6,13 @@ import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.application.SetlistEditService;
 import org.sopt.confeti.domain.setlist.application.SetlistService;
 import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
-import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateRequestDTO;
 import org.sopt.confeti.api.setlist.facade.dto.request.SetlistUpdateMusicOrderDTO;
-import org.sopt.confeti.api.setlist.facade.dto.response.SetlistAddMusicResponse;
+import org.sopt.confeti.api.setlist.facade.dto.response.SetlistAddMusicResponseDTO;
 import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.api.setlist.dto.response.GetSetlistDetailResponse;
-import org.sopt.confeti.api.setlist.facade.dto.response.SetlistCreateResponse;
-import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.api.setlist.facade.dto.response.SetlistCreateResponseDTO;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryResponse;
 import org.sopt.confeti.global.annotation.Facade;
 
 @Facade
@@ -27,16 +27,16 @@ public class SetlistFacade {
         return setlistService.getAllMySetlists(userId, sortType);
     }
 
-    public List<SetlistSummaryDto> getPreviewMySetlists(Long userId) {
+    public List<SetlistSummaryResponse> getPreviewMySetlists(Long userId) {
         return setlistService.getPreviewMySetlists(userId);
     }
 
-    public SetlistCreateResponse createSetLists(Long userId, List<SetlistCreateDTO> requests) {
-        return new SetlistCreateResponse(setlistService.createSetLists(userId, requests));
+    public SetlistCreateResponseDTO createSetLists(Long userId, List<SetlistCreateRequestDTO> requests) {
+        return new SetlistCreateResponseDTO(setlistService.createSetLists(userId, requests));
     }
 
-    public SetlistAddMusicResponse addMusics(Long userId, Long setlistId, List<SetlistAddMusicDTO> requests) {
-        return new SetlistAddMusicResponse(setlistService.addMusics(userId, setlistId, requests));
+    public SetlistAddMusicResponseDTO addMusics(Long userId, Long setlistId, List<SetlistAddMusicDTO> requests) {
+        return new SetlistAddMusicResponseDTO(setlistService.addMusics(userId, setlistId, requests));
     }
 
     public GetSetlistDetailResponse getSetlistDetail(Long userId, Long setlistId) {

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistFacade.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/SetlistFacade.java
@@ -13,7 +13,11 @@ import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.api.setlist.dto.response.GetSetlistDetailResponse;
 import org.sopt.confeti.api.setlist.facade.dto.response.SetlistCreateResponseDTO;
 import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryResponse;
+import org.sopt.confeti.domain.user.User;
+import org.sopt.confeti.domain.user.application.UserService;
 import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.exception.NotFoundException;
+import org.sopt.confeti.global.message.ErrorMessage;
 
 @Facade
 @RequiredArgsConstructor
@@ -21,6 +25,7 @@ public class SetlistFacade {
 
     private final SetlistService setlistService;
     private final SetlistEditService setlistEditService;
+    private final UserService userService;
 
     public GetAllSetlistsResponse getAllMySetlists(Long userId, String sortBy) {
         SetlistSortType sortType = SetlistSortType.from(sortBy);
@@ -32,7 +37,8 @@ public class SetlistFacade {
     }
 
     public SetlistCreateResponseDTO createSetLists(Long userId, List<SetlistCreateRequestDTO> requests) {
-        return new SetlistCreateResponseDTO(setlistService.createSetLists(userId, requests));
+        User user = userService.findById(userId);
+        return new SetlistCreateResponseDTO(setlistService.createSetLists(user, requests));
     }
 
     public SetlistAddMusicResponseDTO addMusics(Long userId, Long setlistId, List<SetlistAddMusicDTO> requests) {

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistAddMusicDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistAddMusicDTO.java
@@ -1,6 +1,6 @@
-package org.sopt.confeti.domain.setlist.application.dto.request;
+package org.sopt.confeti.api.setlist.facade.dto.request;
 
-public record AddSetListMusicRequest(
+public record SetlistAddMusicDTO(
         String trackId,
         String artistName,
         String trackName,

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistCreateDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistCreateDTO.java
@@ -1,8 +1,8 @@
-package org.sopt.confeti.domain.setlist.application.dto.request;
+package org.sopt.confeti.api.setlist.facade.dto.request;
 
 import org.sopt.confeti.domain.setlist.SetlistType;
 
-public record SetlistCreateRequest(
+public record SetlistCreateDTO(
         SetlistType type,
         Long typeId
 ) {

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistCreateRequestDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistCreateRequestDTO.java
@@ -2,7 +2,7 @@ package org.sopt.confeti.api.setlist.facade.dto.request;
 
 import org.sopt.confeti.domain.setlist.SetlistType;
 
-public record SetlistCreateDTO(
+public record SetlistCreateRequestDTO(
         SetlistType type,
         Long typeId
 ) {

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistMusicEditDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistMusicEditDTO.java
@@ -1,8 +1,8 @@
-package org.sopt.confeti.domain.setlist.application.dto.request;
+package org.sopt.confeti.api.setlist.facade.dto.request;
 
 import org.sopt.confeti.domain.setlist.SetlistMusic;
 
-public record SetlistMusicEditDto(
+public record SetlistMusicEditDTO(
         Long musicId,
         String trackId,
         String artistName,
@@ -11,8 +11,8 @@ public record SetlistMusicEditDto(
         String previewUrl,
         int orders
 ) {
-    public static SetlistMusicEditDto from(SetlistMusic music) {
-        return new SetlistMusicEditDto(
+    public static SetlistMusicEditDTO from(SetlistMusic music) {
+        return new SetlistMusicEditDTO(
                 music.getId(),
                 music.getTrackId(),
                 music.getArtistName(),

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistUpdateMusicOrderDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/request/SetlistUpdateMusicOrderDTO.java
@@ -1,0 +1,7 @@
+package org.sopt.confeti.api.setlist.facade.dto.request;
+
+public record SetlistUpdateMusicOrderDTO(
+        String trackId,
+        int orders
+) {
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SetlistAddMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SetlistAddMusicResponse.java
@@ -1,0 +1,6 @@
+package org.sopt.confeti.api.setlist.facade.dto.response;
+
+public record SetlistAddMusicResponse(
+        int addCount
+) {
+}

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SetlistAddMusicResponseDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SetlistAddMusicResponseDTO.java
@@ -1,6 +1,6 @@
 package org.sopt.confeti.api.setlist.facade.dto.response;
 
-public record SetlistAddMusicResponse(
+public record SetlistAddMusicResponseDTO(
         int addCount
 ) {
 }

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SetlistCreateResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SetlistCreateResponse.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.domain.setlist.application.dto.response;
+package org.sopt.confeti.api.setlist.facade.dto.response;
 
 import java.util.List;
 

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SetlistCreateResponseDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/SetlistCreateResponseDTO.java
@@ -2,7 +2,7 @@ package org.sopt.confeti.api.setlist.facade.dto.response;
 
 import java.util.List;
 
-public record SetlistCreateResponse(
+public record SetlistCreateResponseDTO(
         List<Long> setlistIds
 ) {
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/SetlistMusic.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/SetlistMusic.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.domain.setlist;
 
 import jakarta.persistence.*;
 import lombok.*;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
 
 @Entity
 @Table(name = "setlist_musics")
@@ -35,6 +36,17 @@ public class SetlistMusic {
 
     @Column(name = "orders", nullable = false)
     private int orders;
+
+    public static SetlistMusic of(SetlistAddMusicDTO dto, int order) {
+        return SetlistMusic.builder()
+                .trackId(dto.trackId())
+                .artistName(dto.artistName())
+                .trackName(dto.trackName())
+                .artworkUrl(dto.artworkUrl())
+                .previewUrl(dto.previewUrl())
+                .orders(order)
+                .build();
+    }
 
     @Builder
     public SetlistMusic(String trackId, String artistName, String trackName, String artworkUrl, String previewUrl, int orders) {

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistEditService.java
@@ -8,11 +8,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistMusic;
-import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicEditDto;
-import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicOrderUpdateRequest;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistMusicEditDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistUpdateMusicOrderDTO;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
@@ -36,42 +35,49 @@ public class SetlistEditService {
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
         List<SetlistMusic> musics = setlistMusicRepository.findBySetlist(setlist);
-        List<SetlistMusicEditDto> musicDtos = musics.stream()
-                .map(SetlistMusicEditDto::from)
+
+        List<SetlistMusicEditDTO> musicDtos = musics.stream()
+                .map(SetlistMusicEditDTO::from)
                 .toList();
 
         String redisKey = generateRedisKey(userId, setlistId);
+
+        Boolean existed = redisTemplate.hasKey(redisKey);
+        if (Boolean.TRUE.equals(existed)) {
+            redisTemplate.delete(redisKey);
+        }
+
         redisTemplate.opsForValue().set(redisKey, musicDtos);
     }
 
     @Transactional
-    public void updateMusicOrder(Long userId, Long setlistId, List<SetlistMusicOrderUpdateRequest> requests) {
+    public void updateMusicOrder(Long userId, Long setlistId, List<SetlistUpdateMusicOrderDTO> requests) {
         String key = generateRedisKey(userId, setlistId);
         Object raw = redisTemplate.opsForValue().get(key);
         if (raw == null) throw new NotFoundException(ErrorMessage.NOT_FOUND);
 
-        List<SetlistMusicEditDto> musics = objectMapper.convertValue(raw, new TypeReference<>() {});
+        List<SetlistMusicEditDTO> musics = objectMapper.convertValue(raw, new TypeReference<>() {});
         if (musics.isEmpty()) throw new NotFoundException(ErrorMessage.NOT_FOUND);
 
-        Map<String, SetlistMusicEditDto> musicMap = musics.stream()
-                .collect(Collectors.toMap(SetlistMusicEditDto::trackId, dto -> dto));
+        Map<String, SetlistMusicEditDTO> musicMap = musics.stream()
+                .collect(Collectors.toMap(SetlistMusicEditDTO::trackId, dto -> dto));
 
         if (requests.size() == 2) {
-            SetlistMusicEditDto a = musicMap.get(requests.get(0).trackId());
-            SetlistMusicEditDto b = musicMap.get(requests.get(1).trackId());
+            SetlistMusicEditDTO a = musicMap.get(requests.get(0).trackId());
+            SetlistMusicEditDTO b = musicMap.get(requests.get(1).trackId());
 
             if (a != null && b != null) {
                 int tmpOrder = a.orders();
-                a = new SetlistMusicEditDto(a.musicId(), a.trackId(), a.artistName(), a.trackName(), a.artworkUrl(), a.previewUrl(), b.orders());
-                b = new SetlistMusicEditDto(b.musicId(), b.trackId(), b.artistName(), b.trackName(), b.artworkUrl(), b.previewUrl(), tmpOrder);
+                a = new SetlistMusicEditDTO(a.musicId(), a.trackId(), a.artistName(), a.trackName(), a.artworkUrl(), a.previewUrl(), b.orders());
+                b = new SetlistMusicEditDTO(b.musicId(), b.trackId(), b.artistName(), b.trackName(), b.artworkUrl(), b.previewUrl(), tmpOrder);
 
                 musicMap.put(a.trackId(), a);
                 musicMap.put(b.trackId(), b);
             }
         }
 
-        List<SetlistMusicEditDto> updated = new ArrayList<>(musicMap.values()).stream()
-                .sorted(Comparator.comparing(SetlistMusicEditDto::orders))
+        List<SetlistMusicEditDTO> updated = new ArrayList<>(musicMap.values()).stream()
+                .sorted(Comparator.comparing(SetlistMusicEditDTO::orders))
                 .toList();
 
         redisTemplate.opsForValue().set(key, updated);
@@ -83,23 +89,23 @@ public class SetlistEditService {
         Object raw = redisTemplate.opsForValue().get(key);
         if(raw == null) throw new NotFoundException(ErrorMessage.NOT_FOUND);
 
-        List<SetlistMusicEditDto> musics = objectMapper.convertValue(raw, new TypeReference<>() {});
+        List<SetlistMusicEditDTO> musics = objectMapper.convertValue(raw, new TypeReference<>() {});
         if(musics.isEmpty()) throw new NotFoundException(ErrorMessage.NOT_FOUND);
 
-        SetlistMusicEditDto deleted = musics.stream()
+        SetlistMusicEditDTO deleted = musics.stream()
                 .filter(m -> m.orders() == orders)
                 .findFirst()
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
         musics = musics.stream()
                 .filter(m -> m.orders() != orders)
-                .sorted(Comparator.comparing(SetlistMusicEditDto::orders))
+                .sorted(Comparator.comparing(SetlistMusicEditDTO::orders))
                 .toList();
 
-        List<SetlistMusicEditDto> reordered = new ArrayList<>();
+        List<SetlistMusicEditDTO> reordered = new ArrayList<>();
         for (int i = 0; i < musics.size(); i++) {
-            SetlistMusicEditDto m = musics.get(i);
-            reordered.add(new SetlistMusicEditDto(
+            SetlistMusicEditDTO m = musics.get(i);
+            reordered.add(new SetlistMusicEditDTO(
                     m.musicId(), m.trackId(), m.artistName(), m.trackName(),
                     m.artworkUrl(), m.previewUrl(), i + 1
             ));
@@ -115,7 +121,7 @@ public class SetlistEditService {
         Object raw = redisTemplate.opsForValue().get(key);
         if (raw == null) throw new NotFoundException(ErrorMessage.NOT_FOUND);
 
-        List<SetlistMusicEditDto> edited = objectMapper.convertValue(raw, new TypeReference<>() {});
+        List<SetlistMusicEditDTO> edited = objectMapper.convertValue(raw, new TypeReference<>() {});
         if (edited.isEmpty()) throw new NotFoundException(ErrorMessage.NOT_FOUND);
 
         Setlist setlist = setlistRepository.findByIdAndUserId(setlistId, userId)
@@ -123,14 +129,14 @@ public class SetlistEditService {
 
         List<SetlistMusic> original = setlistMusicRepository.findBySetlist(setlist);
 
-        Map<Long, SetlistMusicEditDto> editedMap = edited.stream()
-                .collect(Collectors.toMap(SetlistMusicEditDto::musicId, dto -> dto));
+        Map<Long, SetlistMusicEditDTO> editedMap = edited.stream()
+                .collect(Collectors.toMap(SetlistMusicEditDTO::musicId, dto -> dto));
 
         List<SetlistMusic> toUpdate = new ArrayList<>();
         List<SetlistMusic> toDelete = new ArrayList<>();
 
         for (SetlistMusic music : original) {
-            SetlistMusicEditDto dto = editedMap.get(music.getId());
+            SetlistMusicEditDTO dto = editedMap.get(music.getId());
             if (dto != null) {
                 music.changeOrder(dto.orders());
                 toUpdate.add(music);

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -108,15 +108,7 @@ public class SetlistService {
         for (SetlistAddMusicDTO req : requests) {
             if(existingIds.contains(req.trackId())) continue;
 
-            SetlistMusic music = SetlistMusic.builder()
-                    .trackId(req.trackId())
-                    .artistName(req.artistName())
-                    .trackName(req.trackName())
-                    .artworkUrl(req.artworkUrl())
-                    .previewUrl(req.previewUrl())
-                    .orders(startOrder++)
-                    .build();
-
+            SetlistMusic music = SetlistMusic.of(req, startOrder++);
             setlist.addMusics(music);
             addedCount++;
         }

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -40,7 +40,6 @@ public class SetlistService {
     private final SetlistRepository setlistRepository;
     private final ConcertRepository concertRepository;
     private final FestivalRepository festivalRepository;
-    private final UserRepository userRepository;
     private final SetlistMusicRepository setlistMusicRepository;
     private final S3FileHandler s3FileHandler;
     private final PerformanceService performanceService;
@@ -122,10 +121,7 @@ public class SetlistService {
 
         List<SetlistMusicResponse> musics = setlistMusicRepository.findBySetlist(setlist).stream()
                 .sorted(Comparator.comparing(SetlistMusic::getOrders))
-                .map(m -> new SetlistMusicResponse(
-                        m.getId(), m.getTrackId(), m.getArtistName(),
-                        m.getTrackName(), m.getArtworkUrl(), m.getPreviewUrl(), m.getOrders()
-                ))
+                .map(SetlistMusicResponse::create)
                 .toList();
 
         if (setlist.getType() == SetlistType.CONCERT) {

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -13,11 +13,11 @@ import org.sopt.confeti.domain.setlist.SetlistMusic;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.SetlistType;
 import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
-import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateRequestDTO;
 import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
 import org.sopt.confeti.api.setlist.dto.response.GetSetlistDetailResponse;
 import org.sopt.confeti.api.setlist.dto.response.SetlistMusicResponse;
-import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryResponse;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.User;
@@ -45,18 +45,18 @@ public class SetlistService {
     public GetAllSetlistsResponse getAllMySetlists(Long userId, SetlistSortType sortType) {
         List<Setlist> setlists = setlistRepository.findAllByUserId(userId);
 
-        List<SetlistSummaryDto> dtoList = setlists.stream()
+        List<SetlistSummaryResponse> dtoList = setlists.stream()
                 .map(setlist -> {
                     if (setlist.getType() == SetlistType.CONCERT) {
                         Concert concert = concertRepository.findById(setlist.getTypeId())
                                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-                        return SetlistSummaryDto.of(
+                        return SetlistSummaryResponse.of(
                                 setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt(),
                                 s3FileHandler);
                     } else {
                         Festival festival = festivalRepository.findById(setlist.getTypeId())
                                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-                        return SetlistSummaryDto.of(
+                        return SetlistSummaryResponse.of(
                                 setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt(),
                                 s3FileHandler);
                     }
@@ -77,7 +77,7 @@ public class SetlistService {
     }
 
     @Transactional(readOnly = true)
-    public List<SetlistSummaryDto> getPreviewMySetlists(Long userId) {
+    public List<SetlistSummaryResponse> getPreviewMySetlists(Long userId) {
         List<Setlist> setlists = setlistRepository.findAllByUserId(userId);
 
         return setlists.stream()
@@ -85,24 +85,24 @@ public class SetlistService {
                     if (setlist.getType() == SetlistType.CONCERT) {
                         Concert concert = concertRepository.findById(setlist.getTypeId())
                                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-                        return SetlistSummaryDto.of(
+                        return SetlistSummaryResponse.of(
                                 setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt(),
                                 s3FileHandler);
                     } else {
                         Festival festival = festivalRepository.findById(setlist.getTypeId())
                                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-                        return SetlistSummaryDto.of(
+                        return SetlistSummaryResponse.of(
                                 setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt(),
                                 s3FileHandler);
                     }
                 })
-                .sorted(Comparator.comparing(SetlistSummaryDto::endAt))
+                .sorted(Comparator.comparing(SetlistSummaryResponse::endAt))
                 .limit(3)
                 .toList();
     }
 
     @Transactional
-    public List<Long> createSetLists(Long userId, List<SetlistCreateDTO> requests) {
+    public List<Long> createSetLists(Long userId, List<SetlistCreateRequestDTO> requests) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
         return requests.stream()

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -12,12 +12,12 @@ import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistMusic;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.SetlistType;
-import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRequest;
-import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
-import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
-import org.sopt.confeti.domain.setlist.application.dto.response.GetSetlistDetailResponse;
-import org.sopt.confeti.domain.setlist.application.dto.response.SetlistMusicResponseDto;
-import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateDTO;
+import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.api.setlist.dto.response.GetSetlistDetailResponse;
+import org.sopt.confeti.api.setlist.dto.response.SetlistMusicResponse;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryDto;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.User;
@@ -102,7 +102,7 @@ public class SetlistService {
     }
 
     @Transactional
-    public List<Long> createSetLists(Long userId, List<SetlistCreateRequest> requests) {
+    public List<Long> createSetLists(Long userId, List<SetlistCreateDTO> requests) {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
         return requests.stream()
@@ -118,7 +118,7 @@ public class SetlistService {
     }
 
     @Transactional
-    public int addMusics(Long userId, Long setlistId, List<AddSetListMusicRequest> requests) {
+    public int addMusics(Long userId, Long setlistId, List<SetlistAddMusicDTO> requests) {
         Setlist setlist = setlistRepository.findById(setlistId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
@@ -126,32 +126,39 @@ public class SetlistService {
             throw new UnauthorizedException(ErrorMessage.UNAUTHORIZED);
         }
 
-        int startOrder = setlist.getMusics().size() + 1;
+        List<String> existingIds = setlist.getMusics().stream()
+                .map(SetlistMusic::getTrackId)
+                .toList();
 
-        for (int i = 0; i < requests.size(); i++) {
-            AddSetListMusicRequest req = requests.get(i);
+        int startOrder = setlist.getMusics().size() + 1;
+        int addedCount = 0;
+
+        for (SetlistAddMusicDTO req : requests) {
+            if(existingIds.contains(req.trackId())) continue;
+
             SetlistMusic music = SetlistMusic.builder()
                     .trackId(req.trackId())
                     .artistName(req.artistName())
                     .trackName(req.trackName())
                     .artworkUrl(req.artworkUrl())
                     .previewUrl(req.previewUrl())
-                    .orders(startOrder + i)
+                    .orders(startOrder++)
                     .build();
 
             setlist.addMusics(music);
+            addedCount++;
         }
 
-        return requests.size();
+        return addedCount;
     }
 
     public GetSetlistDetailResponse getSetlistDetail(Long userId, Long setlistId) {
         Setlist setlist = setlistRepository.findByIdAndUserId(setlistId, userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
-        List<SetlistMusicResponseDto> musics = setlistMusicRepository.findBySetlist(setlist).stream()
+        List<SetlistMusicResponse> musics = setlistMusicRepository.findBySetlist(setlist).stream()
                 .sorted(Comparator.comparing(SetlistMusic::getOrders))
-                .map(m -> new SetlistMusicResponseDto(
+                .map(m -> new SetlistMusicResponse(
                         m.getId(), m.getTrackId(), m.getArtistName(),
                         m.getTrackName(), m.getArtworkUrl(), m.getPreviewUrl(), m.getOrders()
                 ))

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -80,11 +80,9 @@ public class SetlistService {
     }
 
     @Transactional
-    public List<Long> createSetLists(Long userId, List<SetlistCreateRequestDTO> requests) {
-        User user = userRepository.findById(userId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+    public List<Long> createSetLists(User user, List<SetlistCreateRequestDTO> requests) {
         return requests.stream()
-                .filter(req -> !setlistRepository.existsByUserIdAndTypeAndTypeId(userId, req.type(), req.typeId()))
+                .filter(req -> !setlistRepository.existsByUserIdAndTypeAndTypeId(user.getId(), req.type(), req.typeId()))
                 .map(req -> Setlist.builder()
                         .user(user)
                         .type(req.type())

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -45,6 +45,8 @@ public class SetlistService {
     private final S3FileHandler s3FileHandler;
     private final PerformanceService performanceService;
 
+    private static final int MAX_SETLIST_PREVIEW_COUNT = 3;
+
     @Transactional(readOnly = true)
     public GetAllSetlistsResponse getAllMySetlists(Long userId, SetlistSortType sortType) {
         List<Setlist> setlists = setlistRepository.findAllByUserId(userId);
@@ -73,7 +75,7 @@ public class SetlistService {
                     return SetlistSummaryResponse.of(setlist, performance, s3FileHandler);
                 })
                 .sorted(Comparator.comparing(SetlistSummaryResponse::endAt))
-                .limit(3)
+                .limit(MAX_SETLIST_PREVIEW_COUNT)
                 .toList();
     }
 

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -95,12 +95,8 @@ public class SetlistService {
 
     @Transactional
     public int addMusics(Long userId, Long setlistId, List<SetlistAddMusicDTO> requests) {
-        Setlist setlist = setlistRepository.findById(setlistId)
+        Setlist setlist = setlistRepository.findByIdAndUserId(userId, setlistId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-
-        if (!setlist.getUser().getId().equals(userId)) {
-            throw new UnauthorizedException(ErrorMessage.UNAUTHORIZED);
-        }
 
         List<String> existingIds = setlist.getMusics().stream()
                 .map(SetlistMusic::getTrackId)

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -22,6 +22,9 @@ import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user.infra.repository.UserRepository;
+import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
@@ -40,6 +43,7 @@ public class SetlistService {
     private final UserRepository userRepository;
     private final SetlistMusicRepository setlistMusicRepository;
     private final S3FileHandler s3FileHandler;
+    private final PerformanceService performanceService;
 
     @Transactional(readOnly = true)
     public GetAllSetlistsResponse getAllMySetlists(Long userId, SetlistSortType sortType) {
@@ -47,30 +51,12 @@ public class SetlistService {
 
         List<SetlistSummaryResponse> dtoList = setlists.stream()
                 .map(setlist -> {
-                    if (setlist.getType() == SetlistType.CONCERT) {
-                        Concert concert = concertRepository.findById(setlist.getTypeId())
-                                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-                        return SetlistSummaryResponse.of(
-                                setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt(),
-                                s3FileHandler);
-                    } else {
-                        Festival festival = festivalRepository.findById(setlist.getTypeId())
-                                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-                        return SetlistSummaryResponse.of(
-                                setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt(),
-                                s3FileHandler);
-                    }
+                    Performance performance = performanceService.getPerformanceByTypeAndTypeId(
+                            PerformanceType.valueOf(setlist.getType().name()), setlist.getTypeId());
+                    return SetlistSummaryResponse.of(setlist, performance, s3FileHandler);
                 })
-                .toList();
-
-        dtoList = dtoList.stream()
-                .sorted((a, b) -> {
-                    if (sortType == SetlistSortType.OLDEST) {
-                        return a.endAt().compareTo(b.endAt());
-                    } else {
-                        return b.endAt().compareTo(a.endAt());
-                    }
-                })
+                .sorted((a , b) -> sortType == SetlistSortType.OLDEST
+                        ? a.endAt().compareTo(b.endAt()) : b.endAt().compareTo(a.endAt()))
                 .toList();
 
         return new GetAllSetlistsResponse(dtoList.size(), dtoList);
@@ -82,19 +68,9 @@ public class SetlistService {
 
         return setlists.stream()
                 .map(setlist -> {
-                    if (setlist.getType() == SetlistType.CONCERT) {
-                        Concert concert = concertRepository.findById(setlist.getTypeId())
-                                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-                        return SetlistSummaryResponse.of(
-                                setlist, concert.getTitle(), concert.getPosterPath(), concert.getEndAt(),
-                                s3FileHandler);
-                    } else {
-                        Festival festival = festivalRepository.findById(setlist.getTypeId())
-                                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
-                        return SetlistSummaryResponse.of(
-                                setlist, festival.getTitle(), festival.getPosterPath(), festival.getEndAt(),
-                                s3FileHandler);
-                    }
+                    Performance performance = performanceService.getPerformanceByTypeAndTypeId(
+                            PerformanceType.valueOf(setlist.getType().name()), setlist.getTypeId());
+                    return SetlistSummaryResponse.of(setlist, performance, s3FileHandler);
                 })
                 .sorted(Comparator.comparing(SetlistSummaryResponse::endAt))
                 .limit(3)

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/SetlistMusicOrderUpdateRequest.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/request/SetlistMusicOrderUpdateRequest.java
@@ -1,7 +1,0 @@
-package org.sopt.confeti.domain.setlist.application.dto.request;
-
-public record SetlistMusicOrderUpdateRequest(
-        String trackId,
-        int orders
-) {
-}

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/AddSetListMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/dto/response/AddSetListMusicResponse.java
@@ -1,6 +1,0 @@
-package org.sopt.confeti.domain.setlist.application.dto.response;
-
-public record AddSetListMusicResponse(
-        int addCount
-) {
-}

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -197,6 +197,12 @@ public class PerformanceService {
                 .toList();
     }
 
+    @Transactional(readOnly = true)
+    public Performance getPerformanceByTypeAndTypeId(PerformanceType type, long typeId) {
+        return performanceRepository.findPerformanceByTypeAndTypeId(type, typeId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+    }
+
     private List<Pair<PerformanceType, Long>> convertToPairs(GetExpectedPerformancesDTO expectedPerformancesDTO) {
         return expectedPerformancesDTO.expectedPerformanceDTOs().stream()
                 .map(performanceDTO -> Pair.of(performanceDTO.type(), performanceDTO.typeId()))

--- a/src/main/java/org/sopt/confeti/global/config/RedisConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/RedisConfig.java
@@ -1,8 +1,6 @@
 package org.sopt.confeti.global.config;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.List;
-import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicEditDto;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistEditServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistEditServiceTest.java
@@ -18,8 +18,8 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistMusic;
 import org.sopt.confeti.domain.setlist.SetlistType;
-import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicEditDto;
-import org.sopt.confeti.domain.setlist.application.dto.request.SetlistMusicOrderUpdateRequest;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistMusicEditDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistUpdateMusicOrderDTO;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.OAuthProvider;
@@ -86,10 +86,10 @@ class SetlistEditServiceTest {
 
         // then
         String expectedKey = "edit:setlist:" + userId + ":" + setlistId;
-        ArgumentCaptor<List<SetlistMusicEditDto>> captor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<SetlistMusicEditDTO>> captor = ArgumentCaptor.forClass(List.class);
         verify(valueOperations).set(eq(expectedKey), captor.capture());
 
-        List<SetlistMusicEditDto> captured = captor.getValue();
+        List<SetlistMusicEditDTO> captured = captor.getValue();
         assertThat(captured).hasSize(1);
         assertThat(captured.get(0).trackId()).isEqualTo("203948575");
         assertThat(captured.get(0).trackName()).isEqualTo("Super Shy");
@@ -103,14 +103,14 @@ class SetlistEditServiceTest {
         Long setlistId = 100L;
         String redisKey = "edit:setlist:" + userId + ":" + setlistId;
 
-        List<SetlistMusicEditDto> originalList = List.of(
-                new SetlistMusicEditDto(1L, "track1", "Artist A", "Song A", "url1", "preview1", 1),
-                new SetlistMusicEditDto(2L, "track2", "Artist B", "Song B", "url2", "preview2", 2)
+        List<SetlistMusicEditDTO> originalList = List.of(
+                new SetlistMusicEditDTO(1L, "track1", "Artist A", "Song A", "url1", "preview1", 1),
+                new SetlistMusicEditDTO(2L, "track2", "Artist B", "Song B", "url2", "preview2", 2)
         );
 
-        List<SetlistMusicOrderUpdateRequest> requestList = List.of(
-                new SetlistMusicOrderUpdateRequest("track1", 1),
-                new SetlistMusicOrderUpdateRequest("track2", 2)
+        List<SetlistUpdateMusicOrderDTO> requestList = List.of(
+                new SetlistUpdateMusicOrderDTO("track1", 1),
+                new SetlistUpdateMusicOrderDTO("track2", 2)
         );
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
@@ -120,10 +120,10 @@ class SetlistEditServiceTest {
         setlistEditService.updateMusicOrder(userId, setlistId, requestList);
 
         // then
-        ArgumentCaptor<List<SetlistMusicEditDto>> captor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<SetlistMusicEditDTO>> captor = ArgumentCaptor.forClass(List.class);
         verify(valueOperations).set(eq(redisKey), captor.capture());
 
-        List<SetlistMusicEditDto> updated = captor.getValue();
+        List<SetlistMusicEditDTO> updated = captor.getValue();
 
         assertThat(updated).hasSize(2);
         assertThat(updated).anySatisfy(dto -> {
@@ -142,10 +142,10 @@ class SetlistEditServiceTest {
         Long setlistId = 100L;
         String redisKey = "edit:setlist:" + userId + ":" + setlistId;
 
-        List<SetlistMusicEditDto> originalList = List.of(
-                new SetlistMusicEditDto(1L, "track1", "Artist A", "Song A", "url1", "preview1", 1),
-                new SetlistMusicEditDto(2L, "track2", "Artist B", "Song B", "url2", "preview2", 2),
-                new SetlistMusicEditDto(3L, "track3", "Artist C", "Song C", "url3", "preview3", 3)
+        List<SetlistMusicEditDTO> originalList = List.of(
+                new SetlistMusicEditDTO(1L, "track1", "Artist A", "Song A", "url1", "preview1", 1),
+                new SetlistMusicEditDTO(2L, "track2", "Artist B", "Song B", "url2", "preview2", 2),
+                new SetlistMusicEditDTO(3L, "track3", "Artist C", "Song C", "url3", "preview3", 3)
         );
 
         given(redisTemplate.opsForValue()).willReturn(valueOperations);
@@ -157,13 +157,13 @@ class SetlistEditServiceTest {
         // then
         assertThat(deletedTrackId).isEqualTo("track2");
 
-        ArgumentCaptor<List<SetlistMusicEditDto>> captor = ArgumentCaptor.forClass(List.class);
+        ArgumentCaptor<List<SetlistMusicEditDTO>> captor = ArgumentCaptor.forClass(List.class);
         verify(valueOperations).set(eq(redisKey), captor.capture());
 
-        List<SetlistMusicEditDto> updated = captor.getValue();
+        List<SetlistMusicEditDTO> updated = captor.getValue();
         assertThat(updated).hasSize(2);
         assertThat(updated.get(0).orders()).isEqualTo(1);
         assertThat(updated.get(1).orders()).isEqualTo(2);
-        assertThat(updated).extracting(SetlistMusicEditDto::trackId).containsExactly("track1", "track3");
+        assertThat(updated).extracting(SetlistMusicEditDTO::trackId).containsExactly("track1", "track3");
     }
 }

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -24,10 +24,10 @@ import org.sopt.confeti.domain.setlist.Setlist;
 import org.sopt.confeti.domain.setlist.SetlistMusic;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.SetlistType;
-import org.sopt.confeti.domain.setlist.application.dto.request.AddSetListMusicRequest;
-import org.sopt.confeti.domain.setlist.application.dto.request.SetlistCreateRequest;
-import org.sopt.confeti.domain.setlist.application.dto.response.GetAllSetlistsResponse;
-import org.sopt.confeti.domain.setlist.application.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateDTO;
+import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryDto;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.OAuthProvider;
@@ -126,9 +126,9 @@ class SetlistServiceTest {
 
     @Test
     void 여러개의_공연을_셋리스트로_생성() {
-        SetlistCreateRequest request1 = new SetlistCreateRequest(SetlistType.CONCERT, 100L);
-        SetlistCreateRequest request2 = new SetlistCreateRequest(SetlistType.FESTIVAL, 200L);
-        List<SetlistCreateRequest> requests = List.of(request1, request2);
+        SetlistCreateDTO request1 = new SetlistCreateDTO(SetlistType.CONCERT, 100L);
+        SetlistCreateDTO request2 = new SetlistCreateDTO(SetlistType.FESTIVAL, 200L);
+        List<SetlistCreateDTO> requests = List.of(request1, request2);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
@@ -148,9 +148,9 @@ class SetlistServiceTest {
 
     @Test
     void 이미_생성된_셋리스트는_중복_생성되지_않는다() {
-        SetlistCreateRequest request1 = new SetlistCreateRequest(SetlistType.CONCERT, 100L);
-        SetlistCreateRequest request2 = new SetlistCreateRequest(SetlistType.FESTIVAL, 200L);
-        List<SetlistCreateRequest> requests = List.of(request1, request2);
+        SetlistCreateDTO request1 = new SetlistCreateDTO(SetlistType.CONCERT, 100L);
+        SetlistCreateDTO request2 = new SetlistCreateDTO(SetlistType.FESTIVAL, 200L);
+        List<SetlistCreateDTO> requests = List.of(request1, request2);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(setlistRepository.existsByUserIdAndTypeAndTypeId(userId, SetlistType.CONCERT, 100L)).willReturn(true);
@@ -177,9 +177,9 @@ class SetlistServiceTest {
 
         given(setlistRepository.findById(setlistId)).willReturn(Optional.of(setlist));
 
-        List<AddSetListMusicRequest> requests = List.of(
-                new AddSetListMusicRequest("01", "IU", "Love wins all", "url1", "preview1"),
-                new AddSetListMusicRequest("02", "NewJeans", "Hype Boy", "url2", "preview2")
+        List<SetlistAddMusicDTO> requests = List.of(
+                new SetlistAddMusicDTO("01", "IU", "Love wins all", "url1", "preview1"),
+                new SetlistAddMusicDTO("02", "NewJeans", "Hype Boy", "url2", "preview2")
         );
 
         int result = setlistService.addMusics(userId, setlistId, requests);

--- a/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
+++ b/src/test/java/org/sopt/confeti/domain/setlist/application/SetlistServiceTest.java
@@ -25,9 +25,9 @@ import org.sopt.confeti.domain.setlist.SetlistMusic;
 import org.sopt.confeti.domain.setlist.SetlistSortType;
 import org.sopt.confeti.domain.setlist.SetlistType;
 import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
-import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateDTO;
+import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateRequestDTO;
 import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
-import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryDto;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryResponse;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistMusicRepository;
 import org.sopt.confeti.domain.setlist.infra.repository.SetlistRepository;
 import org.sopt.confeti.domain.user.OAuthProvider;
@@ -79,7 +79,7 @@ class SetlistServiceTest {
         GetAllSetlistsResponse result = setlistService.getAllMySetlists(userId, SetlistSortType.OLDEST);
 
         assertThat(result.totalCount()).isEqualTo(2);
-        assertThat(result.setlists()).extracting(SetlistSummaryDto::title)
+        assertThat(result.setlists()).extracting(SetlistSummaryResponse::title)
                 .containsExactly("서울재즈페스티벌", "IU 콘서트");
     }
 
@@ -97,7 +97,7 @@ class SetlistServiceTest {
         GetAllSetlistsResponse result = setlistService.getAllMySetlists(userId, SetlistSortType.LATEST);
 
         assertThat(result.totalCount()).isEqualTo(2);
-        assertThat(result.setlists()).extracting(SetlistSummaryDto::title)
+        assertThat(result.setlists()).extracting(SetlistSummaryResponse::title)
                 .containsExactly("IU 콘서트", "서울재즈페스티벌");
     }
 
@@ -118,17 +118,17 @@ class SetlistServiceTest {
         given(concertRepository.findById(101L)).willReturn(Optional.of(mockConcert("C2", LocalDate.of(2024, 6, 1))));
         given(concertRepository.findById(102L)).willReturn(Optional.of(mockConcert("C3", LocalDate.of(2024, 7, 1))));
 
-        List<SetlistSummaryDto> result = setlistService.getPreviewMySetlists(userId);
+        List<SetlistSummaryResponse> result = setlistService.getPreviewMySetlists(userId);
 
         assertThat(result).hasSize(3);
-        assertThat(result).extracting(SetlistSummaryDto::title).containsExactly("F2", "F1", "C1");
+        assertThat(result).extracting(SetlistSummaryResponse::title).containsExactly("F2", "F1", "C1");
     }
 
     @Test
     void 여러개의_공연을_셋리스트로_생성() {
-        SetlistCreateDTO request1 = new SetlistCreateDTO(SetlistType.CONCERT, 100L);
-        SetlistCreateDTO request2 = new SetlistCreateDTO(SetlistType.FESTIVAL, 200L);
-        List<SetlistCreateDTO> requests = List.of(request1, request2);
+        SetlistCreateRequestDTO request1 = new SetlistCreateRequestDTO(SetlistType.CONCERT, 100L);
+        SetlistCreateRequestDTO request2 = new SetlistCreateRequestDTO(SetlistType.FESTIVAL, 200L);
+        List<SetlistCreateRequestDTO> requests = List.of(request1, request2);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
 
@@ -148,9 +148,9 @@ class SetlistServiceTest {
 
     @Test
     void 이미_생성된_셋리스트는_중복_생성되지_않는다() {
-        SetlistCreateDTO request1 = new SetlistCreateDTO(SetlistType.CONCERT, 100L);
-        SetlistCreateDTO request2 = new SetlistCreateDTO(SetlistType.FESTIVAL, 200L);
-        List<SetlistCreateDTO> requests = List.of(request1, request2);
+        SetlistCreateRequestDTO request1 = new SetlistCreateRequestDTO(SetlistType.CONCERT, 100L);
+        SetlistCreateRequestDTO request2 = new SetlistCreateRequestDTO(SetlistType.FESTIVAL, 200L);
+        List<SetlistCreateRequestDTO> requests = List.of(request1, request2);
 
         given(userRepository.findById(userId)).willReturn(Optional.of(user));
         given(setlistRepository.existsByUserIdAndTypeAndTypeId(userId, SetlistType.CONCERT, 100L)).willReturn(true);


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## ✨ Issue Number ✨
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #437 

## ✨ To-do ✨
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 셋리스트 관련 API 에 파서드 패턴을 도입
- [x] 편집 시작 전에 Redis에 기존 캐시가 존재하면 삭제하도록 수정
- [x] 곡을 추가할 때, 기존 셋리스트에 이미 있는 `trackId`가 요청으로 들어오면 무시하도록 수정
- [x] PR 템플릿 수정 -> 이전 PR 내용 추적 할 수 있도록 수정


## ✨ Description ✨  
<!-- 본인이 한 작업을 설명해주세요 -->
### 셋리스트 관련 API 에 파서드 패턴을 도입했어요!
- 셋리스트의 비즈니스 로직에 대한 분기처리를 파서드 계층을 통해 책임을 명확히 하고자 했습니다!
- 해당 프로젝트의 컨벤션에 맞게 `Controller `> `Facade` > `Service` 의 구조를 추가했습니다 :)
<img width="782" alt="image" src="https://github.com/user-attachments/assets/4b67ca1f-d2f4-4032-8d62-8e48f81c2107" />

### 편집 시작 전에 Redis에 기존 캐시가 존재하면 삭제하도록 수정
- 현재까지 문제는 발생하지 않았지만, 편집 시작 전 기존의 캐시가 만약 존재할 경우 셋리스트에 곡을 추가하거나 변경사항이 존재할 때, 에러가 발생할 여지가 있어요.
- 그래서 해당 엣지케이스에 대한 예외처리를 진행했어요! 
- 편집 시작 API를 호출하게 되면, 기존의 캐시 내용이 존재하는지 우선적으로 확인하고, 삭제한 이후 redis에 해당 DB정보를 복사하는 플로우입니다! :)

### 곡을 추가할 때, 기존 셋리스트에 이미 있는 `trackId`가 요청으로 들어오면 무시하도록 수정
- QA 사항 중, 현재 곡을 추가하면 셋리스트의 이미 있는 `trackId`여도 중복으로 추가되는 이슈가 있었어요.
- 그래서 해당 부분에 대한 유효성 검증로직을 추가해, 중복되는 `trackId`는 셋리스트의 곡으로 추가되지 않도록 하였습니다!!

### PR 템플릿 수정 -> 이전 PR 내용 추적 할 수 있도록 수정
- 오늘 회의에 나온 안건대로, 코드리뷰를 위해서 이전의 PR 내용을 추적할 수 있도록 PR 템플릿 내용을 수정했습니다 👍 
<img width="476" alt="image" src="https://github.com/user-attachments/assets/e0d42555-fc5c-4f46-b3cd-33116c554fcf" />

