### PR TITLE
docs [#502] 클로드 코드 리뷰 연동

### DIFF
--- a/.github/workflows/workflow-claude-code-review.yml
+++ b/.github/workflows/workflow-claude-code-review.yml
@@ -1,0 +1,49 @@
+name: 클로드 코드 리뷰
+
+on:
+  issue_comment:
+    types: [ created ]
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+
+
+permissions:
+  contents: write
+  pull-requests: write
+  issues: write
+  id-token: write
+
+jobs:
+  claude-code-action:
+    if: |
+      (github.event_name == 'issue_comment' && contains(github.event.comment.body, '@claude')) ||
+      (github.event_name == 'pull_request')
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 1
+
+      - name: Run Claude PR Action
+        uses: anthropics/claude-code-action@beta
+        with:
+          trigger_phrase: ''
+          anthropic_api_key: ${{ secrets.ANTHROPIC_API_KEY }}
+          timeout_minutes: "60"
+          direct_prompt: |
+            이 PR을 리뷰해주세요.
+            
+            ## 기본 규칙
+            - 한국어로 답변해주세요.
+            - 리뷰 이후 To-Do List는 지워주세요.
+            - 코드의 잠재적인 버그나 성능 문제를 찾아주세요.
+            - 클린 코드 원칙에 따라 개선할 점이 있다면 제안해 주세요.
+            - 변경 사항을 요약해서 설명해 주세요.
+            - 코드가 업데이트 되었을 때 클로드 코드로 작성된 이전 리뷰와 다른 내용을 작성해 주세요.
+            
+            ## !!절대 규칙
+            - 절대 허구의 정보를 만들어내지 마세요.
+            - 컨텍스트 또는 결과로 정확한 응답이 불가능하면 추측을 금지합니다.


### PR DESCRIPTION
<!-- 제목양식을 지켜주세요! Prefix [#이슈번호] {PR 설명} -->
<!-- PR 작성 후 우측에 Development에서 이슈 찾아서 연동하면 merge될때 이슈도 close됩니다 -->
<!-- Reviewer, Assignees, Label 붙이기 --> 
## 🔗 Issue Number
<!-- #{본인 이슈 번호} 치면 알아서 이슈 게시판 링크 걸려요 -->
closes #502 

## 🔙 Previous PR
<!-- 이어지는 PR이라면 이전 PR 링크를 남겨주세요 (ex: #123) -->
- #(이전 PR 번호)

## 📌  To-do
<!-- 본인이 한 업무를 체크리스트로 작성해주세요 -->

- [x] 클로드 코드 리뷰를 연동합니다.


## ✨Description 
<!-- 본인이 한 작업을 설명해주세요 -->
제 개인 API 키로 연동해보려고 합니다.
연동되는지 테스트 PR입니다.

<br>

참고 : [Claude Code Action](https://github.com/anthropics/claude-code-action?tab=readme-ov-file#manual-setup-direct-api)