### PR TITLE
fix [#463] 홈 통합 검색 API - 검색어로 검색 시 아티스트 검색 결과가 404 에러로 처리되지 않도록 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/api/search/facade/SearchFacade.java
+++ b/src/main/java/org/sopt/confeti/api/search/facade/SearchFacade.java
@@ -4,6 +4,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -92,22 +93,22 @@ public class SearchFacade {
         // 검색어 저장 추가
         PerformanceSearchTermAnalyzeResult analyzeResult = SearchTermAnalyzer.analyzePerformance(term);
 
-        ConfetiArtist artist = musicAPIHandler.findArtistByKeyword(analyzeResult.processedTerm())
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
-                );
+        Optional<ConfetiArtist> artist = musicAPIHandler.findArtistByKeyword(analyzeResult.processedTerm());
         boolean artistFavorite = false;
 
-        if (Objects.nonNull(userId)) {
-            artistFavorite = artistFavoriteService.isFavorite(userId, artist.getId());
+        if (Objects.nonNull(userId) && artist.isPresent()) {
+            artistFavorite = artistFavoriteService.isFavorite(userId, artist.get().getId());
         }
 
         // 공연은 아티스트 + 검색어 기반
         Set<PerformanceDTO> performances = new HashSet<>();
 
         // 아티스트 기반
-        performances.addAll(
-                performanceService.getPerformancesByArtistIdAndType(artist.getId(), analyzeResult.performanceType()));
+        artist.ifPresent(confetiArtist -> performances.addAll(
+                        performanceService.getPerformancesByArtistIdAndType(confetiArtist.getId(),
+                                analyzeResult.performanceType())
+                )
+        );
 
         // 검색어 기반
         List<PerformanceDTO> searchedPerformances = performanceSearchService.getExpectedPerformancesByTitleAndTypePartialMatched(
@@ -128,7 +129,8 @@ public class SearchFacade {
             getPerformanceFavorites(performanceFavorites, favoritePerformances);
         }
 
-        return SearchResultDTO.of(artist, artistFavorite, performances.stream().toList(), performanceFavorites);
+        return SearchResultDTO.of(artist.orElse(null), artistFavorite, performances.stream().toList(),
+                performanceFavorites);
     }
 
     public PopularTermsDTO getPopularSearchTerms(int limit) {

--- a/src/main/java/org/sopt/confeti/api/search/facade/dto/response/SearchResultDTO.java
+++ b/src/main/java/org/sopt/confeti/api/search/facade/dto/response/SearchResultDTO.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.api.search.facade.dto.response;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 
@@ -11,8 +12,13 @@ public record SearchResultDTO(
 ) {
     public static SearchResultDTO of(ConfetiArtist artist, boolean artistFavorite, List<PerformanceDTO> performances,
                                      Map<Long, Boolean> performanceFavorites) {
+        SearchResultArtistDTO artistDTO = null;
+        if (Objects.nonNull(artist)) {
+            artistDTO = SearchResultArtistDTO.of(artist, artistFavorite);
+        }
+
         return new SearchResultDTO(
-                SearchResultArtistDTO.of(artist, artistFavorite),
+                artistDTO,
                 performances.stream()
                         .map(performance -> SearchResultPerformanceDTO.of(performance,
                                 performanceFavorites.get(performance.id())))


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## 🔗 Issue Number
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #463 

## 🔙 Previous PR
<!-- 이어지는 PR이라면 이전 PR 링크를 남겨주세요 (ex: #123) -->
- #(이전 PR 번호)

## 📌  To-do
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 홈 통합 검색 API에서 검색어로 검색 시 아티스트 검색 결과가 404 에러로 처리되지 않도록 변경


## ✨Description 
<!-- 본인이 한 작업을 설명해주세요 -->
![image](https://github.com/user-attachments/assets/73985343-bf2f-4e39-8ece-f184e37e53a1)

아티스트를 `Optional`로 조회 후 값의 존재 여부에 따라 처리하도록 수정했습니다!
