### PR TITLE
 refactor [#445] 프로필 편집 API 로직 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserInfoController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserInfoController.java
@@ -14,7 +14,6 @@ import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-import org.springframework.web.multipart.MultipartFile;
 
 @RestController
 @RequiredArgsConstructor
@@ -37,7 +36,7 @@ public class UserInfoController {
     @PatchMapping
     public ResponseEntity<BaseResponse<?>> patchUserInfo(
             @UserId Long userId,
-            @ModelAttribute PatchUserInfoRequest patchUserInfoRequest
+            @RequestBody PatchUserInfoRequest patchUserInfoRequest
     ) {
         userInfoFacade.patchUserInfo(userId, patchUserInfoRequest);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);

--- a/src/main/java/org/sopt/confeti/api/user/dto/request/PatchUserInfoRequest.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/request/PatchUserInfoRequest.java
@@ -1,16 +1,10 @@
 package org.sopt.confeti.api.user.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotEmpty;
-import lombok.Getter;
-import lombok.Setter;
-import org.springframework.web.multipart.MultipartFile;
-
-@Getter
-@Setter
-public class PatchUserInfoRequest {
-    @NotBlank
-    private String name;
-    @NotEmpty
-    private MultipartFile profileFile;
+public record PatchUserInfoRequest(
+        String name,
+        String profileUrl
+        ) {
+    public static PatchUserInfoRequest from(PatchUserInfoRequest request) {
+        return new PatchUserInfoRequest(request.name(), request.profileUrl());
+    }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
@@ -14,7 +14,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class UserInfoFacade {
 
-    private static final int REQUIRED_NAME_LENGTH = 2;
+    private static final int MINIMUM_NAME_LENGTH = 2;
+    private static final int MAXIMUM_NAME_LENGTH = 10;
 
     private final UserService userService;
 
@@ -39,8 +40,14 @@ public class UserInfoFacade {
     }
 
     protected void validateUserInfoRequest(PatchUserInfoRequest patchUserInfoRequest) {
-        if ((patchUserInfoRequest.name() == null || patchUserInfoRequest.name().trim().length() < REQUIRED_NAME_LENGTH)
-                && patchUserInfoRequest.profileUrl() == null) {
+        if (patchUserInfoRequest.profileUrl() != null) return;
+
+        if (patchUserInfoRequest.name() == null) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
+
+        String trimmedName = patchUserInfoRequest.name().trim();
+        if (trimmedName.length() < MINIMUM_NAME_LENGTH || trimmedName.length() > MAXIMUM_NAME_LENGTH) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
     }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
@@ -37,7 +37,7 @@ public class UserInfoFacade {
     }
 
     protected void validateUserInfoRequest(PatchUserInfoRequest patchUserInfoRequest) {
-        if (patchUserInfoRequest.name() == null || patchUserInfoRequest.profileUrl() == null) {
+        if (patchUserInfoRequest.name() == null && patchUserInfoRequest.profileUrl() == null) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
     }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
@@ -22,7 +22,6 @@ public class UserInfoFacade {
         );
     }
 
-    @Transactional
     public void patchUserInfo(Long userId, PatchUserInfoRequest patchUserInfoRequest) {
         validateExistUser(userId);
         validateUserInfoRequest(patchUserInfoRequest);

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
@@ -30,14 +30,12 @@ public class UserInfoFacade {
         userService.patchUserInfo(userId, patchUserInfoRequest);
     }
 
-    @Transactional(readOnly = true)
     protected void validateExistUser(final long userId) {
         if (!userService.existsById(userId)) {
             throw new UnauthorizedException(ErrorMessage.UNAUTHORIZED);
         }
     }
 
-    @Transactional(readOnly = true)
     protected void validateUserInfoRequest(PatchUserInfoRequest patchUserInfoRequest) {
         if (  patchUserInfoRequest.getName() == null || patchUserInfoRequest.getProfileFile() == null) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
@@ -13,6 +13,9 @@ import org.springframework.transaction.annotation.Transactional;
 @Facade
 @RequiredArgsConstructor
 public class UserInfoFacade {
+
+    private static final int REQUIRED_NAME_LENGTH = 2;
+
     private final UserService userService;
 
     @Transactional
@@ -36,7 +39,8 @@ public class UserInfoFacade {
     }
 
     protected void validateUserInfoRequest(PatchUserInfoRequest patchUserInfoRequest) {
-        if (patchUserInfoRequest.name() == null && patchUserInfoRequest.profileUrl() == null) {
+        if ((patchUserInfoRequest.name() == null || patchUserInfoRequest.name().trim().length() < REQUIRED_NAME_LENGTH)
+                && patchUserInfoRequest.profileUrl() == null) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
     }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserInfoFacade.java
@@ -37,7 +37,7 @@ public class UserInfoFacade {
     }
 
     protected void validateUserInfoRequest(PatchUserInfoRequest patchUserInfoRequest) {
-        if (  patchUserInfoRequest.getName() == null || patchUserInfoRequest.getProfileFile() == null) {
+        if (patchUserInfoRequest.name() == null || patchUserInfoRequest.profileUrl() == null) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
     }

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
@@ -88,9 +88,17 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
-        String fileName = uploadProfile(patchUserInfoRequest.profileUrl());
-        user.setProfilePath(fileName);
-        user.setName(patchUserInfoRequest.name());
+        String name = patchUserInfoRequest.name();
+        String profileUrl = patchUserInfoRequest.profileUrl();
+
+        if (profileUrl != null) {
+            String fileName = uploadProfile(profileUrl);
+            user.setProfilePath(fileName);
+        }
+
+        if (name != null) {
+            user.setName(name);
+        }
     }
 
     public String uploadProfile(String profileImgUrl) {

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserService.java
@@ -88,10 +88,19 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
-        String profilePath = s3FileHandler.uploadFile(patchUserInfoRequest.getProfileFile(),
-                FolderPath.combine(FolderPath.USER, FolderPath.PROFILE));
-        user.setName(patchUserInfoRequest.getName());
-        user.setProfilePath(profilePath);
+        String fileName = uploadProfile(patchUserInfoRequest.profileUrl());
+        user.setProfilePath(fileName);
+        user.setName(patchUserInfoRequest.name());
+    }
+
+    public String uploadProfile(String profileImgUrl) {
+        Path profileImg = fileDownloader.downloadFile(profileImgUrl);
+        try {
+            return s3FileHandler.uploadFile(profileImg.toFile(),
+                    FolderPath.combine(FolderPath.USER, FolderPath.PROFILE));
+        } finally {
+            fileDownloader.deleteTempFile(profileImg);
+        }
     }
 
     @Transactional


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## 🔗 Issue Number
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #445

## 🔙 Previous PR
<!-- 이어지는 PR이라면 이전 PR 링크를 남겨주세요 (ex: #123) -->
- #311 

## 📌  To-do
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 프로필 편집 시 사진 MultipartFile -> String 형태로 변경
- [x] 불필요한 트랜잭션 삭제 및 트랜잭션 계층 이동
- [x] 요청값으로 이름, 사진 url 중 하나만 보낼 수 있도록 수정


## ✨Description 
<!-- 본인이 한 작업을 설명해주세요 -->

## 프로필 편집 시 사진 MultipartFile -> String 형태로 변경
기존에는 프로필 사진을 MultipartFile 형태로 처리했으나, 클라이언트 요청에 따라 문자열(String) 형태의 URL로 수정하였습니다.

## 불필요한 트랜잭션 삭제 및 트랜잭션 계층 이동
클래스 내부에서 메서드를 직접 호출할 경우 트랜잭션이 정상적으로 적용되지 않는 문제를 반영하여 불필요한 트랜잭션을 제거하였습니다.

또한, 기존에 Facade 계층에 위치하던 트랜잭션을 Service 계층으로 이동하였습니다.
이는 트랜잭션이 상태 변경을 전제로 하며, 도메인 비즈니스 로직이 집중된 Service 계층에서 관리하는 것이 SRP 관점에서 더 적절하다고 판단했기 때문입니다.


## 요청값으로 이름, 사진 url 중 하나만 보낼 수 있도록 수정
기존 로직은 사진이 변경되지 않아도 클라이언트로부터 항상 파일을 입력받고, S3 Bucket에 중복 업로드되는 비효율적인 처리 방식이었습니다.
이를 개선하여 변경된 값(이름 또는 사진 URL)만 전달받도록 수정해 사진이 실제로 변경된 경우에만 업로드가 이루어지도록 로직을 개선하였습니다.

## 기존 프로필 조회 시 

<img width="1113" alt="스크린샷 2025-05-30 오전 1 53 13" src="https://github.com/user-attachments/assets/0a7ceac4-d87f-420e-8f4c-06d289c2ee44" />

## 프로필 편집 

<img width="1069" alt="스크린샷 2025-05-30 오전 1 54 24" src="https://github.com/user-attachments/assets/a3174c4f-d638-481d-8d2e-82706186a3c5" />

## 새로운 프로필 조회 시 

<img width="1082" alt="스크린샷 2025-05-30 오전 1 54 14" src="https://github.com/user-attachments/assets/8f970aff-1e08-4946-957e-0ec3f50726d9" />
