### PR TITLE
CONFETI-38 feat: BaseResponse 응답에 Type argument를 지정하도록 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/api/artist/controller/ArtistController.java
+++ b/src/main/java/org/sopt/confeti/api/artist/controller/ArtistController.java
@@ -26,12 +26,13 @@ public class ArtistController {
     @GetMapping("/search/ac")
     @BadRequestErrorResponse
     @CommonErrorResponses
-    public ResponseEntity<BaseResponse<?>> searchAutoComplete(
-            @UserId(require = false) Long userId,
-            @RequestParam String term,
-            @RequestParam(required = false, defaultValue = "1") Integer limit
+    public ResponseEntity<BaseResponse<SearchACArtistsResponse>> searchAutoComplete(
+        @UserId(require = false) Long userId,
+        @RequestParam String term,
+        @RequestParam(required = false, defaultValue = "1") Integer limit
     ) {
         SearchACArtistsDTO artistsDTO = artistFacade.searchACArtists(term, limit);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, SearchACArtistsResponse.from(artistsDTO));
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            SearchACArtistsResponse.from(artistsDTO));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/confeti/api/auth/controller/AuthController.java
@@ -31,7 +31,7 @@ public class AuthController {
     private final AuthFacade authFacade;
 
     @PostMapping("/login")
-    public ResponseEntity<BaseResponse<?>> login(
+    public ResponseEntity<BaseResponse<LoginResult>> login(
         @Valid @RequestBody LoginRequest request
     ) {
         LoginResult result = authFacade.login(LoginCommand.from(request));
@@ -40,7 +40,7 @@ public class AuthController {
 
     @Permission(role = {Role.ONBOARDING, Role.GENERAL})
     @PostMapping("/reissue")
-    public ResponseEntity<BaseResponse<?>> reissue(
+    public ResponseEntity<BaseResponse<Token>> reissue(
         @RefreshToken String refreshToken
     ) {
         Token token = authFacade.reissue(refreshToken);
@@ -49,7 +49,7 @@ public class AuthController {
 
     @Permission(role = {Role.ONBOARDING, Role.GENERAL})
     @PostMapping("/logout")
-    public ResponseEntity<BaseResponse<?>> logout(@UserId Long userId) {
+    public ResponseEntity<BaseResponse<Void>> logout(@UserId Long userId) {
         authFacade.logout(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
@@ -59,7 +59,7 @@ public class AuthController {
      */
     @Permission(role = {Role.ONBOARDING, Role.GENERAL})
     @PostMapping("/onboard")
-    public ResponseEntity<BaseResponse<?>> onboard(
+    public ResponseEntity<BaseResponse<Void>> onboard(
         @UserId Long userId,
         @Valid @RequestBody OnboardRequest request
     ) {
@@ -70,7 +70,7 @@ public class AuthController {
 
     @Permission(role = {Role.GENERAL})
     @DeleteMapping("/withdraw")
-    public ResponseEntity<BaseResponse<?>> withdraw(
+    public ResponseEntity<BaseResponse<Void>> withdraw(
         @UserId Long userId
     ) {
         authFacade.withdraw(userId);

--- a/src/main/java/org/sopt/confeti/api/dummy/controller/AppleMusicAPITestController.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/controller/AppleMusicAPITestController.java
@@ -20,146 +20,152 @@ public class AppleMusicAPITestController {
     private final AppleMusicAPITestFacade appleMusicAPITestFacade;
 
     @GetMapping("${api.endpoints.dummy.catalog-album}")
-    public ResponseEntity<BaseResponse<?>> getCatalogAlbum(
-            @RequestParam String id,
-            @RequestParam(required = false) String views,
-            @RequestParam(required = false) List<String> include
+    public ResponseEntity<BaseResponse<Object>> getCatalogAlbum(
+        @RequestParam String id,
+        @RequestParam(required = false) String views,
+        @RequestParam(required = false) List<String> include
     ) {
         Object response = appleMusicAPITestFacade.requestCatalogAlbum(id, views, include);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.multiple-catalog-albums}")
-    public ResponseEntity<BaseResponse<?>> getMultipleCatalogAlbums(
-            @RequestParam String ids,
-            @RequestParam(required = false) List<String> include
+    public ResponseEntity<BaseResponse<Object>> getMultipleCatalogAlbums(
+        @RequestParam String ids,
+        @RequestParam(required = false) List<String> include
     ) {
         Object response = appleMusicAPITestFacade.requestMultipleCatalogAlbums(ids, include);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.catalog-album-relationship}")
-    public ResponseEntity<BaseResponse<?>> getCatalogAlbumRelationship(
-            @RequestParam String id,
-            @RequestParam String relationship,
-            @RequestParam(required = false) List<String> include,
-            @RequestParam(required = false) Integer limit
+    public ResponseEntity<BaseResponse<Object>> getCatalogAlbumRelationship(
+        @RequestParam String id,
+        @RequestParam String relationship,
+        @RequestParam(required = false) List<String> include,
+        @RequestParam(required = false) Integer limit
     ) {
-        Object response = appleMusicAPITestFacade.requestCatalogAlbumRelationship(id, relationship, include, limit);
+        Object response = appleMusicAPITestFacade.requestCatalogAlbumRelationship(id, relationship,
+            include, limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.catalog-album-relationship-view}")
-    public ResponseEntity<BaseResponse<?>> getCatalogAlbumRelationshipView(
-            @RequestParam String id,
-            @RequestParam String view,
-            @RequestParam(required = false) List<String> include,
-            @RequestParam(required = false) Integer limit,
-            @RequestParam(required = false) String with
+    public ResponseEntity<BaseResponse<Object>> getCatalogAlbumRelationshipView(
+        @RequestParam String id,
+        @RequestParam String view,
+        @RequestParam(required = false) List<String> include,
+        @RequestParam(required = false) Integer limit,
+        @RequestParam(required = false) String with
     ) {
-        Object response = appleMusicAPITestFacade.requestCatalogAlbumRelationshipView(id, view, include, limit, with);
+        Object response = appleMusicAPITestFacade.requestCatalogAlbumRelationshipView(id, view,
+            include, limit, with);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.catalog-artist}")
-    public ResponseEntity<BaseResponse<?>> getCatalogArtist(
-            @RequestParam String id,
-            @RequestParam(required = false) String views,
-            @RequestParam(required = false) List<String> include
+    public ResponseEntity<BaseResponse<Object>> getCatalogArtist(
+        @RequestParam String id,
+        @RequestParam(required = false) String views,
+        @RequestParam(required = false) List<String> include
     ) {
         Object response = appleMusicAPITestFacade.requestCatalogArtist(id, views, include);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.multiple-catalog-artists}")
-    public ResponseEntity<BaseResponse<?>> getMultipleCatalogArtists(
-            @RequestParam String ids,
-            @RequestParam(required = false) List<String> include
+    public ResponseEntity<BaseResponse<Object>> getMultipleCatalogArtists(
+        @RequestParam String ids,
+        @RequestParam(required = false) List<String> include
     ) {
         Object response = appleMusicAPITestFacade.requestMultipleCatalogArtists(ids, include);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.catalog-artist-relationship}")
-    public ResponseEntity<BaseResponse<?>> getCatalogArtistRelationship(
-            @RequestParam String id,
-            @RequestParam String relationship,
-            @RequestParam(required = false) List<String> include,
-            @RequestParam(required = false) Integer limit
+    public ResponseEntity<BaseResponse<Object>> getCatalogArtistRelationship(
+        @RequestParam String id,
+        @RequestParam String relationship,
+        @RequestParam(required = false) List<String> include,
+        @RequestParam(required = false) Integer limit
     ) {
-        Object response = appleMusicAPITestFacade.requestCatalogArtistRelationship(id, relationship, include, limit);
+        Object response = appleMusicAPITestFacade.requestCatalogArtistRelationship(id, relationship,
+            include, limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.catalog-artist-relationship-view}")
-    public ResponseEntity<BaseResponse<?>> getCatalogArtistRelationshipView(
-            @RequestParam String id,
-            @RequestParam String view,
-            @RequestParam(required = false) List<String> include,
-            @RequestParam(required = false) Integer limit,
-            @RequestParam(required = false) String with
+    public ResponseEntity<BaseResponse<Object>> getCatalogArtistRelationshipView(
+        @RequestParam String id,
+        @RequestParam String view,
+        @RequestParam(required = false) List<String> include,
+        @RequestParam(required = false) Integer limit,
+        @RequestParam(required = false) String with
     ) {
-        Object response = appleMusicAPITestFacade.requestCatalogArtistRelationshipView(id, view, include, limit, with);
+        Object response = appleMusicAPITestFacade.requestCatalogArtistRelationshipView(id, view,
+            include, limit, with);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.catalog-song}")
-    public ResponseEntity<BaseResponse<?>> getCatalogSong(
-            @RequestParam String id,
-            @RequestParam(required = false) List<String> include
+    public ResponseEntity<BaseResponse<Object>> getCatalogSong(
+        @RequestParam String id,
+        @RequestParam(required = false) List<String> include
     ) {
         Object response = appleMusicAPITestFacade.requestCatalogSong(id, include);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.multiple-catalog-songs}")
-    public ResponseEntity<BaseResponse<?>> getMultipleCatalogSongs(
-            @RequestParam String ids,
-            @RequestParam(required = false) List<String> include
+    public ResponseEntity<BaseResponse<Object>> getMultipleCatalogSongs(
+        @RequestParam String ids,
+        @RequestParam(required = false) List<String> include
     ) {
         Object response = appleMusicAPITestFacade.requestMultipleCatalogSongs(ids, include);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.catalog-song-relationship}")
-    public ResponseEntity<BaseResponse<?>> getCatalogSongRelationship(
-            @RequestParam String id,
-            @RequestParam String relationship,
-            @RequestParam(required = false) List<String> include,
-            @RequestParam(required = false) Integer limit
+    public ResponseEntity<BaseResponse<Object>> getCatalogSongRelationship(
+        @RequestParam String id,
+        @RequestParam String relationship,
+        @RequestParam(required = false) List<String> include,
+        @RequestParam(required = false) Integer limit
     ) {
-        Object response = appleMusicAPITestFacade.requestCatalogSongRelationship(id, relationship, include, limit);
+        Object response = appleMusicAPITestFacade.requestCatalogSongRelationship(id, relationship,
+            include, limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.search-catalog-resources}")
-    public ResponseEntity<BaseResponse<?>> getSearchResult(
-            @RequestParam String term,
-            @RequestParam List<String> types,
-            @RequestParam(required = false) Integer limit,
-            @RequestParam(required = false) String offset
+    public ResponseEntity<BaseResponse<Object>> getSearchResult(
+        @RequestParam String term,
+        @RequestParam List<String> types,
+        @RequestParam(required = false) Integer limit,
+        @RequestParam(required = false) String offset
     ) {
         Object response = appleMusicAPITestFacade.requestSearch(term, types, limit, offset);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.catalog-search-hints}")
-    public ResponseEntity<BaseResponse<?>> getSearchHintsResult(
-            @RequestParam String term,
-            @RequestParam(required = false) Integer limit
+    public ResponseEntity<BaseResponse<Object>> getSearchHintsResult(
+        @RequestParam String term,
+        @RequestParam(required = false) Integer limit
     ) {
         Object response = appleMusicAPITestFacade.requestSearchHints(term, limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 
     @GetMapping("${api.endpoints.dummy.catalog-search-suggestions}")
-    public ResponseEntity<BaseResponse<?>> getSearchSuggestionsResult(
-            @RequestParam List<String> kinds,
-            @RequestParam(required = false) Integer limit,
-            @RequestParam String term,
-            @RequestParam(required = false) List<String> types
+    public ResponseEntity<BaseResponse<Object>> getSearchSuggestionsResult(
+        @RequestParam List<String> kinds,
+        @RequestParam(required = false) Integer limit,
+        @RequestParam String term,
+        @RequestParam(required = false) List<String> types
     ) {
-        Object response = appleMusicAPITestFacade.requestSearchSuggestions(kinds, limit, term, types);
+        Object response = appleMusicAPITestFacade.requestSearchSuggestions(kinds, limit, term,
+            types);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, response);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/dummy/controller/PerformanceSearchController.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/controller/PerformanceSearchController.java
@@ -22,8 +22,8 @@ public class PerformanceSearchController {
 
     @Permission(role = {Role.ADMIN})
     @PatchMapping("${api.endpoints.es.batch}")
-    public ResponseEntity<BaseResponse<?>> batch(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<Void>> batch(
+        @UserId Long userId
     ) {
         performanceSearchFacade.batch();
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -66,137 +66,145 @@ public class PerformanceController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/concerts/{concertId}")
-    public ResponseEntity<BaseResponse<?>> getConcertInfo(
-            @UserId(require = false) Long userId,
-            @PathVariable("concertId") @Min(RequestConstraint.ID) long concertId
+    public ResponseEntity<BaseResponse<ConcertDetailResponse>> getConcertInfo(
+        @UserId(require = false) Long userId,
+        @PathVariable("concertId") @Min(RequestConstraint.ID) long concertId
     ) {
-        ConcertDetailDTO concertDetailDTO = performanceFacade.getConcertDetailInfo(userId, concertId);
+        ConcertDetailDTO concertDetailDTO = performanceFacade.getConcertDetailInfo(userId,
+            concertId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                ConcertDetailResponse.of(concertDetailDTO, s3FileHandler));
+            ConcertDetailResponse.of(concertDetailDTO, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/festivals/{festivalId}")
-    public ResponseEntity<BaseResponse<?>> getFestivalInfo(
-            @UserId(require = false) Long userId,
-            @PathVariable("festivalId") @Min(RequestConstraint.ID) Long festivalId
+    public ResponseEntity<BaseResponse<FestivalDetailResponse>> getFestivalInfo(
+        @UserId(require = false) Long userId,
+        @PathVariable("festivalId") @Min(RequestConstraint.ID) Long festivalId
     ) {
-        FestivalDetailDTO festivalDetailDTO = performanceFacade.getFestivalDetailInfo(userId, festivalId);
+        FestivalDetailDTO festivalDetailDTO = performanceFacade.getFestivalDetailInfo(userId,
+            festivalId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                FestivalDetailResponse.of(festivalDetailDTO, s3FileHandler));
+            FestivalDetailResponse.of(festivalDetailDTO, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/reservation")
-    public ResponseEntity<BaseResponse<?>> getPerformReservationInfo(
-            @UserId(require = false) Long userId
+    public ResponseEntity<BaseResponse<PerformanceReservationResponse>> getPerformReservationInfo(
+        @UserId(require = false) Long userId
     ) {
-        PerformanceReservationDTO performanceReservationDTO = performanceFacade.getPerformReservationInfo(userId);
+        PerformanceReservationDTO performanceReservationDTO = performanceFacade.getPerformReservationInfo(
+            userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                PerformanceReservationResponse.from(performanceReservationDTO));
+            PerformanceReservationResponse.from(performanceReservationDTO));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/association/{artistId}")
-    public ResponseEntity<BaseResponse<?>> getPerformanceByArtist(
-            @UserId(require = false) Long userId,
-            @PathVariable(name = "artistId") String artistId
+    public ResponseEntity<BaseResponse<ArtistPerformancesResponse>> getPerformanceByArtist(
+        @UserId(require = false) Long userId,
+        @PathVariable(name = "artistId") String artistId
     ) {
-        ArtistPerformancesDTO performances = performanceFacade.getPerformancesByArtistId(userId, artistId);
+        ArtistPerformancesDTO performances = performanceFacade.getPerformancesByArtistId(userId,
+            artistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                ArtistPerformancesResponse.of(performances, s3FileHandler));
+            ArtistPerformancesResponse.of(performances, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/info")
-    public ResponseEntity<BaseResponse<?>> getRecentPerformances(
-            @UserId(require = false) Long userId
+    public ResponseEntity<BaseResponse<RecentPerformancesResponse>> getRecentPerformances(
+        @UserId(require = false) Long userId
     ) {
         RecentPerformancesDTO recentPerformances = performanceFacade.getRecentPerformances(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                RecentPerformancesResponse.of(recentPerformances, s3FileHandler));
+            RecentPerformancesResponse.of(recentPerformances, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend")
-    public ResponseEntity<BaseResponse<?>> getRecommendPerformances(
+    public ResponseEntity<BaseResponse<RecommendPerformancesResponse>> getRecommendPerformances(
     ) {
         RecommendPerformancesDTO recommendPerformances = performanceFacade.getRecommendPerformances();
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                RecommendPerformancesResponse.of(recommendPerformances, s3FileHandler));
+            RecommendPerformancesResponse.of(recommendPerformances, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/search/ac")
-    public ResponseEntity<BaseResponse<?>> searchAutoComplete(
-            @UserId(require = false) Long userId,
-            @RequestParam @NotBlank String term,
-            @RequestParam(required = false, defaultValue = "1") @Min(1) @Max(10) Integer limit,
-            @RequestParam(required = false, defaultValue = Default.PERFORMANCE_STATUS) String status
+    public ResponseEntity<BaseResponse<SearchACPerformancesResponse>> searchAutoComplete(
+        @UserId(require = false) Long userId,
+        @RequestParam @NotBlank String term,
+        @RequestParam(required = false, defaultValue = "1") @Min(1) @Max(10) Integer limit,
+        @RequestParam(required = false, defaultValue = Default.PERFORMANCE_STATUS) String status
     ) {
-        SearchACPerformancesDTO performancesDTO = performanceFacade.searchACPerformances(term, limit,
-                PerformanceStatus.convert(status));
+        SearchACPerformancesDTO performancesDTO = performanceFacade.searchACPerformances(term,
+            limit,
+            PerformanceStatus.convert(status));
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                SearchACPerformancesResponse.of(performancesDTO, s3FileHandler));
+            SearchACPerformancesResponse.of(performancesDTO, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend/performance")
-    public ResponseEntity<BaseResponse<?>> getRecommendPerformanceId(
-            @UserId(require = false) Long userId
+    public ResponseEntity<BaseResponse<RecommendMusicsPerformanceResponse>> getRecommendPerformanceId(
+        @UserId(require = false) Long userId
     ) {
         Optional<RecommendMusicsPerformanceDTO> recommendMusicsDTO = performanceFacade.getRecommendPerformanceId(
-                userId);
+            userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                recommendMusicsDTO.map(RecommendMusicsPerformanceResponse::from).orElse(null)
+            recommendMusicsDTO.map(RecommendMusicsPerformanceResponse::from).orElse(null)
         );
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend/musics")
-    public ResponseEntity<BaseResponse<?>> getRecommendMusics(
-            @RequestParam Long performanceId,
-            @RequestParam(required = false) List<String> musicIds
+    public ResponseEntity<BaseResponse<RecommendMusicsResponse>> getRecommendMusics(
+        @RequestParam Long performanceId,
+        @RequestParam(required = false) List<String> musicIds
     ) {
-        RecommendMusicsDTO recommendMusicsDTO = performanceFacade.getNewRecommendMusics(performanceId, musicIds);
+        RecommendMusicsDTO recommendMusicsDTO = performanceFacade.getNewRecommendMusics(
+            performanceId, musicIds);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                RecommendMusicsResponse.from(recommendMusicsDTO));
+            RecommendMusicsResponse.from(recommendMusicsDTO));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/record")
-    public ResponseEntity<BaseResponse<?>> getConfetiRecord(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<ConfetiRecordResponse>> getConfetiRecord(
+        @UserId Long userId
     ) {
         ConfetiRecordDTO recordDTO = performanceFacade.getConfetiRecord(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                ConfetiRecordResponse.from(recordDTO));
+            ConfetiRecordResponse.from(recordDTO));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/expected")
-    public ResponseEntity<BaseResponse<?>> getExpectedPerformances(
-            @UserId(require = false) Long userId,
-            @RequestParam String items
+    public ResponseEntity<BaseResponse<ExpectedPerformancesResponse>> getExpectedPerformances(
+        @UserId(require = false) Long userId,
+        @RequestParam String items
     ) {
-        List<GetExpectedPerformanceRequest> performanceRequests = decodeToExpectedPerformancesRequest(items);
+        List<GetExpectedPerformanceRequest> performanceRequests = decodeToExpectedPerformancesRequest(
+            items);
         ExpectedPerformancesDTO expectedPerformances = performanceFacade.getExpectedPerformances(
-                GetExpectedPerformancesDTO.from(performanceRequests));
+            GetExpectedPerformancesDTO.from(performanceRequests));
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                ExpectedPerformancesResponse.of(expectedPerformances, s3FileHandler));
+            ExpectedPerformancesResponse.of(expectedPerformances, s3FileHandler));
     }
 
-    private List<GetExpectedPerformanceRequest> decodeToExpectedPerformancesRequest(String request) {
+    private List<GetExpectedPerformanceRequest> decodeToExpectedPerformancesRequest(
+        String request) {
         try {
             return Arrays.stream(request.split(","))
-                    .map(item -> {
-                        String[] performance = item.split(":");
-                        return GetExpectedPerformanceRequest.of(
-                                PerformanceType.convert(performance[0].trim()),
-                                Long.parseLong(performance[1].trim())
-                        );
-                    })
-                    .toList();
+                .map(item -> {
+                    String[] performance = item.split(":");
+                    return GetExpectedPerformanceRequest.of(
+                        PerformanceType.convert(performance[0].trim()),
+                        Long.parseLong(performance[1].trim())
+                    );
+                })
+                .toList();
         } catch (Exception e) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
@@ -204,9 +212,9 @@ public class PerformanceController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping
-    public ResponseEntity<BaseResponse<?>> getPerformances() {
+    public ResponseEntity<BaseResponse<PerformanceIdsResponse>> getPerformances() {
         PerformanceIdsDTO performances = performanceFacade.getPerformances();
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                PerformanceIdsResponse.from(performances));
+            PerformanceIdsResponse.from(performances));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/search/controller/SearchController.java
+++ b/src/main/java/org/sopt/confeti/api/search/controller/SearchController.java
@@ -33,23 +33,24 @@ public class SearchController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping
-    public ResponseEntity<BaseResponse<?>> homeSearch(
-            @UserId(require = false) Long userId,
-            @RequestParam(required = false) String aid,
-            @RequestParam(required = false) Long pid,
-            @RequestParam(required = false) String term
+    public ResponseEntity<BaseResponse<SearchResultResponse>> homeSearch(
+        @UserId(require = false) Long userId,
+        @RequestParam(required = false) String aid,
+        @RequestParam(required = false) Long pid,
+        @RequestParam(required = false) String term
     ) {
         SearchType searchType = SearchType.resolve(aid, pid, term);
         SearchResultDTO searchResult = searchType.search(searchFacade, userId, aid, pid, term);
 
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, SearchResultResponse.of(searchResult, s3FileHandler));
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            SearchResultResponse.of(searchResult, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/terms/popular")
-    public ResponseEntity<BaseResponse<?>> getPopularSearchTerms(
-            @UserId(require = false) Long userId,
-            @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(20) Integer limit
+    public ResponseEntity<BaseResponse<PopularTermsResponse>> getPopularSearchTerms(
+        @UserId(require = false) Long userId,
+        @RequestParam(required = false, defaultValue = "10") @Min(1) @Max(20) Integer limit
     ) {
         PopularTermsDTO terms = searchFacade.getPopularSearchTerms(limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, PopularTermsResponse.from(terms));

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistController.java
@@ -2,14 +2,14 @@ package org.sopt.confeti.api.setlist.controller;
 
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
+import org.sopt.confeti.api.setlist.dto.response.GetSetlistDetailResponse;
+import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryResponse;
 import org.sopt.confeti.api.setlist.facade.SetlistFacade;
 import org.sopt.confeti.api.setlist.facade.dto.request.SetlistAddMusicDTO;
 import org.sopt.confeti.api.setlist.facade.dto.request.SetlistCreateRequestDTO;
 import org.sopt.confeti.api.setlist.facade.dto.response.SetlistAddMusicResponseDTO;
-import org.sopt.confeti.api.setlist.dto.response.GetAllSetlistsResponse;
-import org.sopt.confeti.api.setlist.dto.response.GetSetlistDetailResponse;
 import org.sopt.confeti.api.setlist.facade.dto.response.SetlistCreateResponseDTO;
-import org.sopt.confeti.api.setlist.dto.response.SetlistSummaryResponse;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
@@ -34,9 +34,9 @@ public class SetlistController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/all")
-    public ResponseEntity<BaseResponse<?>> getAllMySetlists(
-            @UserId Long userId,
-            @RequestParam(name = "sortBy", required = false) String sortBy
+    public ResponseEntity<BaseResponse<GetAllSetlistsResponse>> getAllMySetlists(
+        @UserId Long userId,
+        @RequestParam(name = "sortBy", required = false) String sortBy
     ) {
         GetAllSetlistsResponse data = setlistFacade.getAllMySetlists(userId, sortBy);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
@@ -44,8 +44,8 @@ public class SetlistController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/preview")
-    public ResponseEntity<BaseResponse<?>> getPreviewMySetlists(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<List<SetlistSummaryResponse>>> getPreviewMySetlists(
+        @UserId Long userId
     ) {
         List<SetlistSummaryResponse> data = setlistFacade.getPreviewMySetlists(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);
@@ -53,9 +53,9 @@ public class SetlistController {
 
     @Permission(role = {Role.GENERAL})
     @PostMapping
-    public ResponseEntity<BaseResponse<?>> createSetlists(
-            @UserId Long userId,
-            @RequestBody List<SetlistCreateRequestDTO> requests
+    public ResponseEntity<BaseResponse<SetlistCreateResponseDTO>> createSetlists(
+        @UserId Long userId,
+        @RequestBody List<SetlistCreateRequestDTO> requests
     ) {
         SetlistCreateResponseDTO data = setlistFacade.createSetLists(userId, requests);
         return ApiResponseUtil.success(SuccessMessage.CREATED, data);
@@ -63,10 +63,10 @@ public class SetlistController {
 
     @Permission(role = {Role.GENERAL})
     @PostMapping("/{setlistId}/musics")
-    public ResponseEntity<BaseResponse<?>> addMusicsToSetlist(
-            @UserId Long userId,
-            @PathVariable Long setlistId,
-            @RequestBody List<SetlistAddMusicDTO> requests
+    public ResponseEntity<BaseResponse<SetlistAddMusicResponseDTO>> addMusicsToSetlist(
+        @UserId Long userId,
+        @PathVariable Long setlistId,
+        @RequestBody List<SetlistAddMusicDTO> requests
     ) {
         SetlistAddMusicResponseDTO data = setlistFacade.addMusics(userId, setlistId, requests);
         return ApiResponseUtil.success(SuccessMessage.CREATED, data);
@@ -74,9 +74,9 @@ public class SetlistController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/{setlistId}")
-    public ResponseEntity<BaseResponse<?>> getSetlistDetail(
-            @UserId Long userId,
-            @PathVariable Long setlistId
+    public ResponseEntity<BaseResponse<GetSetlistDetailResponse>> getSetlistDetail(
+        @UserId Long userId,
+        @PathVariable Long setlistId
     ) {
         GetSetlistDetailResponse data = setlistFacade.getSetlistDetail(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, data);

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistEditController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistEditController.java
@@ -25,47 +25,47 @@ public class SetlistEditController {
     private final SetlistFacade setlistFacade;
 
     @PostMapping("/{setlistId}/edit/start")
-    public ResponseEntity<BaseResponse<?>> startEdit(
-            @UserId Long userId,
-            @PathVariable Long setlistId
+    public ResponseEntity<BaseResponse<Void>> startEdit(
+        @UserId Long userId,
+        @PathVariable Long setlistId
     ) {
         setlistFacade.startEdit(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.CREATED);
     }
 
     @PatchMapping("/{setlistId}/edit/musics/order")
-    public ResponseEntity<BaseResponse<?>> updateMusicOrder(
-            @UserId Long userId,
-            @PathVariable Long setlistId,
-            @RequestBody List<SetlistUpdateMusicOrderDTO> request
+    public ResponseEntity<BaseResponse<Void>> updateMusicOrder(
+        @UserId Long userId,
+        @PathVariable Long setlistId,
+        @RequestBody List<SetlistUpdateMusicOrderDTO> request
     ) {
         setlistFacade.updateMusicOrder(userId, setlistId, request);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
     @DeleteMapping("/{setlistId}/musics/{orders}")
-    public ResponseEntity<BaseResponse<?>> deleteMusic(
-            @UserId Long userId,
-            @PathVariable Long setlistId,
-            @PathVariable int orders
+    public ResponseEntity<BaseResponse<String>> deleteMusic(
+        @UserId Long userId,
+        @PathVariable Long setlistId,
+        @PathVariable int orders
     ) {
         String deleteTrackId = setlistFacade.deleteMusic(userId, setlistId, orders);
         return ApiResponseUtil.success(SuccessMessage.DELETED, deleteTrackId);
     }
 
     @PatchMapping("/{setlistId}/edit/complete")
-    public ResponseEntity<BaseResponse<?>> completeEdit(
-            @UserId Long userId,
-            @PathVariable Long setlistId
+    public ResponseEntity<BaseResponse<Void>> completeEdit(
+        @UserId Long userId,
+        @PathVariable Long setlistId
     ) {
         setlistFacade.completeEdit(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.UPDATED);
     }
 
     @DeleteMapping("/{setlistId}/edit/cancel")
-    public ResponseEntity<BaseResponse<?>> cancelEdit(
-            @UserId Long userId,
-            @PathVariable Long setlistId
+    public ResponseEntity<BaseResponse<Void>> cancelEdit(
+        @UserId Long userId,
+        @PathVariable Long setlistId
     ) {
         setlistFacade.cancelEdit(userId, setlistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);

--- a/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
+++ b/src/main/java/org/sopt/confeti/api/setlist/controller/SetlistSearchController.java
@@ -36,43 +36,46 @@ public class SetlistSearchController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/performances")
-    public ResponseEntity<BaseResponse<?>> searchPerformances(
-            @UserId Long userId,
-            @RequestParam(required = false) String aid,
-            @RequestParam(required = false) Long pid,
-            @RequestParam(required = false) String term
+    public ResponseEntity<BaseResponse<SetlistSearchPerformancesResponse>> searchPerformances(
+        @UserId Long userId,
+        @RequestParam(required = false) String aid,
+        @RequestParam(required = false) Long pid,
+        @RequestParam(required = false) String term
     ) {
         SearchPerformancesDTO searchResult = setlistSearchFacade.searchPerformances(aid, pid, term);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                SetlistSearchPerformancesResponse.of(searchResult, s3FileHandler));
+            SetlistSearchPerformancesResponse.of(searchResult, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/artist-musics")
-    public ResponseEntity<BaseResponse<?>> searchArtistMusics(
-            @UserId Long userId,
-            @RequestParam(required = false) String aid,
-            @RequestParam(required = false) String term,
-            @RequestParam(required = false, defaultValue = "0") @Min(0) int offset,
-            @RequestParam(required = false, defaultValue = "5") @Min(1) @Max(20) int limit
+    public ResponseEntity<BaseResponse<SetlistSearchArtistMusicsResponse>> searchArtistMusics(
+        @UserId Long userId,
+        @RequestParam(required = false) String aid,
+        @RequestParam(required = false) String term,
+        @RequestParam(required = false, defaultValue = "0") @Min(0) int offset,
+        @RequestParam(required = false, defaultValue = "5") @Min(1) @Max(20) int limit
     ) {
         if (Objects.isNull(aid) && Objects.isNull(term)) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
 
-        SetlistSearchArtistMusicsDTO artistMusics = setlistSearchFacade.searchArtistMusics(aid, term, offset, limit);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, SetlistSearchArtistMusicsResponse.from(artistMusics));
+        SetlistSearchArtistMusicsDTO artistMusics = setlistSearchFacade.searchArtistMusics(aid,
+            term, offset, limit);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            SetlistSearchArtistMusicsResponse.from(artistMusics));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/musics")
-    public ResponseEntity<BaseResponse<?>> searchMusics(
-            @UserId Long userId,
-            @RequestParam String term,
-            @RequestParam(required = false, defaultValue = "0") @Min(0) int offset,
-            @RequestParam(required = false, defaultValue = "5") @Min(1) @Max(20) int limit
+    public ResponseEntity<BaseResponse<SetlistSearchMusicsResponse>> searchMusics(
+        @UserId Long userId,
+        @RequestParam String term,
+        @RequestParam(required = false, defaultValue = "0") @Min(0) int offset,
+        @RequestParam(required = false, defaultValue = "5") @Min(1) @Max(20) int limit
     ) {
         SetlistSearchMusicsDTO musics = setlistSearchFacade.searchMusics(term, offset, limit);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, SetlistSearchMusicsResponse.from(musics));
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            SetlistSearchMusicsResponse.from(musics));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserFavoriteController.java
@@ -43,38 +43,38 @@ public class UserFavoriteController {
 
     @Permission(role = {Role.GENERAL})
     @PostMapping("/festivals/{festivalId}")
-    public ResponseEntity<BaseResponse<?>> postFavoriteFestival(
-            @UserId Long userId,
-            @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) Long festivalId) {
+    public ResponseEntity<BaseResponse<Void>> postFavoriteFestival(
+        @UserId Long userId,
+        @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) Long festivalId) {
         userFavoriteFacade.addFestivalFavorite(userId, festivalId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
     @Permission(role = {Role.GENERAL})
     @DeleteMapping("/festivals/{festivalId}")
-    public ResponseEntity<BaseResponse<?>> deleteFavoriteFestival(
-            @UserId Long userId,
-            @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) Long festivalId) {
+    public ResponseEntity<BaseResponse<Void>> deleteFavoriteFestival(
+        @UserId Long userId,
+        @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) Long festivalId) {
         userFavoriteFacade.removeFestivalFavorite(userId, festivalId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/artists/preview")
-    public ResponseEntity<BaseResponse<?>> getFavoriteArtistsPreview(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<UserFavoriteArtistsPreviewResponse>> getFavoriteArtistsPreview(
+        @UserId Long userId
     ) {
         UserFavoriteArtistsPreviewDTO userFavoriteArtistsPreviewDTO = userFavoriteFacade.getFavoriteArtistsPreview(
-                userId);
+            userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UserFavoriteArtistsPreviewResponse.from(userFavoriteArtistsPreviewDTO.artists()));
+            UserFavoriteArtistsPreviewResponse.from(userFavoriteArtistsPreviewDTO.artists()));
     }
 
     @Permission(role = {Role.GENERAL})
     @PostMapping("/artists/{artistId}")
-    public ResponseEntity<BaseResponse<?>> addArtistFavorite(
-            @UserId Long userId,
-            @PathVariable(name = "artistId") String artistId
+    public ResponseEntity<BaseResponse<Void>> addArtistFavorite(
+        @UserId Long userId,
+        @PathVariable(name = "artistId") String artistId
     ) {
         userFavoriteFacade.addArtistFavorite(userId, artistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
@@ -82,9 +82,9 @@ public class UserFavoriteController {
 
     @Permission(role = {Role.GENERAL})
     @DeleteMapping("/artists/{artistId}")
-    public ResponseEntity<BaseResponse<?>> removeArtistFavorite(
-            @UserId Long userId,
-            @PathVariable(name = "artistId") String artistId
+    public ResponseEntity<BaseResponse<Void>> removeArtistFavorite(
+        @UserId Long userId,
+        @PathVariable(name = "artistId") String artistId
     ) {
         userFavoriteFacade.removeArtistFavorite(userId, artistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
@@ -92,9 +92,9 @@ public class UserFavoriteController {
 
     @Permission(role = {Role.GENERAL})
     @PostMapping("/concerts/{concertId}")
-    public ResponseEntity<BaseResponse<?>> addConcertFavorite(
-            @UserId Long userId,
-            @PathVariable(name = "concertId") Long concertId
+    public ResponseEntity<BaseResponse<Void>> addConcertFavorite(
+        @UserId Long userId,
+        @PathVariable(name = "concertId") Long concertId
     ) {
         userFavoriteFacade.addConcertFavorite(userId, concertId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
@@ -102,9 +102,9 @@ public class UserFavoriteController {
 
     @Permission(role = {Role.GENERAL})
     @DeleteMapping("/concerts/{concertId}")
-    public ResponseEntity<BaseResponse<?>> removeConcertFavorite(
-            @UserId Long userId,
-            @PathVariable(name = "concertId") Long concertId
+    public ResponseEntity<BaseResponse<Void>> removeConcertFavorite(
+        @UserId Long userId,
+        @PathVariable(name = "concertId") Long concertId
     ) {
         userFavoriteFacade.removeConcertFavorite(userId, concertId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
@@ -112,47 +112,54 @@ public class UserFavoriteController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/performances/preview")
-    public ResponseEntity<BaseResponse<?>> getFavoritePerformances(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<UserFavoritePerformancesResponse>> getFavoritePerformances(
+        @UserId Long userId
     ) {
-        UserFavoritePerformancesDTO userFavoritePerformancesDTO = userFavoriteFacade.getFavoritePerformances(userId);
+        UserFavoritePerformancesDTO userFavoritePerformancesDTO = userFavoriteFacade.getFavoritePerformances(
+            userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UserFavoritePerformancesResponse.of(userFavoritePerformancesDTO, s3FileHandler));
+            UserFavoritePerformancesResponse.of(userFavoritePerformancesDTO, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/performances")
-    public ResponseEntity<BaseResponse<?>> getFavoritePerformancesAll(
-            @RequestParam(value = "type") String type,
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<UserFavoritePerformancesAllResponse>> getFavoritePerformancesAll(
+        @RequestParam(value = "type") String type,
+        @UserId Long userId
     ) {
         UserFavoritePerformancesAllDTO userFavoritePerformancesAllDTO = userFavoriteFacade.getFavoritePerformancesAll(
-                userId, type);
+            userId, type);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UserFavoritePerformancesAllResponse.of(userFavoritePerformancesAllDTO, s3FileHandler));
+            UserFavoritePerformancesAllResponse.of(userFavoritePerformancesAllDTO, s3FileHandler));
     }
 
+    /**
+     * BaseResponse 의 type argument가 Map 일 수도, UpcomingPerformanceResponse 일 수도 있어서 타입 통일을 하려다가, 4차
+     * 스프린트부터 사용되지 않는 API라고 하셔서 우선 Object로 두었습니다.
+     */
     @Permission(role = {Role.GENERAL})
     @GetMapping("/performance")
-    public ResponseEntity<BaseResponse<?>> getUpcomingPerformance(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<Object>> getUpcomingPerformance(
+        @UserId Long userId
     ) {
-        UpcomingPerformanceDTO upcomingPerformanceDTO = userFavoriteFacade.getUpcomingPerformance(userId);
+        UpcomingPerformanceDTO upcomingPerformanceDTO = userFavoriteFacade.getUpcomingPerformance(
+            userId);
         if (upcomingPerformanceDTO == null) {
             return ApiResponseUtil.success(SuccessMessage.SUCCESS, Collections.emptyMap());
         }
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UpcomingPerformanceResponse.of(upcomingPerformanceDTO, s3FileHandler));
+            UpcomingPerformanceResponse.of(upcomingPerformanceDTO, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/artists")
-    public ResponseEntity<BaseResponse<?>> getFavoriteArtists(
-            @UserId Long userId,
-            @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy
+    public ResponseEntity<BaseResponse<UserFavoriteArtistsResponse>> getFavoriteArtists(
+        @UserId Long userId,
+        @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy
     ) {
-        UserFavoriteArtistsDTO userFavoriteArtistsDTO = userFavoriteFacade.getFavoriteArtists(userId, sortBy);
+        UserFavoriteArtistsDTO userFavoriteArtistsDTO = userFavoriteFacade.getFavoriteArtists(
+            userId, sortBy);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UserFavoriteArtistsResponse.from(userFavoriteArtistsDTO.artists()));
+            UserFavoriteArtistsResponse.from(userFavoriteArtistsDTO.artists()));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserInfoController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserInfoController.java
@@ -13,7 +13,11 @@ import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @RequiredArgsConstructor
@@ -25,18 +29,19 @@ public class UserInfoController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping
-    public ResponseEntity<BaseResponse<?>> getUserInfo(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<UserInfoResponse>> getUserInfo(
+        @UserId Long userId
     ) {
         UserInfoDTO userInfo = userInfoFacade.getUserInfo(userId);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserInfoResponse.of(userInfo, s3FileHandler));
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserInfoResponse.of(userInfo, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @PatchMapping
-    public ResponseEntity<BaseResponse<?>> patchUserInfo(
-            @UserId Long userId,
-            @ModelAttribute PatchUserInfoRequest patchUserInfoRequest
+    public ResponseEntity<BaseResponse<Void>> patchUserInfo(
+        @UserId Long userId,
+        @ModelAttribute PatchUserInfoRequest patchUserInfoRequest
     ) {
         userInfoFacade.patchUserInfo(userId, patchUserInfoRequest);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -38,7 +38,7 @@ public class UserOnboardController {
      */
     @Permission(role = {Role.ONBOARDING, Role.GENERAL})
     @GetMapping("/artists/{artistId}/related")
-    public ResponseEntity<BaseResponse<?>> getRelatedArtists(
+    public ResponseEntity<BaseResponse<UserOnboardRelatedArtistsResponse>> getRelatedArtists(
         @UserId Long userId,
         @PathVariable String artistId,
         @RequestParam(defaultValue = "1") @Min(1) @Max(30) Integer limit
@@ -50,7 +50,7 @@ public class UserOnboardController {
     }
 
     @GetMapping("/artists/search")
-    public ResponseEntity<BaseResponse<?>> getArtistsRelatedTerm(
+    public ResponseEntity<BaseResponse<UserOnboardRelatedArtistsResponse>> getArtistsRelatedTerm(
         @UserId Long userId,
         @RequestParam String term,
         @RequestParam(defaultValue = "1") @Min(1) @Max(25) Integer limit
@@ -66,7 +66,7 @@ public class UserOnboardController {
      */
     @Permission(role = {Role.ONBOARDING, Role.GENERAL})
     @GetMapping("/artists")
-    public ResponseEntity<BaseResponse<?>> getTopArtists(
+    public ResponseEntity<BaseResponse<UserOnboardTopArtistsResponse>> getTopArtists(
         @UserId Long userId,
         @RequestParam(required = false, defaultValue = "100") @Min(1) @Max(200) int limit
     ) {
@@ -81,7 +81,7 @@ public class UserOnboardController {
      */
     @Permission(role = {Role.ONBOARDING, Role.GENERAL})
     @PostMapping("/artists/{artistId}")
-    public ResponseEntity<BaseResponse<?>> addArtist(
+    public ResponseEntity<BaseResponse<Void>> addArtist(
         @UserId Long userId,
         @PathVariable String artistId
     ) {
@@ -91,7 +91,8 @@ public class UserOnboardController {
 
     @Permission(role = {Role.ONBOARDING, Role.GENERAL, Role.ADMIN})
     @GetMapping("/status")
-    public ResponseEntity<BaseResponse<?>> getOnboardStatus(@UserId Long userId) {
+    public ResponseEntity<BaseResponse<GetOnboardStatusResponse>> getOnboardStatus(
+        @UserId Long userId) {
         GetOnboardStatusDTO onboardStatusDTO = userOnboardFacade.getOnboardStatus(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             GetOnboardStatusResponse.from(onboardStatusDTO));

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
@@ -6,20 +6,20 @@ import org.sopt.confeti.api.user.dto.request.AddTimetableFestivalRequest;
 import org.sopt.confeti.api.user.dto.request.PatchTimetableRequest;
 import org.sopt.confeti.api.user.dto.response.TimetablesToAddResponse;
 import org.sopt.confeti.api.user.dto.response.UserTimetableDetailFestivalsResponse;
+import org.sopt.confeti.api.user.dto.response.UserTimetableEntireFestivalResponse;
 import org.sopt.confeti.api.user.dto.response.UserTimetableFestivalResponse;
 import org.sopt.confeti.api.user.dto.response.UserTimetableHistoryResponse;
 import org.sopt.confeti.api.user.dto.response.UserTimetablesPreviewResponse;
 import org.sopt.confeti.api.user.dto.response.UserTimetablesResponse;
-import org.sopt.confeti.api.user.dto.response.UserTimetableEntireFestivalResponse;
 import org.sopt.confeti.api.user.facade.UserTimetableFacade;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
 import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableDTO;
 import org.sopt.confeti.api.user.facade.dto.response.TimetableToAddDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserTimetableDetailFestivalsDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetableEntireFestivalDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserTimetableFestivalBasicDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserTimetableHistoryDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserTimetablesDTO;
-import org.sopt.confeti.api.user.facade.dto.response.UserTimetableEntireFestivalDTO;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Permission;
 import org.sopt.confeti.global.annotation.UserId;
@@ -52,50 +52,55 @@ public class UserTimetableController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/festivals")
-    public ResponseEntity<BaseResponse<?>> getTimetablesListAndDate(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<UserTimetableDetailFestivalsResponse>> getTimetablesListAndDate(
+        @UserId Long userId
     ) {
         UserTimetableDetailFestivalsDTO userTimetableDetailFestivalsDTO = userTimetableFacade.getTimetablesListAndDate(
-                userId);
+            userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UserTimetableDetailFestivalsResponse.of(userTimetableDetailFestivalsDTO, s3FileHandler));
+            UserTimetableDetailFestivalsResponse.of(userTimetableDetailFestivalsDTO,
+                s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/festivals/history")
-    public ResponseEntity<BaseResponse<?>> getHasTimetableHistory(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<UserTimetableHistoryResponse>> getHasTimetableHistory(
+        @UserId Long userId
     ) {
-        UserTimetableHistoryDTO timetableHistoryDTO = userTimetableFacade.getHasTimetableHistory(userId);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserTimetableHistoryResponse.from(timetableHistoryDTO));
+        UserTimetableHistoryDTO timetableHistoryDTO = userTimetableFacade.getHasTimetableHistory(
+            userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetableHistoryResponse.from(timetableHistoryDTO));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/festivals/add")
-    public ResponseEntity<BaseResponse<?>> getTimetablesToAdd(
-            @UserId Long userId,
-            @RequestParam(name = "cursor", required = false) Long cursor
+    public ResponseEntity<BaseResponse<TimetablesToAddResponse>> getTimetablesToAdd(
+        @UserId Long userId,
+        @RequestParam(name = "cursor", required = false) Long cursor
     ) {
-        CursorPage<TimetableToAddDTO> timetablesToAdd = userTimetableFacade.getTimetablesToAdd(userId, cursor);
+        CursorPage<TimetableToAddDTO> timetablesToAdd = userTimetableFacade.getTimetablesToAdd(
+            userId, cursor);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                TimetablesToAddResponse.of(timetablesToAdd, s3FileHandler));
+            TimetablesToAddResponse.of(timetablesToAdd, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @PostMapping("/festivals")
-    public ResponseEntity<BaseResponse<?>> addTimetableFestival(
-            @UserId Long userId,
-            @RequestBody AddTimetableFestivalRequest addTimetableFestivalRequest
+    public ResponseEntity<BaseResponse<Void>> addTimetableFestival(
+        @UserId Long userId,
+        @RequestBody AddTimetableFestivalRequest addTimetableFestivalRequest
     ) {
-        userTimetableFacade.addTimetableFestivals(userId, AddTimetableFestivalDTO.from(addTimetableFestivalRequest));
+        userTimetableFacade.addTimetableFestivals(userId,
+            AddTimetableFestivalDTO.from(addTimetableFestivalRequest));
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
     @Permission(role = {Role.GENERAL})
     @DeleteMapping("/festivals/{festivalId}")
-    public ResponseEntity<BaseResponse<?>> removeTimetableFestival(
-            @UserId Long userId,
-            @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) long festivalId
+    public ResponseEntity<BaseResponse<Void>> removeTimetableFestival(
+        @UserId Long userId,
+        @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) long festivalId
     ) {
         userTimetableFacade.removeTimetableFestival(userId, festivalId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
@@ -103,59 +108,65 @@ public class UserTimetableController {
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/festivals/{festivalDateId}")
-    public ResponseEntity<BaseResponse<?>> getTimetableFestival(
-            @UserId Long userId,
-            @PathVariable(name = "festivalDateId") @Min(RequestConstraint.ID) long festivalDateId
+    public ResponseEntity<BaseResponse<UserTimetableFestivalResponse>> getTimetableFestival(
+        @UserId Long userId,
+        @PathVariable(name = "festivalDateId") @Min(RequestConstraint.ID) long festivalDateId
     ) {
-        UserTimetableFestivalBasicDTO response = userTimetableFacade.getTimetableInfo(userId, festivalDateId);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserTimetableFestivalResponse.from(response));
+        UserTimetableFestivalBasicDTO response = userTimetableFacade.getTimetableInfo(userId,
+            festivalDateId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetableFestivalResponse.from(response));
     }
 
     @Permission(role = {Role.GENERAL})
     @PatchMapping("/festivals")
-    public ResponseEntity<BaseResponse<?>> updateTimetableFestival(
-            @UserId Long userId,
-            @RequestBody PatchTimetableRequest patchTimetablerequest
+    public ResponseEntity<BaseResponse<Void>> updateTimetableFestival(
+        @UserId Long userId,
+        @RequestBody PatchTimetableRequest patchTimetablerequest
     ) {
-        userTimetableFacade.patchTimetableFestivals(userId, PatchTimetableDTO.from(patchTimetablerequest));
+        userTimetableFacade.patchTimetableFestivals(userId,
+            PatchTimetableDTO.from(patchTimetablerequest));
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
     @GetMapping
-    public ResponseEntity<BaseResponse<?>> getTimetables(
-            @UserId Long userId,
-            @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy
+    public ResponseEntity<BaseResponse<UserTimetablesResponse>> getTimetables(
+        @UserId Long userId,
+        @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy
     ) {
         UserTimetablesDTO timetables = userTimetableFacade.getTimetables(userId, sortBy);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS, UserTimetablesResponse.of(timetables, s3FileHandler));
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetablesResponse.of(timetables, s3FileHandler));
     }
 
     @GetMapping("/preview")
-    public ResponseEntity<BaseResponse<?>> getTimetablesPreview(
-            @UserId Long userId
+    public ResponseEntity<BaseResponse<UserTimetablesPreviewResponse>> getTimetablesPreview(
+        @UserId Long userId
     ) {
         UserTimetablesDTO timetables = userTimetableFacade.getTimetablesPreview(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UserTimetablesPreviewResponse.of(timetables, s3FileHandler));
+            UserTimetablesPreviewResponse.of(timetables, s3FileHandler));
     }
 
     @GetMapping("/archive/{festivalId}")
-    public ResponseEntity<BaseResponse<?>> getEntireFestivalInfo(
-            @UserId Long userId,
-            @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) Long festivalId
+    public ResponseEntity<BaseResponse<UserTimetableEntireFestivalResponse>> getEntireFestivalInfo(
+        @UserId Long userId,
+        @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) Long festivalId
     ) {
-        UserTimetableEntireFestivalDTO entireFestivalDTO = userTimetableFacade.getEntireFestivalInfo(userId, festivalId);
+        UserTimetableEntireFestivalDTO entireFestivalDTO = userTimetableFacade.getEntireFestivalInfo(
+            userId, festivalId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UserTimetableEntireFestivalResponse.of(entireFestivalDTO, s3FileHandler));
+            UserTimetableEntireFestivalResponse.of(entireFestivalDTO, s3FileHandler));
     }
 
     @GetMapping("/archive/festival/{festivalDateId}")
-    public ResponseEntity<BaseResponse<?>> getEntireFestivalDateInfo(
-            @UserId Long userId,
-            @PathVariable(name = "festivalDateId") @Min(RequestConstraint.ID) Long festivalDateId
+    public ResponseEntity<BaseResponse<UserTimetableFestivalResponse>> getEntireFestivalDateInfo(
+        @UserId Long userId,
+        @PathVariable(name = "festivalDateId") @Min(RequestConstraint.ID) Long festivalDateId
     ) {
-        UserTimetableFestivalBasicDTO festivalBasicDTO = userTimetableFacade.getEntireFestivalDateInfo(userId, festivalDateId);
+        UserTimetableFestivalBasicDTO festivalBasicDTO = userTimetableFacade.getEntireFestivalDateInfo(
+            userId, festivalDateId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                UserTimetableFestivalResponse.from(festivalBasicDTO));
+            UserTimetableFestivalResponse.from(festivalBasicDTO));
     }
 }

--- a/src/main/java/org/sopt/confeti/global/common/BaseResponse.java
+++ b/src/main/java/org/sopt/confeti/global/common/BaseResponse.java
@@ -7,6 +7,7 @@ import org.sopt.confeti.global.message.SuccessMessage;
 
 @Getter
 public class BaseResponse<T> {
+
     private final int status;
     private final String message;
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
@@ -21,26 +22,26 @@ public class BaseResponse<T> {
         this.exception = builder.exception;
     }
 
-    public static BaseResponse<?> of(SuccessMessage successMessage) {
-        return builder()
-                .status(successMessage.getHttpStatus().value())
-                .message(successMessage.getMessage())
-                .build();
+    public static BaseResponse<Void> of(SuccessMessage successMessage) {
+        return BaseResponse.<Void>builder()
+            .status(successMessage.getHttpStatus().value())
+            .message(successMessage.getMessage())
+            .build();
     }
 
-    public static <T> BaseResponse<?> of(SuccessMessage successMessage, T data) {
-        return builder()
-                .status(successMessage.getHttpStatus().value())
-                .message(successMessage.getMessage())
-                .data(data)
-                .build();
+    public static <T> BaseResponse<T> of(SuccessMessage successMessage, T data) {
+        return BaseResponse.<T>builder()
+            .status(successMessage.getHttpStatus().value())
+            .message(successMessage.getMessage())
+            .data(data)
+            .build();
     }
 
-    public static BaseResponse<?> of(ErrorMessage errorMessage) {
-        return builder()
-                .status(errorMessage.getHttpStatus().value())
-                .message(errorMessage.getMessage())
-                .build();
+    public static BaseResponse<Void> of(ErrorMessage errorMessage) {
+        return BaseResponse.<Void>builder()
+            .status(errorMessage.getHttpStatus().value())
+            .message(errorMessage.getMessage())
+            .build();
     }
 
     public static <T> Builder<T> builder() {
@@ -48,6 +49,7 @@ public class BaseResponse<T> {
     }
 
     public static class Builder<T> {
+
         private int status;
         private String message;
         private T data;

--- a/src/main/java/org/sopt/confeti/global/exception/GlobalExceptionHandler.java
+++ b/src/main/java/org/sopt/confeti/global/exception/GlobalExceptionHandler.java
@@ -13,57 +13,64 @@ import org.springframework.web.bind.annotation.RestControllerAdvice;
 public class GlobalExceptionHandler {
 
     @ExceptionHandler(IllegalArgumentException.class)
-    public ResponseEntity<BaseResponse<?>> handleIllegalArgumentException(IllegalArgumentException e, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> handleIllegalArgumentException(
+        IllegalArgumentException e, HttpServletRequest request) {
         request.setAttribute("exception", e);
         return ApiResponseUtil.failure(ErrorMessage.BAD_REQUEST);
     }
 
     @ExceptionHandler(MethodArgumentTypeMismatchException.class)
-    public ResponseEntity<BaseResponse<?>> handleMethodArgumentTypeMismatchException(
-            MethodArgumentTypeMismatchException e, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> handleMethodArgumentTypeMismatchException(
+        MethodArgumentTypeMismatchException e, HttpServletRequest request) {
         request.setAttribute("exception", e);
         return ApiResponseUtil.failure(ErrorMessage.TYPE_MISMATCH);
     }
 
     @ExceptionHandler(UnauthorizedException.class)
-    public ResponseEntity<BaseResponse<?>> handleUnauthorizedException(UnauthorizedException e, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> handleUnauthorizedException(UnauthorizedException e,
+        HttpServletRequest request) {
         request.setAttribute("exception", e);
         return ApiResponseUtil.failure(ErrorMessage.UNAUTHORIZED);
     }
 
     @ExceptionHandler(NotFoundException.class)
-    public ResponseEntity<BaseResponse<?>> handleNotFoundException(NotFoundException e, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> handleNotFoundException(NotFoundException e,
+        HttpServletRequest request) {
         request.setAttribute("exception", e);
         return ApiResponseUtil.failure(ErrorMessage.NOT_FOUND);
     }
 
     @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
-    public ResponseEntity<BaseResponse<?>> handleHttpRequestMethodNotSupportedException(
-            HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> handleHttpRequestMethodNotSupportedException(
+        HttpRequestMethodNotSupportedException e, HttpServletRequest request) {
         request.setAttribute("exception", e);
         return ApiResponseUtil.failure(ErrorMessage.METHOD_NOT_ALLOWED);
     }
 
     @ExceptionHandler(ConflictException.class)
-    public ResponseEntity<BaseResponse<?>> handleConflictException(ConflictException e, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> handleConflictException(ConflictException e,
+        HttpServletRequest request) {
         request.setAttribute("exception", e);
         return ApiResponseUtil.failure(ErrorMessage.CONFLICT);
     }
 
     @ExceptionHandler(ConfetiException.class)
-    public ResponseEntity<BaseResponse<?>> handleConfetiException(ConfetiException e, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> handleConfetiException(ConfetiException e,
+        HttpServletRequest request) {
         request.setAttribute("exception", e);
         return ApiResponseUtil.failure(e.getErrorMessage());
     }
 
     @ExceptionHandler(ConstraintViolationException.class)
-    public ResponseEntity<BaseResponse<?>> handleConstraintViolationException(ConstraintViolationException e, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> handleConstraintViolationException(
+        ConstraintViolationException e, HttpServletRequest request) {
         request.setAttribute("exception", e);
         return ApiResponseUtil.failure(ErrorMessage.BAD_REQUEST);
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<BaseResponse<?>> handleException(Exception e, HttpServletRequest request) {
+    public ResponseEntity<BaseResponse<Void>> handleException(Exception e,
+        HttpServletRequest request) {
         request.setAttribute("exception", e);
         return ApiResponseUtil.failure(ErrorMessage.INTERNAL_SERVER_ERROR);
     }

--- a/src/main/java/org/sopt/confeti/global/util/ApiResponseUtil.java
+++ b/src/main/java/org/sopt/confeti/global/util/ApiResponseUtil.java
@@ -7,20 +7,22 @@ import org.springframework.http.ResponseEntity;
 import reactor.core.publisher.Mono;
 
 public interface ApiResponseUtil {
-    static ResponseEntity<BaseResponse<?>> success(SuccessMessage successMessage) {
+
+    static ResponseEntity<BaseResponse<Void>> success(SuccessMessage successMessage) {
         return ResponseEntity.status(successMessage.getHttpStatus())
-                .body(BaseResponse.of(successMessage));
+            .body(BaseResponse.of(successMessage));
     }
 
-    static <T> ResponseEntity<BaseResponse<?>> success(SuccessMessage successMessage, T data) {
+    static <T> ResponseEntity<BaseResponse<T>> success(SuccessMessage successMessage, T data) {
         return ResponseEntity.status(successMessage.getHttpStatus())
-                .body(BaseResponse.of(successMessage, data));
+            .body(BaseResponse.of(successMessage, data));
     }
 
-    static <T> Mono<ResponseEntity<BaseResponse<?>>> success(SuccessMessage successMessage, Mono<T> data) {
+    static <T> Mono<ResponseEntity<BaseResponse<T>>> success(SuccessMessage successMessage,
+        Mono<T> data) {
         return data.map(result ->
-                ResponseEntity.status(successMessage.getHttpStatus())
-                        .body(BaseResponse.of(successMessage, result))
+            ResponseEntity.status(successMessage.getHttpStatus())
+                .body(BaseResponse.of(successMessage, result))
         );
     }
 

--- a/src/main/java/org/sopt/confeti/global/util/ApiResponseUtil.java
+++ b/src/main/java/org/sopt/confeti/global/util/ApiResponseUtil.java
@@ -26,8 +26,8 @@ public interface ApiResponseUtil {
         );
     }
 
-    static ResponseEntity<BaseResponse<?>> failure(ErrorMessage errorMessage) {
+    static ResponseEntity<BaseResponse<Void>> failure(ErrorMessage errorMessage) {
         return ResponseEntity.status(errorMessage.getHttpStatus())
-                .body(BaseResponse.of(errorMessage));
+            .body(BaseResponse.of(errorMessage));
     }
 }


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- BaseResponse 응답 시 Success, Failure 모두 Type을 지정하도록 변경했습니다.
  - 타입 안정성을 높히기 위함
  - 스웨거 사용 시 정상적인 응답값 매핑을 위함
- 원래는 메서드만 수정하고 각 컨트롤러의 응답에는 스웨거 설정 시 적용하려 했는데 의도대로? 강제 타입 지정이 필요해서 전부 수정해두었습니다. 
  - null일 경우에는 Void를 반환합니다.
- getUpcomingPerformance 의 경우 BaseResponse 의 type argument가 Map 일 수도, UpcomingPerformanceResponse 일 수도 있어서 타입 통일을 하려다가, 4차 스프린트부터 사용되지 않는 API라고 하셔서 우선 Object로 두고 추후 삭제하는 쪽으로 하려합니다
   
## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
