### PR TITLE
fix [#461] 셋리스트 곡 검색 API에서 조회 결과가 없을 경우 빈 리스트 반환

### DIFF
--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -631,6 +631,10 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
     }
 
     private MusicPage convertToConfetiMusicPage(AppleMusicArtistMusicsResponse artistMusics) {
+        if (Objects.isNull(artistMusics.data())) {
+            return MusicPage.empty();
+        }
+        
         return MusicPage.of(
                 artistMusics.next(),
                 artistMusics.data().stream()
@@ -686,6 +690,10 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
     }
 
     private MusicPage convertToConfetiMusicPage(AppleMusicSearchResponse searchResult) {
+        if (Objects.isNull(searchResult.results().songs())) {
+            return MusicPage.empty();
+        }
+
         AppleMusicMusicsResponse musics = searchResult.results().songs();
 
         return MusicPage.of(

--- a/src/main/java/org/sopt/confeti/global/util/music/dto/music/MusicPage.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/dto/music/MusicPage.java
@@ -37,4 +37,8 @@ public class MusicPage {
 
         return new MusicPage(nextOffset, isLast, musics);
     }
+
+    public static MusicPage empty() {
+        return new MusicPage(DEFAULT_NEXT_OFFSET, true, List.of());
+    }
 }


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## 🔗 Issue Number
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #461 

## 🔙 Previous PR
<!-- 이어지는 PR이라면 이전 PR 링크를 남겨주세요 (ex: #123) -->
- #(이전 PR 번호)

## 📌  To-do
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 곡 검색에서 Apple Music의 응답 값이 없을 때 빈 리스트 반환


## ✨Description 
<!-- 본인이 한 작업을 설명해주세요 -->
![image](https://github.com/user-attachments/assets/6faf210c-5228-4136-9f60-15f631857363)

응답 값이 `Null` 인지 체크해 `빈 MusicPage`를 반환했습니다.
