### PR TITLE
refactor [#451] 2차 스프린트 기간 코드리뷰 사항 반영

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ build/
 !**/src/main/**/build/
 !**/src/test/**/build/
 application*.yml
-**/src/main/resources/static/swagger-ui/openapi3.yaml
+src/main/resources/static/swagger-ui/openapi3.yaml
 
 ### STS ###
 .apt_generated

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -3,9 +3,8 @@ package org.sopt.confeti.api.performance.controller;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+
+import java.util.*;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.dto.request.GetExpectedPerformanceRequest;
@@ -146,12 +145,14 @@ public class PerformanceController {
     public ResponseEntity<BaseResponse<?>> getRecommendPerformanceId(
             @UserId(require = false) Long userId
     ) {
-        if (Objects.isNull(userId)) {
-            return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                    RecommendMusicsPerformanceResponse.from(performanceFacade.getRecommendPerformanceIdByRand()));
-        }
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                RecommendMusicsPerformanceResponse.from(performanceFacade.getRecommendPerformanceIdByUserId(userId)));
+        Optional<RecommendMusicsPerformanceDTO> performanceDto = Objects.isNull(userId)
+                ? performanceFacade.getRecommendPerformanceIdByRand()
+                : performanceFacade.getRecommendPerformanceIdByUserId(userId);
+
+        return performanceDto
+                .map(performance ->
+                        ApiResponseUtil.success(SuccessMessage.SUCCESS, RecommendMusicsPerformanceResponse.from(performance)))
+                .orElseGet(()-> ApiResponseUtil.success(SuccessMessage.SUCCESS, Collections.emptyMap()));
     }
 
     @Permission(role = {Role.GENERAL})

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
+
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.dto.request.GetExpectedPerformanceRequest;
 import org.sopt.confeti.api.performance.dto.response.ArtistPerformancesResponse;
@@ -144,9 +146,12 @@ public class PerformanceController {
     public ResponseEntity<BaseResponse<?>> getRecommendPerformanceId(
             @UserId(require = false) Long userId
     ) {
-        RecommendMusicsPerformanceDTO recommendMusicsDTO = performanceFacade.getRecommendPerformanceId(userId);
+        if (Objects.isNull(userId)) {
+            return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                    RecommendMusicsPerformanceResponse.from(performanceFacade.getRecommendPerformanceIdByRand()));
+        }
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                RecommendMusicsPerformanceResponse.from(recommendMusicsDTO));
+                RecommendMusicsPerformanceResponse.from(performanceFacade.getRecommendPerformanceIdByUserId(userId)));
     }
 
     @Permission(role = {Role.GENERAL})

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -3,9 +3,11 @@ package org.sopt.confeti.api.performance.controller;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
-
-import java.util.*;
-
+import java.util.List;
+import java.util.Optional;
+import java.util.Arrays;
+import java.util.Objects;
+import java.util.Collections;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.dto.request.GetExpectedPerformanceRequest;
 import org.sopt.confeti.api.performance.dto.response.ArtistPerformancesResponse;

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -256,12 +256,14 @@ public class PerformanceFacade {
         );
     }
 
