### PR TITLE
refactor [#473] 파일 등록 시 이름에서 슬레시 제거 및 인코딩해서 URL 반환

### DIFF
--- a/src/main/java/org/sopt/confeti/global/util/FileNameGenerator.java
+++ b/src/main/java/org/sopt/confeti/global/util/FileNameGenerator.java
@@ -11,13 +11,15 @@ public class FileNameGenerator {
     private static final String UUID_SEQUENCE_DELIMITER = "_";
     private static final String EXTENSION_DOT = ".";
 
-    public String generate(String originalFileName) {
-        int lastDotIndex = originalFileName.lastIndexOf(EXTENSION_DOT);
-        String fileName = originalFileName.substring(0, lastDotIndex);
-        String extension = originalFileName.substring(lastDotIndex + 1);
+    public String generate(String originalFileFullName) {
+        int lastDotIndex = originalFileFullName.lastIndexOf(EXTENSION_DOT);
+        String originalFileName = originalFileFullName.substring(0, lastDotIndex);
+        String extension = originalFileFullName.substring(lastDotIndex + 1);
 
-        return getRandomUUID() + UUID_SEQUENCE_DELIMITER + Base64.getEncoder()
-                .encodeToString(fileName.getBytes(StandardCharsets.UTF_8)) + EXTENSION_DOT + extension;
+        String fileName = getRandomUUID() + UUID_SEQUENCE_DELIMITER + Base64.getEncoder()
+                .encodeToString(originalFileName.getBytes(StandardCharsets.UTF_8)) + EXTENSION_DOT + extension;
+
+        return fileName.replaceAll("/", "");
     }
 
     private String getRandomUUID() {

--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -10,6 +10,8 @@ import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.URLEncoder;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.util.Objects;
@@ -121,7 +123,7 @@ public class S3FileHandler {
         checkFileExist(folderPath, key);
 
         try {
-            return new URI(host + folderPath + key).toURL();
+            return new URI(host + folderPath + URLEncoder.encode(key, StandardCharsets.UTF_8)).toURL();
         } catch (URISyntaxException | MalformedURLException e) {
             throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
@@ -133,7 +135,8 @@ public class S3FileHandler {
     public URL getFileSignedUrl(String folderPath, String key) {
         checkFileExist(folderPath, key);
 
-        return s3Operations.createSignedGetURL(bucket, folderPath + key, urlDuration);
+        return s3Operations.createSignedGetURL(bucket, folderPath + URLEncoder.encode(key, StandardCharsets.UTF_8),
+                urlDuration);
     }
 
     /**


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## 🔗 Issue Number
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #473 

## 🔙 Previous PR
<!-- 이어지는 PR이라면 이전 PR 링크를 남겨주세요 (ex: #123) -->
- #(이전 PR 번호)

## 📌  To-do
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 파일 등록 시 이름에서 슬레시 제거
- [x] URL 반환 시 파일 이름 인코딩 처리


## ✨Description 
<!-- 본인이 한 작업을 설명해주세요 -->
<img width="1062" alt="image" src="https://github.com/user-attachments/assets/f73bf438-f39e-4967-98f9-374a9182b3fa" />
파일 이름을 등록할 때 Base64로 변환하는 과정에서 `'/'` 문자가 포함될 수 있습니다.
S3에서는 `'/'` 문자가 포함된 경우 디렉토리를 생성하기 때문에 제거하는 로직을 추가했어요.

그리고 URL 반환할 때 인코딩이 되지 않아 조회가 되지 않는 문제가 발생했었습니다. 이를 해결하기 위해 인코딩을 하는 로직을 추가했습니다.