### PR TITLE
refactor [#465] 음악 제목 변수 네이밍 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecommendMusicResponse.java
@@ -5,7 +5,7 @@ import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicDTO;
 public record RecommendMusicResponse(
         String musicId,
         String artistName,
-        String title,
+        String trackName,
         String artworkUrl,
         String previewUrl
 ) {
@@ -13,7 +13,7 @@ public record RecommendMusicResponse(
         return new RecommendMusicResponse(
                 recommendMusicDTO.id(),
                 recommendMusicDTO.artistName(),
-                recommendMusicDTO.title(),
+                recommendMusicDTO.trackName(),
                 recommendMusicDTO.artworkUrl(),
                 recommendMusicDTO.previewUrl()
         );

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecommendMusicDTO.java
@@ -5,7 +5,7 @@ import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 public record RecommendMusicDTO(
         String id,
         String artistName,
-        String title,
+        String trackName,
         String artworkUrl,
         String previewUrl
 ) {
@@ -13,7 +13,7 @@ public record RecommendMusicDTO(
         return new RecommendMusicDTO(
                 music.getId(),
                 music.getArtistName(),
-                music.getTitle(),
+                music.getTrackName(),
                 music.getArtworkUrl(),
                 music.getPreviewUrl()
         );

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchArtistMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchArtistMusicResponse.java
@@ -4,7 +4,7 @@ import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchArti
 
 public record SetlistSearchArtistMusicResponse(
         String musicId,
-        String title,
+        String trackName,
         String artistName,
         String artworkUrl,
         String previewUrl
@@ -12,7 +12,7 @@ public record SetlistSearchArtistMusicResponse(
     public static SetlistSearchArtistMusicResponse from(SetlistSearchArtistMusicDTO artistMusic) {
         return new SetlistSearchArtistMusicResponse(
                 artistMusic.id(),
-                artistMusic.title(),
+                artistMusic.trackName(),
                 artistMusic.artistName(),
                 artistMusic.artworkUrl(),
                 artistMusic.previewUrl()

--- a/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchMusicResponse.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/dto/response/search/SetlistSearchMusicResponse.java
@@ -4,7 +4,7 @@ import org.sopt.confeti.api.setlist.facade.dto.response.search.SetlistSearchMusi
 
 public record SetlistSearchMusicResponse(
         String musicId,
-        String title,
+        String trackName,
         String artistName,
         String artworkUrl,
         String previewUrl
@@ -12,7 +12,7 @@ public record SetlistSearchMusicResponse(
     public static SetlistSearchMusicResponse from(SetlistSearchMusicDTO artistMusic) {
         return new SetlistSearchMusicResponse(
                 artistMusic.id(),
-                artistMusic.title(),
+                artistMusic.trackName(),
                 artistMusic.artistName(),
                 artistMusic.artworkUrl(),
                 artistMusic.previewUrl()

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchArtistMusicDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchArtistMusicDTO.java
@@ -4,7 +4,7 @@ import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 
 public record SetlistSearchArtistMusicDTO(
         String id,
-        String title,
+        String trackName,
         String artistName,
         String artworkUrl,
         String previewUrl
@@ -12,7 +12,7 @@ public record SetlistSearchArtistMusicDTO(
     public static SetlistSearchArtistMusicDTO from(ConfetiMusic music) {
         return new SetlistSearchArtistMusicDTO(
                 music.getId(),
-                music.getTitle(),
+                music.getTrackName(),
                 music.getArtistName(),
                 music.getArtworkUrl(),
                 music.getPreviewUrl()

--- a/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchMusicDTO.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/facade/dto/response/search/SetlistSearchMusicDTO.java
@@ -4,7 +4,7 @@ import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 
 public record SetlistSearchMusicDTO(
         String id,
-        String title,
+        String trackName,
         String artistName,
         String artworkUrl,
         String previewUrl
@@ -12,7 +12,7 @@ public record SetlistSearchMusicDTO(
     public static SetlistSearchMusicDTO from(ConfetiMusic music) {
         return new SetlistSearchMusicDTO(
                 music.getId(),
-                music.getTitle(),
+                music.getTrackName(),
                 music.getArtistName(),
                 music.getArtworkUrl(),
                 music.getPreviewUrl()

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/music/MusicResolver.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/music/MusicResolver.java
@@ -85,7 +85,7 @@ public class MusicResolver extends AbstractMusicAPISpecificResolver {
             while (!mappedConfetiMusics.isEmpty()) {
                 ConfetiMusic mappedConfetiMusic = mappedConfetiMusics.poll();
 
-                mappedConfetiMusic.setTitle(confetiMusic.getTitle());
+                mappedConfetiMusic.setTrackName(confetiMusic.getTrackName());
                 mappedConfetiMusic.setArtworkUrl(confetiMusic.getArtworkUrl());
                 mappedConfetiMusic.setArtistName(confetiMusic.getArtistName());
                 mappedConfetiMusic.setPreviewUrl(confetiMusic.getPreviewUrl());

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusic.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/music/vo/ConfetiMusic.java
@@ -27,7 +27,7 @@ public class ConfetiMusic {
 
     @Setter
     @Transient
-    private String title;
+    private String trackName;
 
     @Setter
     @Transient


### PR DESCRIPTION
- title -> trackName

<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## 🔗 Issue Number
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #465 

## 🔙 Previous PR
<!-- 이어지는 PR이라면 이전 PR 링크를 남겨주세요 (ex: #123) -->
- #(이전 PR 번호)

## 📌  To-do
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 음악 제목 변수 네이밍 변경


## ✨Description 
<!-- 본인이 한 작업을 설명해주세요 -->
Apple Music API에서 넘어오는 음악의 제목 변수명을 통합하기 위해서 기존에 사용하던 네이밍을 변경했어요.
`title` -> `trackName`

<img width="405" alt="image" src="https://github.com/user-attachments/assets/9d3c5eaa-af39-43d4-bd34-663c47057b1a" />

변경된 API는 아래와 같습니다.

[ MY 셋리스트 > 아티스트 곡 검색 API ]
![image](https://github.com/user-attachments/assets/891085a6-da5b-46af-9baf-c3d477733001)


[ MY 셋리스트 > 곡 검색 API ]
![image](https://github.com/user-attachments/assets/dea9a874-7885-49cd-90ed-b4f539021fa6)


[ 선호 공연 출연하는 아티스트의 음악 조회 API ]
![image](https://github.com/user-attachments/assets/b175b56d-9cfb-420b-9a72-388a8a495a8e)