-    public RecommendMusicsPerformanceDTO getRecommendPerformanceIdByRand() {
-        return RecommendMusicsPerformanceDTO.from(performanceService.getPerformanceByRand());
+    public Optional<RecommendMusicsPerformanceDTO> getRecommendPerformanceIdByRand() {
+        return performanceService.getPerformanceByRand()
+                .map(RecommendMusicsPerformanceDTO::from);
     }
 
-    public RecommendMusicsPerformanceDTO getRecommendPerformanceIdByUserId(final Long userId) {
-        return RecommendMusicsPerformanceDTO.from(performanceService.getPerformanceByUserFavorites(userId));
+    public Optional<RecommendMusicsPerformanceDTO> getRecommendPerformanceIdByUserId(final Long userId) {
+        return performanceService.getPerformanceByUserFavorites(userId)
+                .map(RecommendMusicsPerformanceDTO::from);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -1,7 +1,15 @@
 package org.sopt.confeti.api.performance.facade;
 
 import java.time.LocalDate;
-import java.util.*;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Arrays;
+import java.util.ArrayList;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -274,8 +282,10 @@ public class PerformanceFacade {
         Set<String> selectedArtistIds = selectRandomArtistIds(performance);
         Set<String> existingMusicIds = (musicIds == null || musicIds.isEmpty())
                 ? Collections.emptySet()
-                : musicIds.stream().flatMap(ids -> Arrays.stream(ids.split(",")))
-                        .map(String::trim).collect(Collectors.toSet());
+                : musicIds.stream()
+                    .flatMap(ids -> Arrays.stream(ids.split(",")))
+                    .map(String::trim)
+                    .collect(Collectors.toSet());
 
         List<String> artistIdList = new ArrayList<>(selectedArtistIds);
         List<ConfetiMusic> recommendMusics = recommendMusicsByArtistCount(artistIdList, existingMusicIds);

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -54,6 +54,8 @@ public class PerformanceFacade {
 
     private static final int RECENT_PERFORMANCES_SIZE = 7;
     private static final int RECOMMEND_MUSIC_SIZE = 3;
+    private static final int MUSIC_FETCH_SIZE = 5;
+    private static final int SELECTED_ARTISTS_SIZE = 3;
     private static final boolean PERSONALIZED = true;
     private static final boolean UNPERSONALIZED = false;
 
@@ -262,24 +264,10 @@ public class PerformanceFacade {
         return RecommendMusicsPerformanceDTO.from(performanceService.getPerformanceByUserFavorites(userId));
     }
 
-    protected Set<String> setArtistsByRandom(Performance performance) {
-        List<PerformanceArtist> performanceArtists = performance.getArtists();
-
-        if (performanceArtists.isEmpty()) {
-            return Collections.emptySet();
-        }
-
-        List<String> artistList = performanceArtists.stream()
-                .map(PerformanceArtist::getArtistId).distinct().collect(Collectors.toList());
-        Collections.shuffle(artistList);
-
-        int artistCount = Math.min(artistList.size(), 3);
-        return new HashSet<>(artistList.subList(0, artistCount));
-    }
-
+    @Transactional(readOnly = true)
     public RecommendMusicsDTO getNewRecommendMusics(long performanceId, List<String> musicIds) {
         Performance performance = performanceService.getPerformanceById(performanceId);
-        Set<String> selectedArtistIds = setArtistsByRandom(performance);
+        Set<String> selectedArtistIds = selectRandomArtistIds(performance);
         Set<String> existingMusicIds = (musicIds == null || musicIds.isEmpty())
                 ? Collections.emptySet()
                 : musicIds.stream().flatMap(ids -> Arrays.stream(ids.split(",")))
@@ -291,38 +279,45 @@ public class PerformanceFacade {
         return RecommendMusicsDTO.from(recommendMusics);
     }
 
+    protected Set<String> selectRandomArtistIds(Performance performance) {
+        List<PerformanceArtist> performanceArtists = performance.getArtists();
+
+        if (performanceArtists.isEmpty()) {
+            return Collections.emptySet();
+        }
+
+        List<String> artistList = performanceArtists.stream()
+                .map(PerformanceArtist::getArtistId).distinct().collect(Collectors.toList());
+        Collections.shuffle(artistList);
+
+        int artistCount = Math.min(artistList.size(), SELECTED_ARTISTS_SIZE);
+        return new HashSet<>(artistList.subList(0, artistCount));
+    }
+
     private List<ConfetiMusic> recommendMusicsByArtistCount(List<String> artistIdList, Set<String> existingMusicIds) {
-        int artistCount = artistIdList.size();
-        if (artistCount == 1) {
-            return recommendForSingleArtist(artistIdList, existingMusicIds);
-        }
-        if (artistCount == 2) {
-            return recommendForTwoArtists(artistIdList, existingMusicIds);
-        }
-        return recommendForMultipleArtists(artistIdList, existingMusicIds);
-    }
-
-    private List<ConfetiMusic> recommendForSingleArtist(List<String> artistIdList, Set<String> existingMusicIds) {
-        return musicAPIHandler.getFilteredTopSongsByArtist(
-                artistIdList.getFirst(), RECOMMEND_MUSIC_SIZE, existingMusicIds
-        );
-    }
-
-    private List<ConfetiMusic> recommendForTwoArtists(List<String> artistIdList, Set<String> existingMusicIds) {
         List<ConfetiMusic> musics = new ArrayList<>();
-        musics.addAll(musicAPIHandler.getFilteredTopSongsByArtist(artistIdList.getFirst(), 2, existingMusicIds));
-        musics.addAll(musicAPIHandler.getFilteredTopSongsByArtist(artistIdList.getLast(), 1, existingMusicIds));
-        return musics;
-    }
+        Set<String> seenMusicIds = new HashSet<>(existingMusicIds);
+        int round = 0;
 
-    private List<ConfetiMusic> recommendForMultipleArtists(List<String> artistIdList, Set<String> existingMusicIds) {
-        List<ConfetiMusic> musics = new ArrayList<>();
-        for (String artistId : artistIdList) {
-            if (musics.size() >= RECOMMEND_MUSIC_SIZE) {
-                break;
+        while (musics.size() < RECOMMEND_MUSIC_SIZE && round < MUSIC_FETCH_SIZE) {
+            for (String artistId : artistIdList) {
+                if (musics.size() >= RECOMMEND_MUSIC_SIZE) break;
+
+                List<ConfetiMusic> topSongs = musicAPIHandler.getFilteredTopSongsByArtist(
+                        artistId, MUSIC_FETCH_SIZE, seenMusicIds
+                );
+
+                if (round < topSongs.size()) {
+                    ConfetiMusic song = topSongs.get(round);
+                    if (!seenMusicIds.contains(song.getId())) {
+                        musics.add(song);
+                        seenMusicIds.add(song.getId());
+                    }
+                }
             }
-            musics.addAll(musicAPIHandler.getFilteredTopSongsByArtist(artistId, 1, existingMusicIds));
+            round++;
         }
+
         return musics;
     }
 

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -1,14 +1,7 @@
 package org.sopt.confeti.api.performance.facade;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -261,15 +254,12 @@ public class PerformanceFacade {
         );
     }
 
-    @Transactional(readOnly = true)
-    public RecommendMusicsPerformanceDTO getRecommendPerformanceId(final Long userId) {
+    public RecommendMusicsPerformanceDTO getRecommendPerformanceIdByRand() {
+        return RecommendMusicsPerformanceDTO.from(performanceService.getPerformanceByRand());
+    }
 
-        Performance performance = performanceService.getPerformanceByUserFavorites(userId);
-        if (userId == null || performance == null) {
-            performance = performanceService.getPerformanceByRand();
-        }
-
-        return RecommendMusicsPerformanceDTO.from(performance);
+    public RecommendMusicsPerformanceDTO getRecommendPerformanceIdByUserId(final Long userId) {
+        return RecommendMusicsPerformanceDTO.from(performanceService.getPerformanceByUserFavorites(userId));
     }
 
     protected Set<String> setArtistsByRandom(Performance performance) {
@@ -287,7 +277,6 @@ public class PerformanceFacade {
         return new HashSet<>(artistList.subList(0, artistCount));
     }
 
-    @Transactional(readOnly = true)
     public RecommendMusicsDTO getNewRecommendMusics(long performanceId, List<String> musicIds) {
         Performance performance = performanceService.getPerformanceById(performanceId);
         Set<String> selectedArtistIds = setArtistsByRandom(performance);

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -19,6 +19,7 @@ import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsPerfo
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.SearchACPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceIdsDTO;
+import org.sopt.confeti.api.performance.vo.UserPerformanceRecordVO;
 import org.sopt.confeti.domain.artist_favorite.ArtistFavorite;
 import org.sopt.confeti.domain.artist_favorite.application.ArtistFavoriteService;
 import org.sopt.confeti.domain.concert.Concert;
@@ -29,6 +30,7 @@ import org.sopt.confeti.domain.elastic_search.application.SearchTermService;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.FestivalService;
 import org.sopt.confeti.domain.festival_favorite.application.FestivalFavoriteService;
+import org.sopt.confeti.domain.setlist.SetlistType;
 import org.sopt.confeti.domain.setlist.application.SetlistService;
 import org.sopt.confeti.domain.timetable_festival.application.TimetableFestivalService;
 import org.sopt.confeti.domain.user.application.UserService;
@@ -323,7 +325,6 @@ public class PerformanceFacade {
         return musics;
     }
 
-    @Transactional(readOnly = true)
     public ConfetiRecordDTO getConfetiRecord(final long userId) {
         validateExistUser(userId);
 
@@ -331,14 +332,13 @@ public class PerformanceFacade {
         List<Long> setListFestivalIds = setlistService.findFestivalIdsByUserId(userId);
         List<Long> setListConcertIds = setlistService.findConcertIdsByUserId(userId);
 
-        Set<Long> uniqueFestivalIds = new HashSet<>();
-        uniqueFestivalIds.addAll(timetableFestivalIds);
-        uniqueFestivalIds.addAll(setListFestivalIds);
+        UserPerformanceRecordVO record = new UserPerformanceRecordVO(
+                timetableFestivalIds,
+                setListFestivalIds,
+                setListConcertIds
+        );
 
-        int totalCount = uniqueFestivalIds.size() + setListConcertIds.size();
-
-        return ConfetiRecordDTO.of(totalCount, timetableFestivalIds.size(),
-                setListFestivalIds.size() + setListConcertIds.size());
+        return ConfetiRecordDTO.from(record);
     }
 
     protected void validateExistUser(final long userId) {

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -329,8 +329,8 @@ public class PerformanceFacade {
         validateExistUser(userId);
 
         List<Long> timetableFestivalIds = timetableFestivalService.findFestivalIdsByUserId(userId);
-        List<Long> setListFestivalIds = setlistService.findFestivalIdsByUserId(userId);
-        List<Long> setListConcertIds = setlistService.findConcertIdsByUserId(userId);
+        List<Long> setListFestivalIds = setlistService.findMusicIdsByUserId(userId, SetlistType.FESTIVAL);
+        List<Long> setListConcertIds = setlistService.findMusicIdsByUserId(userId, SetlistType.CONCERT);
 
         UserPerformanceRecordVO record = new UserPerformanceRecordVO(
                 timetableFestivalIds,

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ConfetiRecordDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/ConfetiRecordDTO.java
@@ -1,13 +1,17 @@
 package org.sopt.confeti.api.performance.facade.dto.response;
 
+import org.sopt.confeti.api.performance.vo.UserPerformanceRecordVO;
+
 public record ConfetiRecordDTO(
         long totalCount,
         long timetableCount,
         long setlistCount
 ) {
-    public static ConfetiRecordDTO of(final long totalCount, final long timetableCount, final long setlistCount) {
+    public static ConfetiRecordDTO from(UserPerformanceRecordVO record) {
         return new ConfetiRecordDTO(
-                totalCount, timetableCount, setlistCount
+                record.getTotalUniquePerformanceCount(),
+                record.getTimetableFestivalCount(),
+                record.getSetListPerformanceCount()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/vo/UserPerformanceRecordVO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/vo/UserPerformanceRecordVO.java
@@ -1,0 +1,25 @@
+package org.sopt.confeti.api.performance.vo;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+public record UserPerformanceRecordVO(
+        List<Long> timetableFestivalIds,
+        List<Long> setListFestivalIds,
+        List<Long> setListConcertIds
+) {
+    public int getTotalUniquePerformanceCount() {
+        Set<Long> uniqueFestivalIds = new HashSet<>(timetableFestivalIds);
+        uniqueFestivalIds.addAll(setListFestivalIds);
+        return uniqueFestivalIds.size() + setListConcertIds.size();
+    }
+
+    public int getTimetableFestivalCount() {
+        return timetableFestivalIds.size();
+    }
+
+    public int getSetListPerformanceCount() {
+        return setListFestivalIds.size() + setListConcertIds.size();
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.api.user.controller;
 
 import jakarta.validation.constraints.Min;
 import java.util.Collections;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.dto.response.UpcomingPerformanceResponse;
 import org.sopt.confeti.api.user.dto.response.UserFavoriteArtistsPreviewResponse;
@@ -137,12 +138,11 @@ public class UserFavoriteController {
     public ResponseEntity<BaseResponse<?>> getUpcomingPerformance(
             @UserId Long userId
     ) {
-        UpcomingPerformanceDTO upcomingPerformanceDTO = userFavoriteFacade.getUpcomingPerformance(userId);
-        if (upcomingPerformanceDTO == null) {
-            return ApiResponseUtil.success(SuccessMessage.SUCCESS, Collections.emptyMap());
-        }
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UpcomingPerformanceResponse.of(upcomingPerformanceDTO, s3FileHandler));
+        Optional<UpcomingPerformanceDTO> upcomingPerformanceDTO = userFavoriteFacade.getUpcomingPerformance(userId);
+        return upcomingPerformanceDTO
+                .map(performanceDTO ->
+                        ApiResponseUtil.success(SuccessMessage.SUCCESS, UpcomingPerformanceResponse.of(performanceDTO, s3FileHandler)))
+                .orElseGet(() -> ApiResponseUtil.success(SuccessMessage.SUCCESS, Collections.emptyMap()));
     }
 
     @Permission(role = {Role.GENERAL})

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteSortType.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteSortType.java
@@ -1,0 +1,28 @@
+package org.sopt.confeti.api.user.controller;
+
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
+
+import java.util.Arrays;
+
+public enum UserFavoriteSortType {
+    CREATED_AT("createdAt"),
+    ALPHABETICALLY("alphabetically");
+
+    private final String value;
+
+    UserFavoriteSortType(String value) {
+        this.value = value;
+    }
+
+    public static UserFavoriteSortType from(String value) {
+        return Arrays.stream(values())
+                .filter(type -> type.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new ConfetiException(ErrorMessage.BAD_REQUEST));
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableSortType.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableSortType.java
@@ -1,0 +1,28 @@
+package org.sopt.confeti.api.user.controller;
+
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
+
+import java.util.Arrays;
+
+public enum UserTimetableSortType {
+    OLDEST_FIRST("oldestFirst"),
+    CREATED_AT("createdAt");
+
+    private final String value;
+
+    UserTimetableSortType(String value) {
+        this.value = value;
+    }
+
+    public static UserTimetableSortType from(String value) {
+        return Arrays.stream(values())
+                .filter(type -> type.value.equalsIgnoreCase(value))
+                .findFirst()
+                .orElseThrow(() -> new ConfetiException(ErrorMessage.BAD_REQUEST));
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.api.user.facade;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.controller.UserFavoriteSortType;
@@ -177,7 +178,6 @@ public class UserFavoriteFacade {
         }
     }
 
-    @Transactional(readOnly = true)
     protected void validateExistUser(final long userId) {
         if (!userService.existsById(userId)) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
@@ -199,15 +199,14 @@ public class UserFavoriteFacade {
         }
     }
 
-    @Transactional(readOnly = true)
-    public UpcomingPerformanceDTO getUpcomingPerformance(final long userId) {
+    public Optional<UpcomingPerformanceDTO> getUpcomingPerformance(final long userId) {
         validateExistUser(userId);
 
         Performance performance = performanceService.getUpcomingPerformanceByUserId(userId);
-        if (performance == null) {
-            return null;
+        if (Objects.isNull(performance)) {
+            return Optional.empty();
         }
-        return UpcomingPerformanceDTO.from(performance);
+        return Optional.of(UpcomingPerformanceDTO.from(performance));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserFavoriteFacade.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.api.user.facade;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.controller.UserFavoriteSortType;
 import org.sopt.confeti.api.user.facade.dto.response.UpcomingPerformanceDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoriteArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserFavoriteArtistsPreviewDTO;
@@ -212,16 +213,9 @@ public class UserFavoriteFacade {
     @Transactional(readOnly = true)
     public UserFavoriteArtistsDTO getFavoriteArtists(long userId, String sortBy) {
         validateExistUser(userId);
-        validateSortType(sortBy);
+        UserFavoriteSortType sortType = UserFavoriteSortType.from(sortBy);
 
-        List<ArtistFavorite> artists = artistFavoriteService.getFavoriteArtists(userId, sortBy);
+        List<ArtistFavorite> artists = artistFavoriteService.getFavoriteArtists(userId, sortType);
         return UserFavoriteArtistsDTO.from(artists);
-    }
-
-    @Transactional(readOnly = true)
-    protected void validateSortType(final String sortBy) {
-        if (!sortBy.equalsIgnoreCase("createdAt") && !sortBy.equalsIgnoreCase("alphabetically")) {
-            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
-        }
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -7,6 +7,7 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.controller.UserTimetableSortType;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalArtiestDTO;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
 import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableDTO;
@@ -207,9 +208,9 @@ public class UserTimetableFacade {
     @Transactional(readOnly = true)
     public UserTimetablesDTO getTimetables(final long userId, final String sortBy) {
         validateUserExists(userId);
-        validateSortType(sortBy);
+        UserTimetableSortType sortType = UserTimetableSortType.from(sortBy);
 
-        List<TimetableFestival> userTimetables = timetableFestivalService.getTimetables(userId, sortBy);
+        List<TimetableFestival> userTimetables = timetableFestivalService.getTimetables(userId, sortType);
 
         return UserTimetablesDTO.from(userTimetables);
     }
@@ -260,13 +261,6 @@ public class UserTimetableFacade {
             if (!existingIds.contains(timetableListDTO.userTimetableId())) {
                 throw new NotFoundException(ErrorMessage.NOT_FOUND);
             }
-        }
-    }
-
-    @Transactional(readOnly = true)
-    protected void validateSortType(final String sortBy) {
-        if (!sortBy.equalsIgnoreCase("createdAt") && !sortBy.equalsIgnoreCase("oldestFirst")) {
-            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
     }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UpcomingPerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/UpcomingPerformanceDTO.java
@@ -24,5 +24,4 @@ public record UpcomingPerformanceDTO(
                 performance.getArea()
         );
     }
-
 }

--- a/src/main/java/org/sopt/confeti/domain/artist_favorite/ArtistFavorite.java
+++ b/src/main/java/org/sopt/confeti/domain/artist_favorite/ArtistFavorite.java
@@ -1,14 +1,7 @@
 package org.sopt.confeti.domain.artist_favorite;
 
-import jakarta.persistence.Embedded;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;
@@ -17,9 +10,11 @@ import lombok.NoArgsConstructor;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "artist_favorites")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class ArtistFavorite {
@@ -33,23 +28,22 @@ public class ArtistFavorite {
     private User user;
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @Embedded
     private ConfetiArtist artist;
 
     @Builder
-    private ArtistFavorite(User user, String artistId, LocalDateTime createdAt) {
+    private ArtistFavorite(User user, String artistId) {
         this.user = user;
         this.artist = ConfetiArtist.from(artistId);
-        this.createdAt = LocalDateTime.now();
     }
 
     public static ArtistFavorite create(User user, String artistId) {
         return ArtistFavorite.builder()
                 .user(user)
                 .artistId(artistId)
-                .createdAt(LocalDateTime.now())
                 .build();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/artist_favorite/ArtistFavorite.java
+++ b/src/main/java/org/sopt/confeti/domain/artist_favorite/ArtistFavorite.java
@@ -1,7 +1,16 @@
 package org.sopt.confeti.domain.artist_favorite;
 
-import jakarta.persistence.*;
-
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import java.time.LocalDateTime;
 import lombok.AccessLevel;
 import lombok.Builder;

--- a/src/main/java/org/sopt/confeti/domain/artist_favorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artist_favorite/application/ArtistFavoriteService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.AllArgsConstructor;
+import org.sopt.confeti.api.user.controller.UserFavoriteSortType;
 import org.sopt.confeti.domain.artist_favorite.ArtistFavorite;
 import org.sopt.confeti.domain.artist_favorite.infra.repository.ArtistFavoriteRepository;
 import org.sopt.confeti.domain.user.User;
@@ -63,13 +64,13 @@ public class ArtistFavoriteService {
     }
 
     @Transactional(readOnly = true)
-    public List<ArtistFavorite> getFavoriteArtists(Long userId, String sortBy) {
+    public List<ArtistFavorite> getFavoriteArtists(Long userId, UserFavoriteSortType sortBy) {
         List<ArtistFavorite> artistList = artistFavoriteRepository.findArtistFavoritesByUserId(userId);
         musicAPIResolver.load(artistList);
 
-        if ("createdAt".equalsIgnoreCase(sortBy)) {
+        if ("createdAt".equalsIgnoreCase(sortBy.getValue())) {
             artistList.sort(Comparator.comparing(ArtistFavorite::getCreatedAt).reversed());
-        } else if ("alphabetically".equalsIgnoreCase(sortBy)) {
+        } else if ("alphabetically".equalsIgnoreCase(sortBy.getValue())) {
             artistList.sort(Comparator.comparing(artist -> artist.getArtist().getName()));
         }
 

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -146,12 +146,7 @@ public class SetlistService {
     }
 
     @Transactional(readOnly = true)
-    public List<Long> findFestivalIdsByUserId(final Long userId) {
-        return setlistRepository.findFestivalIdsByUserId(userId);
-    }
-
-    @Transactional(readOnly = true)
-    public List<Long> findConcertIdsByUserId(final Long userId) {
-        return setlistRepository.findConcertIdsByUserId(userId);
+    public List<Long> findMusicIdsByUserId(final Long userId, final SetlistType sortType) {
+        return setlistRepository.findTypeIdsByUserIdAndType(userId, sortType);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
@@ -19,9 +19,6 @@ public interface SetlistRepository extends JpaRepository<Setlist, Long> {
 
     Optional<Setlist> findByIdAndUserId(Long id, Long userId);
 
-    @Query("SELECT s.typeId FROM Setlist s WHERE s.type = org.sopt.confeti.domain.setlist.SetlistType.FESTIVAL AND s.user.id = :userId")
-    List<Long> findFestivalIdsByUserId(@Param("userId") Long userId);
-
-    @Query("SELECT s.typeId FROM Setlist s WHERE s.type =  org.sopt.confeti.domain.setlist.SetlistType.CONCERT AND s.user.id = :userId")
-    List<Long> findConcertIdsByUserId(@Param("userId") Long userId);
+    @Query("SELECT s.typeId FROM Setlist s WHERE s.type = :type AND s.user.id = :userId")
+    List<Long> findTypeIdsByUserIdAndType(@Param("userId") Long userId, @Param("type") SetlistType type);
 }

--- a/src/main/java/org/sopt/confeti/domain/timetable_festival/TimetableFestival.java
+++ b/src/main/java/org/sopt/confeti/domain/timetable_festival/TimetableFestival.java
@@ -1,15 +1,7 @@
 package org.sopt.confeti.domain.timetable_festival;
 
-import jakarta.persistence.CascadeType;
-import jakarta.persistence.Entity;
-import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
-import jakarta.persistence.JoinColumn;
-import jakarta.persistence.ManyToOne;
-import jakarta.persistence.OneToMany;
-import jakarta.persistence.Table;
+import jakarta.persistence.*;
+
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;
@@ -20,9 +12,11 @@ import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.user.User;
 import org.sopt.confeti.domain.user_timetable.UserTimetable;
 import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 
 @Entity
 @Table(name = "timetable_festivals")
+@EntityListeners(AuditingEntityListener.class)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class TimetableFestival {
@@ -43,14 +37,13 @@ public class TimetableFestival {
     private List<UserTimetable> userTimetables;
 
     @CreatedDate
+    @Column(updatable = false)
     private LocalDateTime createdAt;
 
     @Builder
     public TimetableFestival(User user, Festival festival) {
         this.user = user;
         this.festival = festival;
-        this.createdAt = LocalDateTime.now();
-
         this.userTimetables = festival.getDates().stream()
                 .flatMap(festivalDate -> festivalDate.getStages().stream())
                 .flatMap(festivalStage -> festivalStage.getTimes().stream())

--- a/src/main/java/org/sopt/confeti/domain/timetable_festival/TimetableFestival.java
+++ b/src/main/java/org/sopt/confeti/domain/timetable_festival/TimetableFestival.java
@@ -1,7 +1,17 @@
 package org.sopt.confeti.domain.timetable_festival;
 
-import jakarta.persistence.*;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.Table;
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.AccessLevel;

--- a/src/main/java/org/sopt/confeti/domain/timetable_festival/application/TimetableFestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/timetable_festival/application/TimetableFestivalService.java
@@ -8,6 +8,8 @@ import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.timetable_festival.TimetableFestival;
 import org.sopt.confeti.domain.timetable_festival.infra.repository.TimetableFestivalRepository;
 import org.sopt.confeti.domain.user.User;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -42,15 +44,13 @@ public class TimetableFestivalService {
 
     @Transactional(readOnly = true)
     public List<TimetableFestival> getTimetables(final long userId, final UserTimetableSortType sortBy) {
-        List<TimetableFestival> festivals = timetableFestivalRepository.findByUserId(userId);
-
-        if ("createdAt".equalsIgnoreCase(sortBy.getValue())) {
-            festivals.sort(Comparator.comparing(TimetableFestival::getCreatedAt).reversed());
-        } else if ("oldestFirst".equalsIgnoreCase(sortBy.getValue())) {
-            festivals.sort(Comparator.comparing(TimetableFestival::getCreatedAt));
+        if (sortBy == UserTimetableSortType.CREATED_AT) {
+            return timetableFestivalRepository.findByUserIdOrderByCreatedAtDesc(userId);
         }
-
-        return festivals;
+        if (sortBy == UserTimetableSortType.OLDEST_FIRST) {
+            return timetableFestivalRepository.findByUserIdOrderByCreatedAtAsc(userId);
+        }
+        throw new ConfetiException(ErrorMessage.BAD_REQUEST);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/domain/timetable_festival/application/TimetableFestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/timetable_festival/application/TimetableFestivalService.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.domain.timetable_festival.application;
 import java.util.Comparator;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import org.sopt.confeti.api.user.controller.UserTimetableSortType;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.timetable_festival.TimetableFestival;
 import org.sopt.confeti.domain.timetable_festival.infra.repository.TimetableFestivalRepository;
@@ -40,12 +41,12 @@ public class TimetableFestivalService {
     }
 
     @Transactional(readOnly = true)
-    public List<TimetableFestival> getTimetables(final long userId, final String sortBy) {
+    public List<TimetableFestival> getTimetables(final long userId, final UserTimetableSortType sortBy) {
         List<TimetableFestival> festivals = timetableFestivalRepository.findByUserId(userId);
 
-        if ("createdAt".equalsIgnoreCase(sortBy)) {
+        if ("createdAt".equalsIgnoreCase(sortBy.getValue())) {
             festivals.sort(Comparator.comparing(TimetableFestival::getCreatedAt).reversed());
-        } else if ("oldestFirst".equalsIgnoreCase(sortBy)) {
+        } else if ("oldestFirst".equalsIgnoreCase(sortBy.getValue())) {
             festivals.sort(Comparator.comparing(TimetableFestival::getCreatedAt));
         }
 

--- a/src/main/java/org/sopt/confeti/domain/timetable_festival/infra/repository/TimetableFestivalRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/timetable_festival/infra/repository/TimetableFestivalRepository.java
@@ -10,8 +10,6 @@ public interface TimetableFestivalRepository extends JpaRepository<TimetableFest
     @Query("select tf from TimetableFestival tf join fetch tf.festival f where tf.user.id = :userId and f.endAt >= CURRENT_DATE")
     List<TimetableFestival> findByUserIdWhereEndAtLENow(@Param("userId") Long userId);
 
-    List<TimetableFestival> findByUserId(final long userId);
-
     boolean existsByUserIdAndFestivalId(final long userId, final long festivalId);
 
     void deleteByUserIdAndFestivalId(final long userId, final long festivalId);
@@ -20,4 +18,8 @@ public interface TimetableFestivalRepository extends JpaRepository<TimetableFest
 
     @Query("SELECT tf.festival.id FROM TimetableFestival tf WHERE tf.user.id = :userId")
     List<Long> findFestivalIdsByUserId(@Param("userId") Long userId);
+
+    List<TimetableFestival> findByUserIdOrderByCreatedAtDesc(final long userId);
+
+    List<TimetableFestival> findByUserIdOrderByCreatedAtAsc(final long userId);
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -161,14 +162,13 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
-    public Performance getPerformanceByRand() {
+    public Optional<Performance> getPerformanceByRand() {
         return performanceRepository.findPerformanceByRand();
     }
 
     @Transactional(readOnly = true)
-    public Performance getPerformanceByUserFavorites(final Long userId) {
-        return performanceRepository.getPerformanceByUserFavorites(userId)
-                .orElseGet(this::getPerformanceByRand);
+    public Optional<Performance> getPerformanceByUserFavorites(final Long userId) {
+        return performanceRepository.getPerformanceByUserFavorites(userId);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -167,7 +167,8 @@ public class PerformanceService {
 
     @Transactional(readOnly = true)
     public Performance getPerformanceByUserFavorites(final Long userId) {
-        return performanceRepository.getPerformanceByUserFavorites(userId);
+        return performanceRepository.getPerformanceByUserFavorites(userId)
+                .orElseGet(this::getPerformanceByRand);
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -91,7 +91,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
             "        AND p.typeId IN (SELECT tf.festival.id FROM TimetableFestival tf WHERE tf.user.id = :userId))) " +
             "AND p.endAt >= CURRENT_DATE " +
             "ORDER BY RAND() ASC LIMIT 1 ")
-    Performance getPerformanceByUserFavorites(final @Param("userId") Long userId);
+    Optional<Performance> getPerformanceByUserFavorites(final @Param("userId") Long userId);
 
     List<Performance> findRecentPerformancesByEndAtGreaterThanEqual(LocalDate now, PageRequest pageRequest);
 

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -82,7 +82,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     Optional<Performance> findPerformanceByIdAndEndAtGreaterThanEqual(long performanceId, LocalDate date);
 
     @Query(value = "SELECT p FROM Performance p WHERE p.endAt >= CURRENT_DATE ORDER BY RAND() LIMIT 1")
-    Performance findPerformanceByRand();
+    Optional<Performance> findPerformanceByRand();
 
     @Query(value = "SELECT p FROM Performance p " +
             "WHERE ((p.type = org.sopt.confeti.global.common.constant.PerformanceType.CONCERT " +

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -536,6 +536,7 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
         redisTemplate.opsForValue().set(REDIS_KEY_ARTISTS_TOP_MUSICS + artistId, musics, REDIS_TTL_DAY, TimeUnit.DAYS);
     }
 
+    @RetryOnTokenExpire
     public List<ConfetiMusic> getTopSongsByArtistId(final String artistId, final int fetchSize) {
         List<ConfetiMusic> topMusics = new ArrayList<>(getCachedTopMusicsByArtistId(artistId, fetchSize));
         if (!topMusics.isEmpty()) {
@@ -561,7 +562,6 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
     }
 
     @Override
-    @RetryOnTokenExpire
     public List<ConfetiMusic> getFilteredTopSongsByArtist(String artistId, int limit, Set<String> excludedMusicIds) {
         List<ConfetiMusic> songs = getTopSongsByArtistId(artistId, limit);
 

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -563,7 +563,7 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
     @Override
     @RetryOnTokenExpire
     public List<ConfetiMusic> getFilteredTopSongsByArtist(String artistId, int limit, Set<String> excludedMusicIds) {
-        List<ConfetiMusic> songs = getTopSongsByArtistId(artistId, limit * 5);
+        List<ConfetiMusic> songs = getTopSongsByArtistId(artistId, limit);
 
         List<ConfetiMusic> filteredSongs = songs.stream()
                 .filter(song -> !excludedMusicIds.contains(song.getId()))


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## 🔗 Issue Number
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #451

## 🔙 Previous PR
<!-- 이어지는 PR이라면 이전 PR 링크를 남겨주세요 (ex: #123) -->
- #(이전 PR 번호)

## 📌  To-do
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] @EntityListeners 적용 및 사용되지 않는 createdAt 파라미터 제거
- [x] SortType Enum으로 수정
- [x] null 값 삭제 및 존재하지 않는 값에 대해 emptyMap 반환되도록 수정
- [x] 음악 추천 로직 분기 제거 및 공통 로직으로 통합
- [x] 내 공연 관람 기록 조회 API 에서 VO 도입
- [x] import 구문 와일드카드 제거

## ✨Description 
<!-- 본인이 한 작업을 설명해주세요 -->
### @EntityListeners 적용 및 사용되지 않는 createdAt 파라미터 제거
필요한 생성자 파라미터 createdAt 제거하고 @EntityListeners(AuditingEntityListener.class) 어노테이션을 추가해 @CreatedDate가 선언된 필드에 생성 시점의 시간이 자동으로 주입되도록 설정했습니다.

### SortType Enum으로 수정
기존에 문자열로 사용하던 sortBy 파라미터를 `UserFavoriteSortType`, `UserTimetableSortType`와 같은 enum으로 변경하여 타입 안정성을 높였습니다.
기존에는 문자열 기반 비교로 인해 오타나 유효하지 않은 값에 대한 검증이 Controller나 Service 단에서 별도로 필요했지만, enum을 도입함으로써 잘못된 입력 값에 대한 검증 책임을 enum 내부의 from() 메서드로 위임하였습니다.

```java
public enum UserFavoriteSortType {Add commentMore actions
    CREATED_AT("createdAt"),
    ALPHABETICALLY("alphabetically");

    private final String value;

    UserFavoriteSortType(String value) {
        this.value = value;
    }

    public static UserFavoriteSortType from(String value) {
        return Arrays.stream(values())
                .filter(type -> type.value.equalsIgnoreCase(value))
                .findFirst()
                .orElseThrow(() -> new ConfetiException(ErrorMessage.BAD_REQUEST));
    }

    public String getValue() {
        return value;
    }
```

```java
public enum UserTimetableSortType {
    OLDEST_FIRST("oldestFirst"),
    CREATED_AT("createdAt");

    private final String value;

    UserTimetableSortType(String value) {
        this.value = value;
    }

    public static UserTimetableSortType from(String value) {
        return Arrays.stream(values())
                .filter(type -> type.value.equalsIgnoreCase(value))
                .findFirst()
                .orElseThrow(() -> new ConfetiException(ErrorMessage.BAD_REQUEST));
    }

    public String getValue() {
        return value;
    }
}
```
### null 값 삭제 및 존재하지 않는 값에 대해 emptyMap 반환되도록 수정

기존에는 null을 직접 비교하거나 반환값으로 사용하는 방식이 있어 NPE의 가능성이 존재했습니다. 이를 방지하고 코드의 안정성과 가독성을 높이기 위해 리팩토링을 적용했습니다.

1. `Objects.isNull()`을 사용해 명시적인 null 비교를 제거하고 더 읽기 쉬운 방식으로 변경하였습니다.
2. `Optional`을 적용해 파사드 계층에서 반환값으로 Optional<DTO> 형식을 사용하여 null 처리 로직을 명확히 하고 불필요한 null 체크를 제거했습니다.
3. 컨트롤러 계층에서는` Optional.orElseGet()`을 통해 null인 경우 빈 객체 형태인 `Collections.emptyMap()`을 반환하도록 했습니다. 

```java
// 파서드 계층 
   public Optional<UpcomingPerformanceDTO> getUpcomingPerformance(final long userId) {Add commentMore actions

        validateExistUser(userId);

        Performance performance = performanceService.getUpcomingPerformanceByUserId(userId);
        if (Objects.isNull(performance)) {
            return Optional.empty();
        }
        return Optional.of(UpcomingPerformanceDTO.from(performance));
    }

// 컨트롤러 계층 
    public ResponseEntity<BaseResponse<?>> getUpcomingPerformance(
            @UserId Long userId
    ) {
        Optional<UpcomingPerformanceDTO> upcomingPerformanceDTO = userFavoriteFacade.getUpcomingPerformance(userId);
        return upcomingPerformanceDTO
                .map(performanceDTO ->
                        ApiResponseUtil.success(SuccessMessage.SUCCESS, UpcomingPerformanceResponse.of(performanceDTO, s3FileHandler)))
                .orElseGet(() -> ApiResponseUtil.success(SuccessMessage.SUCCESS, Collections.emptyMap()));
    }
```

### 음악 추천 로직 분기 제거 및 공통 로직으로 통합
기존 음악 추천 로직은 아티스트 수에 따라 분기 처리가 하드코딩되어 있어 유지보수와 재사용이 어려운 구조였습니다. 따라서, 아티스트 수에 따라 나뉘던 조건문을 제거하고 아티스트 수에 상관없이 동일한 방식으로 추천이 동작되도록 수정했습니다.  

1.각 아티스트별 상위 곡 리스트(MUSIC_FETCH_SIZE만큼)를 가져옴
2. round 인덱스를 기준으로 곡을 골라 추천 리스트에 추가
3. 중복된 곡은 건너뛰고, 추천 곡이 원하는 개수만큼(RECOMMEND_MUSIC_SIZE) 모이면 종료
4. 최대 round는 MUSIC_FETCH_SIZE로 제한

```java
 private List<ConfetiMusic> recommendMusicsByArtistCount(List<String> artistIdList, Set<String> existingMusicIds) {
    List<ConfetiMusic> musics = new ArrayList<>();
    Set<String> seenMusicIds = new HashSet<>(existingMusicIds);

    // 각 아티스트별 추천 곡 리스트를 round 인덱스로 순차적으로 탐색
    int round = 0;

    // 추천 곡이 원하는 개수(RECOMMEND_MUSIC_SIZE)만큼 모일 때까지 반복
    // 단, 무한 루프 방지를 위해 round가 MUSIC_FETCH_SIZE 이상이 되면 중단
    while (musics.size() < RECOMMEND_MUSIC_SIZE && round < MUSIC_FETCH_SIZE) {
        for (String artistId : artistIdList) {
            if (musics.size() >= RECOMMEND_MUSIC_SIZE) break;

            // 각 아티스트의 필터링된 상위 곡 리스트를 가져옴
            List<ConfetiMusic> topSongs = musicAPIHandler.getFilteredTopSongsByArtist(
                    artistId, MUSIC_FETCH_SIZE, seenMusicIds
            );

            // 현재 round 인덱스에 해당하는 곡이 있다면 추천 리스트에 추가
            if (round < topSongs.size()) {
                ConfetiMusic song = topSongs.get(round);
                if (!seenMusicIds.contains(song.getId())) {
                    musics.add(song);
                    seenMusicIds.add(song.getId());
                }
            }
        }
        round++;
    }

    return musics;
}
```
### 내 공연 관람 기록 조회 API 에서 VO 도입
기존에는 Facade 계층에서 직접 공연 관람 기록 데이터를 조합하고 DTO로 변환하는 로직이 포함되어 있어 계층 간 책임이 모호하고 가독성이 저하되는 문제가 있었습니다. 따라서 VO를 도입해 해당 부분을 개선했습니다. 

```java
// Facade
        UserPerformanceRecordVO record = new UserPerformanceRecordVO(
                timetableFestivalIds,
                setListFestivalIds,
                setListConcertIds
        );

        return ConfetiRecordDTO.from(record);

// VO
public record UserPerformanceRecordVO(
        List<Long> timetableFestivalIds,
        List<Long> setListFestivalIds,
        List<Long> setListConcertIds
) {
    public int getTotalUniquePerformanceCount() {
        Set<Long> uniqueFestivalIds = new HashSet<>(timetableFestivalIds);
        uniqueFestivalIds.addAll(setListFestivalIds);
        return uniqueFestivalIds.size() + setListConcertIds.size();
    }

    public int getTimetableFestivalCount() {
        return timetableFestivalIds.size();
    }

    public int getSetListPerformanceCount() {
        return setListFestivalIds.size() + setListConcertIds.size();
    }
}
```
### import 구문 와일드카드 제거
Java 스타일 가이드의 권고에 따라 와일드카드 import 대신 실제로 사용하는 클래스와 어노테이션을 명시적으로 import 해 코드의 의도가 명확히 드러나는 방식으로 수정했습니다.

