### PR TITLE
CONFETI-39  feat: [온보딩 뷰] 선택한 아티스트 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4.java
@@ -7,6 +7,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.performance.controller.docs.PerformanceControllerV4Docs;
 import org.sopt.confeti.api.performance.dto.request.GetExpectedPerformanceRequest;
 import org.sopt.confeti.api.performance.dto.response.ArtistPerformancesResponse;
 import org.sopt.confeti.api.performance.dto.response.ConcertDetailResponse;
@@ -67,137 +68,146 @@ public class PerformanceControllerV4 implements PerformanceControllerV4Docs {
     @Permission(role = {Role.GENERAL})
     @GetMapping("/concerts/{concertId}")
     public ResponseEntity<BaseResponse<ConcertDetailResponse>> getConcertInfo(
-            @UserId(require = false) Long userId,
-            @PathVariable("concertId") @Min(RequestConstraint.ID) long concertId
+        @UserId(require = false) Long userId,
+        @PathVariable("concertId") @Min(RequestConstraint.ID) long concertId
     ) {
-        ConcertDetailDTO concertDetailDTO = performanceFacade.getConcertDetailInfo(userId, concertId);
+        ConcertDetailDTO concertDetailDTO = performanceFacade.getConcertDetailInfo(userId,
+            concertId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                ConcertDetailResponse.of(concertDetailDTO, s3FileHandler));
+            ConcertDetailResponse.of(concertDetailDTO, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/festivals/{festivalId}")
     public ResponseEntity<BaseResponse<FestivalDetailResponse>> getFestivalInfo(
-            @UserId(require = false) Long userId,
-            @PathVariable("festivalId") @Min(RequestConstraint.ID) Long festivalId
+        @UserId(require = false) Long userId,
+        @PathVariable("festivalId") @Min(RequestConstraint.ID) Long festivalId
     ) {
-        FestivalDetailDTO festivalDetailDTO = performanceFacade.getFestivalDetailInfo(userId, festivalId);
+        FestivalDetailDTO festivalDetailDTO = performanceFacade.getFestivalDetailInfo(userId,
+            festivalId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                FestivalDetailResponse.of(festivalDetailDTO, s3FileHandler));
+            FestivalDetailResponse.of(festivalDetailDTO, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/reservation")
     public ResponseEntity<BaseResponse<PerformanceReservationResponse>> getPerformReservationInfo(
-            @UserId(require = false) Long userId
+        @UserId(require = false) Long userId
     ) {
-        PerformanceReservationDTO performanceReservationDTO = performanceFacade.getPerformReservationInfo(userId);
+        PerformanceReservationDTO performanceReservationDTO = performanceFacade.getPerformReservationInfo(
+            userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                PerformanceReservationResponse.from(performanceReservationDTO));
+            PerformanceReservationResponse.from(performanceReservationDTO));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/association/{artistId}")
     public ResponseEntity<BaseResponse<ArtistPerformancesResponse>> getPerformanceByArtist(
-            @UserId(require = false) Long userId,
-            @PathVariable(name = "artistId") String artistId
+        @UserId(require = false) Long userId,
+        @PathVariable(name = "artistId") String artistId
     ) {
-        ArtistPerformancesDTO performances = performanceFacade.getPerformancesByArtistId(userId, artistId);
+        ArtistPerformancesDTO performances = performanceFacade.getPerformancesByArtistId(userId,
+            artistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                ArtistPerformancesResponse.of(performances, s3FileHandler));
+            ArtistPerformancesResponse.of(performances, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/info")
     public ResponseEntity<BaseResponse<RecentPerformancesResponse>> getRecentPerformances(
-            @UserId(require = false) Long userId
+        @UserId(require = false) Long userId
     ) {
         RecentPerformancesDTO recentPerformances = performanceFacade.getRecentPerformances(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                RecentPerformancesResponse.of(recentPerformances, s3FileHandler));
+            RecentPerformancesResponse.of(recentPerformances, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend")
     public ResponseEntity<BaseResponse<RecommendPerformancesResponse>> getRecommendPerformances(
-            @RequestParam(defaultValue = "5") @Min(1) @Max(20) int limit
+        @RequestParam(defaultValue = "5") @Min(1) @Max(20) int limit
     ) {
-        RecommendPerformancesDTO recommendPerformances = performanceFacade.getRecommendPerformances(limit);
+        RecommendPerformancesDTO recommendPerformances = performanceFacade.getRecommendPerformances(
+            limit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                RecommendPerformancesResponse.of(recommendPerformances, s3FileHandler));
+            RecommendPerformancesResponse.of(recommendPerformances, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/search/ac")
     public ResponseEntity<BaseResponse<SearchACPerformancesResponse>> searchAutoComplete(
-            @UserId(require = false) Long userId,
-            @RequestParam @NotBlank String term,
-            @RequestParam(required = false, defaultValue = "1") @Min(1) @Max(10) Integer limit,
-            @RequestParam(required = false, defaultValue = Default.PERFORMANCE_STATUS) String status
+        @UserId(require = false) Long userId,
+        @RequestParam @NotBlank String term,
+        @RequestParam(required = false, defaultValue = "1") @Min(1) @Max(10) Integer limit,
+        @RequestParam(required = false, defaultValue = Default.PERFORMANCE_STATUS) String status
     ) {
-        SearchACPerformancesDTO performancesDTO = performanceFacade.searchACPerformances(term, limit,
-                PerformanceStatus.convert(status));
+        SearchACPerformancesDTO performancesDTO = performanceFacade.searchACPerformances(term,
+            limit,
+            PerformanceStatus.convert(status));
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                SearchACPerformancesResponse.of(performancesDTO, s3FileHandler));
+            SearchACPerformancesResponse.of(performancesDTO, s3FileHandler));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend/performance")
     public ResponseEntity<BaseResponse<RecommendMusicsPerformanceResponse>> getRecommendPerformanceId(
-            @UserId(require = false) Long userId
+        @UserId(require = false) Long userId
     ) {
         Optional<RecommendMusicsPerformanceDTO> recommendMusicsDTO = performanceFacade.getRecommendPerformanceId(
-                userId);
+            userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                recommendMusicsDTO.map(RecommendMusicsPerformanceResponse::from).orElse(null)
+            recommendMusicsDTO.map(RecommendMusicsPerformanceResponse::from).orElse(null)
         );
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend/musics")
     public ResponseEntity<BaseResponse<RecommendMusicsResponse>> getRecommendMusics(
-            @RequestParam Long performanceId,
-            @RequestParam(required = false) List<String> musicIds
+        @RequestParam Long performanceId,
+        @RequestParam(required = false) List<String> musicIds
     ) {
-        RecommendMusicsDTO recommendMusicsDTO = performanceFacade.getNewRecommendMusics(performanceId, musicIds);
+        RecommendMusicsDTO recommendMusicsDTO = performanceFacade.getNewRecommendMusics(
+            performanceId, musicIds);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                RecommendMusicsResponse.from(recommendMusicsDTO));
+            RecommendMusicsResponse.from(recommendMusicsDTO));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/record")
     public ResponseEntity<BaseResponse<ConfetiRecordResponse>> getConfetiRecord(
-            @UserId Long userId
+        @UserId Long userId
     ) {
         ConfetiRecordDTO recordDTO = performanceFacade.getConfetiRecord(userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                ConfetiRecordResponse.from(recordDTO));
+            ConfetiRecordResponse.from(recordDTO));
     }
 
     @Permission(role = {Role.GENERAL})
     @GetMapping("/expected")
     public ResponseEntity<BaseResponse<ExpectedPerformancesResponse>> getExpectedPerformances(
-            @UserId(require = false) Long userId,
-            @RequestParam String items
+        @UserId(require = false) Long userId,
+        @RequestParam String items
     ) {
-        List<GetExpectedPerformanceRequest> performanceRequests = decodeToExpectedPerformancesRequest(items);
+        List<GetExpectedPerformanceRequest> performanceRequests = decodeToExpectedPerformancesRequest(
+            items);
         ExpectedPerformancesDTO expectedPerformances = performanceFacade.getExpectedPerformances(
-                GetExpectedPerformancesDTO.from(performanceRequests));
+            GetExpectedPerformancesDTO.from(performanceRequests));
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                ExpectedPerformancesResponse.of(expectedPerformances, s3FileHandler));
+            ExpectedPerformancesResponse.of(expectedPerformances, s3FileHandler));
     }
 
-    private List<GetExpectedPerformanceRequest> decodeToExpectedPerformancesRequest(String request) {
+    private List<GetExpectedPerformanceRequest> decodeToExpectedPerformancesRequest(
+        String request) {
         try {
             return Arrays.stream(request.split(","))
-                    .map(item -> {
-                        String[] performance = item.split(":");
-                        return GetExpectedPerformanceRequest.of(
-                                PerformanceType.convert(performance[0].trim()),
-                                Long.parseLong(performance[1].trim())
-                        );
-                    })
-                    .toList();
+                .map(item -> {
+                    String[] performance = item.split(":");
+                    return GetExpectedPerformanceRequest.of(
+                        PerformanceType.convert(performance[0].trim()),
+                        Long.parseLong(performance[1].trim())
+                    );
+                })
+                .toList();
         } catch (Exception e) {
             throw new ConfetiException(ErrorMessage.BAD_REQUEST);
         }
@@ -208,6 +218,6 @@ public class PerformanceControllerV4 implements PerformanceControllerV4Docs {
     public ResponseEntity<BaseResponse<PerformanceIdsResponse>> getPerformances() {
         PerformanceIdsDTO performances = performanceFacade.getPerformances();
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                PerformanceIdsResponse.from(performances));
+            PerformanceIdsResponse.from(performances));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/controller/docs/PerformanceControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/docs/PerformanceControllerV4Docs.java
@@ -1,8 +1,6 @@
-package org.sopt.confeti.api.performance.controller;
+package org.sopt.confeti.api.performance.controller.docs;
 
 import io.swagger.v3.oas.annotations.Operation;
-import io.swagger.v3.oas.annotations.media.Content;
-import io.swagger.v3.oas.annotations.media.Schema;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
@@ -19,22 +17,15 @@ public interface PerformanceControllerV4Docs {
 
     @Operation(summary = "Confeti's pick 추천 공연 조회")
     @ApiResponses(
-            value = {
-                    @ApiResponse(
-                            responseCode = "200",
-                            description = "성공",
-                            content =
-                                    @Content(
-                                            schema =
-                                                    @Schema(
-                                                            implementation = RecommendPerformancesResponse.class
-                                                    )
-                                    )
-                    )
-            }
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
     )
     @CommonErrorResponses
     ResponseEntity<BaseResponse<RecommendPerformancesResponse>> getRecommendPerformances(
-            @RequestParam(defaultValue = "5") @Min(1) @Max(20) int limit
+        @RequestParam(defaultValue = "5") @Min(1) @Max(20) int limit
     );
 }

--- a/src/main/java/org/sopt/confeti/api/performance/controller/docs/PerformanceControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/docs/PerformanceControllerV4Docs.java
@@ -15,7 +15,14 @@ import org.springframework.web.bind.annotation.RequestParam;
 @Tag(name = "공연")
 public interface PerformanceControllerV4Docs {
 
-    @Operation(summary = "Confeti's pick 추천 공연 조회")
+    @Operation(
+            summary = "Confeti's pick 추천 공연 조회",
+            description =
+                    """
+                    V4 변경사항
+                    - 공연 개수를 클라이언트에서 정할 수 있도록 수정 (1 ~ 20, default 5)
+                    """
+    )
     @ApiResponses(
         value = {
             @ApiResponse(

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -85,7 +85,7 @@ public class UserOnboardController {
         @UserId Long userId,
         @PathVariable String artistId
     ) {
-        userOnboardFacade.cacheTopArtist(userId, artistId);
+        userOnboardFacade.cacheExposedArtist(userId, artistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -74,7 +74,6 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
         @RequestParam(required = false, defaultValue = "100") @Min(1) @Max(200) int limit
     ) {
         UserOnboardTopArtistsDTO topArtists = userOnboardFacade.getTopArtists(limit, userId);
-        userOnboardFacade.cacheTopArtistsToUser(userId, topArtists);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             UserOnboardTopArtistsResponse.from(topArtists));
     }

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -1,0 +1,118 @@
+package org.sopt.confeti.api.user.controller;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.controller.docs.UserOnboardControllerV4Docs;
+import org.sopt.confeti.api.user.dto.response.UserOnboardTopArtistsResponse;
+import org.sopt.confeti.api.user.dto.response.onboard.GetOnboardStatusResponse;
+import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;
+import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardRelatedArtistsResponse;
+import org.sopt.confeti.api.user.facade.UserOnboardFacade;
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.GetOnboardStatusDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardFavoriteArtistsDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/user/onboard/v4")
+@Validated
+public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
+
+    private final UserOnboardFacade userOnboardFacade;
+
+    /**
+     * 개발을 위해 임시로 Role.GENERAL 접근 허용
+     */
+    @Permission(role = {Role.ONBOARDING, Role.GENERAL})
+    @GetMapping("/artists/{artistId}/related")
+    public ResponseEntity<BaseResponse<UserOnboardRelatedArtistsResponse>> getRelatedArtists(
+        @UserId Long userId,
+        @PathVariable String artistId,
+        @RequestParam(defaultValue = "1") @Min(1) @Max(30) Integer limit
+    ) {
+        UserOnboardRelatedArtistsDTO relatedArtists = userOnboardFacade.getRelatedArtists(userId,
+            artistId, limit);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserOnboardRelatedArtistsResponse.from(relatedArtists));
+    }
+
+    @GetMapping("/artists/search")
+    public ResponseEntity<BaseResponse<UserOnboardRelatedArtistsResponse>> getArtistsRelatedTerm(
+        @UserId Long userId,
+        @RequestParam String term,
+        @RequestParam(defaultValue = "1") @Min(1) @Max(25) Integer limit
+    ) {
+        UserOnboardRelatedArtistsDTO relatedArtistsDTO = userOnboardFacade.getArtistsRelatedTerm(
+            userId, term, limit);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserOnboardRelatedArtistsResponse.from(relatedArtistsDTO));
+    }
+
+    /**
+     * 개발을 위해 임시로 Role.GENERAL 접근 허용
+     */
+    @Permission(role = {Role.ONBOARDING, Role.GENERAL})
+    @GetMapping("/artists")
+    public ResponseEntity<BaseResponse<UserOnboardTopArtistsResponse>> getTopArtists(
+        @UserId Long userId,
+        @RequestParam(required = false, defaultValue = "100") @Min(1) @Max(200) int limit
+    ) {
+        UserOnboardTopArtistsDTO topArtists = userOnboardFacade.getTopArtists(limit);
+        userOnboardFacade.cacheTopArtistsToUser(userId, topArtists);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserOnboardTopArtistsResponse.from(topArtists));
+    }
+
+    /**
+     * 개발을 위해 임시로 Role.GENERAL 접근 허용
+     */
+    @Permission(role = {Role.ONBOARDING, Role.GENERAL})
+    @PostMapping("/artists/{artistId}")
+    public ResponseEntity<BaseResponse<Void>> addArtist(
+        @UserId Long userId,
+        @PathVariable String artistId
+    ) {
+        userOnboardFacade.cacheTopArtist(userId, artistId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
+    @Permission(role = {Role.ONBOARDING, Role.GENERAL, Role.ADMIN})
+    @GetMapping("/status")
+    public ResponseEntity<BaseResponse<GetOnboardStatusResponse>> getOnboardStatus(
+        @UserId Long userId) {
+        GetOnboardStatusDTO onboardStatusDTO = userOnboardFacade.getOnboardStatus(userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            GetOnboardStatusResponse.from(onboardStatusDTO));
+    }
+
+    /**
+     * 개발을 위해 임시로 Role.GENERAL 접근 허용
+     */
+    @Permission(role = {Role.ONBOARDING, Role.GENERAL})
+    @GetMapping("/artists/favorite")
+    public ResponseEntity<BaseResponse<UserOnboardFavoriteArtistsResponse>> getFavoriteArtists(
+        @UserId Long userId
+    ) {
+        UserOnboardFavoriteArtistsDTO favoriteArtists = userOnboardFacade.getFavoriteArtists(
+            userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserOnboardFavoriteArtistsResponse.from(favoriteArtists));
+    }
+
+}

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -73,7 +73,7 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
         @UserId Long userId,
         @RequestParam(required = false, defaultValue = "100") @Min(1) @Max(200) int limit
     ) {
-        UserOnboardTopArtistsDTO topArtists = userOnboardFacade.getTopArtists(limit);
+        UserOnboardTopArtistsDTO topArtists = userOnboardFacade.getTopArtists(limit, userId);
         userOnboardFacade.cacheTopArtistsToUser(userId, topArtists);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             UserOnboardTopArtistsResponse.from(topArtists));

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -88,7 +88,7 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
         @UserId Long userId,
         @PathVariable String artistId
     ) {
-        userOnboardFacade.cacheTopArtist(userId, artistId);
+        userOnboardFacade.cacheExposedArtist(userId, artistId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
@@ -1,0 +1,29 @@
+package org.sopt.confeti.api.user.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.common.swagger.CommonErrorResponses;
+import org.springframework.http.ResponseEntity;
+
+@Tag(name = "유저 온보딩")
+public interface UserOnboardControllerV4Docs {
+
+    @Operation(summary = "온보딩 진행 중 favorite 으로 선택했던 아티스트 목록 조회")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<UserOnboardFavoriteArtistsResponse>> getFavoriteArtists(
+        Long userId
+    );
+
+}

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
@@ -6,6 +6,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;
 import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.common.swagger.AuthErrorResponses;
 import org.sopt.confeti.global.common.swagger.CommonErrorResponses;
 import org.springframework.http.ResponseEntity;
 
@@ -21,6 +22,7 @@ public interface UserOnboardControllerV4Docs {
             )
         }
     )
+    @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<UserOnboardFavoriteArtistsResponse>> getFavoriteArtists(
         Long userId

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardFavoriteArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardFavoriteArtistResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.api.user.dto.response.onboard;
+
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardFavoriteArtistDTO;
+
+public record UserOnboardFavoriteArtistResponse(
+    String id,
+    String profileUrl,
+    String name
+) {
+
+    public static UserOnboardFavoriteArtistResponse from(UserOnboardFavoriteArtistDTO artistDTO) {
+        return new UserOnboardFavoriteArtistResponse(
+            artistDTO.id(),
+            artistDTO.profileUrl(),
+            artistDTO.name()
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardFavoriteArtistsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardFavoriteArtistsResponse.java
@@ -4,13 +4,13 @@ import java.util.List;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardFavoriteArtistsDTO;
 
 public record UserOnboardFavoriteArtistsResponse(
-    List<UserOnboardFavoriteArtistResponse> favoriteArtistIds
+    List<UserOnboardFavoriteArtistResponse> artists
 ) {
 
     public static UserOnboardFavoriteArtistsResponse from(
         UserOnboardFavoriteArtistsDTO artistsDTO) {
         return new UserOnboardFavoriteArtistsResponse(
-            artistsDTO.favoriteArtistIds().stream()
+            artistsDTO.artists().stream()
                 .map(UserOnboardFavoriteArtistResponse::from)
                 .toList()
         );

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardFavoriteArtistsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardFavoriteArtistsResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.confeti.api.user.dto.response.onboard;
+
+import java.util.List;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardFavoriteArtistsDTO;
+
+public record UserOnboardFavoriteArtistsResponse(
+    List<UserOnboardFavoriteArtistResponse> favoriteArtistIds
+) {
+
+    public static UserOnboardFavoriteArtistsResponse from(
+        UserOnboardFavoriteArtistsDTO artistsDTO) {
+        return new UserOnboardFavoriteArtistsResponse(
+            artistsDTO.favoriteArtistIds().stream()
+                .map(UserOnboardFavoriteArtistResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -73,7 +73,15 @@ public class UserOnboardFacade {
 
     public UserOnboardTopArtistsDTO getTopArtists(int limit, long userId) {
         List<ConfetiArtist> topArtists = getAllTopArtists();
-        return UserOnboardTopArtistsDTO.from(topArtists);
+
+        Set<String> exposedArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
+
+        return UserOnboardTopArtistsDTO.from(
+            topArtists.stream()
+                .filter(artist -> !exposedArtistIds.contains(artist.getId()))
+                .limit(limit)
+                .toList()
+        );
     }
 
     public UserOnboardRelatedArtistsDTO getRelatedArtists(

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -74,14 +74,24 @@ public class UserOnboardFacade {
     public UserOnboardTopArtistsDTO getTopArtists(int limit, long userId) {
         List<ConfetiArtist> topArtists = getAllTopArtists();
 
-        Set<String> exposedArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
+        UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
+        Set<String> favoriteArtistIds = cachedArtists.favoriteArtistIds();
+        Set<String> exposedArtistIds = cachedArtists.exposedArtistIds();
 
-        return UserOnboardTopArtistsDTO.from(
+        UserOnboardTopArtistsDTO userOnboardTopArtistsDTO = UserOnboardTopArtistsDTO.from(
             topArtists.stream()
-                .filter(artist -> !exposedArtistIds.contains(artist.getId()))
+                .filter(artist -> !favoriteArtistIds.contains(artist.getId()))
                 .limit(limit)
                 .toList()
         );
+
+        userOnboardTopArtistsDTO.artists()
+            .forEach(artist -> exposedArtistIds.add(artist.id()));
+
+        userOnboardService.cacheOnboardArtists(userId,
+            UserOnboardCacheDTO.of(favoriteArtistIds, exposedArtistIds));
+
+        return userOnboardTopArtistsDTO;
     }
 
     public UserOnboardRelatedArtistsDTO getRelatedArtists(

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -105,12 +105,12 @@ public class UserOnboardFacade {
         userOnboardService.cacheTopArtists(userId, UserOnboardCacheDTO.from(topArtists));
     }
 
-    public void cacheTopArtist(long userId, String artistId) {
-        Set<String> topArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
-        topArtistIds.add(artistId);
+    public void cacheExposedArtist(long userId, String artistId) {
+        Set<String> exposedArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
+        exposedArtistIds.add(artistId);
 
         userOnboardService.cacheTopArtists(userId,
-            UserOnboardCacheDTO.createWithExposedArtistIds(topArtistIds));
+            UserOnboardCacheDTO.createWithExposedArtistIds(exposedArtistIds));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -118,4 +118,12 @@ public class UserOnboardFacade {
         Role userRole = userService.getRole(userId);
         return GetOnboardStatusDTO.from(userRole);
     }
+
+    public UserOnboardFavoriteArtistsDTO getFavoriteArtists(long userId) {
+        UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
+        List<ConfetiArtist> favoriteArtists = musicAPIHandler.getArtistsByArtistIds(
+            cachedArtists.favoriteArtistIds());
+
+        return UserOnboardFavoriteArtistsDTO.from(favoriteArtists);
+    }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -102,19 +102,20 @@ public class UserOnboardFacade {
         return UserOnboardRelatedArtistsDTO.from(relatedArtists);
     }
 
+    @Deprecated
     public void cacheTopArtistsToUser(Long userId, UserOnboardTopArtistsDTO topArtists) {
         if (!userService.existsById(userId)) {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
 
-        userOnboardService.cacheTopArtists(userId, UserOnboardCacheDTO.from(topArtists));
+        userOnboardService.cacheOnboardArtists(userId, UserOnboardCacheDTO.from(topArtists));
     }
 
     public void cacheExposedArtist(long userId, String artistId) {
         Set<String> exposedArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
         exposedArtistIds.add(artistId);
 
-        userOnboardService.cacheTopArtists(userId,
+        userOnboardService.cacheOnboardArtists(userId,
             UserOnboardCacheDTO.createWithExposedArtistIds(exposedArtistIds));
     }
 
@@ -189,7 +190,7 @@ public class UserOnboardFacade {
         newFavoriteArtistIds.add(requestArtistId);
         newExposedArtistIds.addAll(exposedArtistIds);
 
-        userOnboardService.cacheTopArtists(userId,
+        userOnboardService.cacheOnboardArtists(userId,
             UserOnboardCacheDTO.of(newFavoriteArtistIds, newExposedArtistIds));
     }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,10 +1,13 @@
 package org.sopt.confeti.api.user.facade;
 
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.GetOnboardStatusDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardCacheDTO;
@@ -19,9 +22,12 @@ import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusicArtist;
+import org.sopt.confeti.global.util.RedisKey;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Facade
 @RequiredArgsConstructor
 public class UserOnboardFacade {
@@ -29,9 +35,12 @@ public class UserOnboardFacade {
     private static final int FIXED_RELATED_ARTISTS_FETCH_SIZE = 50;
     private static final int FIXED_SEARCH_ARTISTS_FETCH_SIZE = 25;
 
+    private static final int DEFAULT_TOP_SONGS_FETCH_SIZE = 100;
+
     private final MusicAPIHandler musicAPIHandler;
     private final UserService userService;
     private final UserOnboardService userOnboardService;
+    private final RedisTemplate<String, Object> redisTemplate;
 
     public UserOnboardRelatedArtistsDTO getArtistsRelatedTerm(long userId, String term, int limit) {
         Set<String> topArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
@@ -45,6 +54,7 @@ public class UserOnboardFacade {
         return UserOnboardRelatedArtistsDTO.from(artists);
     }
 
+    @Deprecated
     public UserOnboardTopArtistsDTO getTopArtists(int limit) {
         List<ConfetiMusic> topMusics = musicAPIHandler.getTopMusics(limit);
         Set<String> topMusicIds = topMusics.stream()
@@ -61,8 +71,16 @@ public class UserOnboardFacade {
         return UserOnboardTopArtistsDTO.from(topArtists);
     }
 
-    public UserOnboardRelatedArtistsDTO getRelatedArtists(long userId, String requestArtistId,
-        int limit) {
+    public UserOnboardTopArtistsDTO getTopArtists(int limit, long userId) {
+        List<ConfetiArtist> topArtists = getAllTopArtists();
+        return UserOnboardTopArtistsDTO.from(topArtists);
+    }
+
+    public UserOnboardRelatedArtistsDTO getRelatedArtists(
+        long userId,
+        String requestArtistId,
+        int limit
+    ) {
         UserOnboardCacheDTO cachedOnboardArtists = userOnboardService.getCachedArtists(userId);
 
         List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
@@ -74,27 +92,6 @@ public class UserOnboardFacade {
         cacheRelatedArtists(userId, requestArtistId, cachedOnboardArtists, relatedArtists);
 
         return UserOnboardRelatedArtistsDTO.from(relatedArtists);
-    }
-
-    private void cacheRelatedArtists(
-        long userId,
-        String requestArtistId,
-        UserOnboardCacheDTO userOnboardCacheDTO,
-        List<ConfetiArtist> artists
-    ) {
-
-        Set<String> newFavoriteArtistIds = new HashSet<>(userOnboardCacheDTO.favoriteArtistIds());
-        Set<String> newExposedArtistIds = new HashSet<>(userOnboardCacheDTO.exposedArtistIds());
-
-        List<String> exposedArtistIds = artists.stream()
-            .map(ConfetiArtist::getId)
-            .toList();
-
-        newFavoriteArtistIds.add(requestArtistId);
-        newExposedArtistIds.addAll(exposedArtistIds);
-
-        userOnboardService.cacheTopArtists(userId,
-            UserOnboardCacheDTO.of(newFavoriteArtistIds, newExposedArtistIds));
     }
 
     public void cacheTopArtistsToUser(Long userId, UserOnboardTopArtistsDTO topArtists) {
@@ -126,4 +123,66 @@ public class UserOnboardFacade {
 
         return UserOnboardFavoriteArtistsDTO.from(favoriteArtists);
     }
+
+    public void cacheTopArtists(List<ConfetiArtist> topArtists) {
+        redisTemplate.opsForValue().set(RedisKey.MUSIC_TOP_ARTISTS.get(), topArtists);
+    }
+
+    /**
+     * MUSIC_TOP_ARTISTS 캐시는 항상 List<ConfetiArtist> 타입을 캐싱하므로 unchecked 하도록 함
+     */
+    @SuppressWarnings("unchecked")
+    private List<ConfetiArtist> getAllTopArtists() {
+        Object cachedTopArtists = redisTemplate.opsForValue().get(RedisKey.MUSIC_TOP_ARTISTS);
+
+        if (!Objects.isNull(cachedTopArtists) &&
+            (cachedTopArtists instanceof Collection<?> topArtists && !topArtists.isEmpty())) {
+            try {
+                return (List<ConfetiArtist>) topArtists;
+            } catch (ClassCastException e) {
+                log.error("[Casting Exception]", e);
+            }
+        }
+
+        return fetchAllTopArtists();
+    }
+
+    private List<ConfetiArtist> fetchAllTopArtists() {
+        List<ConfetiMusic> topMusics = musicAPIHandler.getTopMusics(DEFAULT_TOP_SONGS_FETCH_SIZE);
+        Set<String> topMusicIds = topMusics.stream()
+            .map(ConfetiMusic::getId)
+            .collect(Collectors.toSet());
+
+        List<ConfetiMusic> topMusicsWithArtists = musicAPIHandler.getMusicsByMusicIds(topMusicIds);
+        Set<String> topArtistIds = topMusicsWithArtists.stream()
+            .flatMap(music -> music.getArtists().stream())
+            .map(ConfetiMusicArtist::getId)
+            .collect(Collectors.toSet());
+
+        List<ConfetiArtist> topArtists = musicAPIHandler.getArtistsByArtistIds(topArtistIds);
+        cacheTopArtists(topArtists);
+        return topArtists;
+    }
+
+    private void cacheRelatedArtists(
+        long userId,
+        String requestArtistId,
+        UserOnboardCacheDTO userOnboardCacheDTO,
+        List<ConfetiArtist> artists
+    ) {
+
+        Set<String> newFavoriteArtistIds = new HashSet<>(userOnboardCacheDTO.favoriteArtistIds());
+        Set<String> newExposedArtistIds = new HashSet<>(userOnboardCacheDTO.exposedArtistIds());
+
+        List<String> exposedArtistIds = artists.stream()
+            .map(ConfetiArtist::getId)
+            .toList();
+
+        newFavoriteArtistIds.add(requestArtistId);
+        newExposedArtistIds.addAll(exposedArtistIds);
+
+        userOnboardService.cacheTopArtists(userId,
+            UserOnboardCacheDTO.of(newFavoriteArtistIds, newExposedArtistIds));
+    }
+
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -122,11 +122,14 @@ public class UserOnboardFacade {
     }
 
     public void cacheExposedArtist(long userId, String artistId) {
-        Set<String> exposedArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
+        UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
+        Set<String> favoriteArtistIds = cachedArtists.favoriteArtistIds();
+        Set<String> exposedArtistIds = cachedArtists.exposedArtistIds();
+
         exposedArtistIds.add(artistId);
 
         userOnboardService.cacheOnboardArtists(userId,
-            UserOnboardCacheDTO.createWithExposedArtistIds(exposedArtistIds));
+            UserOnboardCacheDTO.of(favoriteArtistIds, exposedArtistIds));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,15 +1,17 @@
 package org.sopt.confeti.api.user.facade;
 
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.GetOnboardStatusDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardCacheDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardFavoriteArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
 import org.sopt.confeti.domain.user.application.UserOnboardService;
 import org.sopt.confeti.domain.user.application.UserService;
-import org.sopt.confeti.domain.user.application.dto.request.UserOnboardCacheTopArtistsDTO;
 import org.sopt.confeti.domain.user.constant.Role;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.exception.NotFoundException;
@@ -32,12 +34,13 @@ public class UserOnboardFacade {
     private final UserOnboardService userOnboardService;
 
     public UserOnboardRelatedArtistsDTO getArtistsRelatedTerm(long userId, String term, int limit) {
-        Set<String> topArtistIds = userOnboardService.getCachedTopArtists(userId);
-        List<ConfetiArtist> artists = musicAPIHandler.findArtistsByKeyword(term, FIXED_SEARCH_ARTISTS_FETCH_SIZE)
-                .stream()
-                .filter(artist -> !topArtistIds.contains(artist.getId()))
-                .limit(limit)
-                .toList();
+        Set<String> topArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
+        List<ConfetiArtist> artists = musicAPIHandler.findArtistsByKeyword(term,
+                FIXED_SEARCH_ARTISTS_FETCH_SIZE)
+            .stream()
+            .filter(artist -> !topArtistIds.contains(artist.getId()))
+            .limit(limit)
+            .toList();
 
         return UserOnboardRelatedArtistsDTO.from(artists);
     }
@@ -45,30 +48,53 @@ public class UserOnboardFacade {
     public UserOnboardTopArtistsDTO getTopArtists(int limit) {
         List<ConfetiMusic> topMusics = musicAPIHandler.getTopMusics(limit);
         Set<String> topMusicIds = topMusics.stream()
-                .map(ConfetiMusic::getId)
-                .collect(Collectors.toSet());
+            .map(ConfetiMusic::getId)
+            .collect(Collectors.toSet());
 
         List<ConfetiMusic> topMusicsWithArtists = musicAPIHandler.getMusicsByMusicIds(topMusicIds);
         Set<String> topArtistIds = topMusicsWithArtists.stream()
-                .flatMap(music -> music.getArtists().stream())
-                .map(ConfetiMusicArtist::getId)
-                .collect(Collectors.toSet());
+            .flatMap(music -> music.getArtists().stream())
+            .map(ConfetiMusicArtist::getId)
+            .collect(Collectors.toSet());
 
         List<ConfetiArtist> topArtists = musicAPIHandler.getArtistsByArtistIds(topArtistIds);
         return UserOnboardTopArtistsDTO.from(topArtists);
     }
 
-    public UserOnboardRelatedArtistsDTO getRelatedArtists(long userId, String artistId, int limit) {
-        Set<String> topArtistIds = userOnboardService.getCachedTopArtists(userId);
-        List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(artistId,
-                        FIXED_RELATED_ARTISTS_FETCH_SIZE).stream()
-                .filter(artist -> !topArtistIds.contains(artist.getId()))
-                .limit(limit)
-                .toList();
+    public UserOnboardRelatedArtistsDTO getRelatedArtists(long userId, String requestArtistId,
+        int limit) {
+        UserOnboardCacheDTO cachedOnboardArtists = userOnboardService.getCachedArtists(userId);
 
-        cacheTopArtists(userId, relatedArtists);
+        List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
+                FIXED_RELATED_ARTISTS_FETCH_SIZE).stream()
+            .filter(artist -> !cachedOnboardArtists.exposedArtistIds().contains(artist.getId()))
+            .limit(limit)
+            .toList();
+
+        cacheRelatedArtists(userId, requestArtistId, cachedOnboardArtists, relatedArtists);
 
         return UserOnboardRelatedArtistsDTO.from(relatedArtists);
+    }
+
+    private void cacheRelatedArtists(
+        long userId,
+        String requestArtistId,
+        UserOnboardCacheDTO userOnboardCacheDTO,
+        List<ConfetiArtist> artists
+    ) {
+
+        Set<String> newFavoriteArtistIds = new HashSet<>(userOnboardCacheDTO.favoriteArtistIds());
+        Set<String> newExposedArtistIds = new HashSet<>(userOnboardCacheDTO.exposedArtistIds());
+
+        List<String> exposedArtistIds = artists.stream()
+            .map(ConfetiArtist::getId)
+            .toList();
+
+        newFavoriteArtistIds.add(requestArtistId);
+        newExposedArtistIds.addAll(exposedArtistIds);
+
+        userOnboardService.cacheTopArtists(userId,
+            UserOnboardCacheDTO.of(newFavoriteArtistIds, newExposedArtistIds));
     }
 
     public void cacheTopArtistsToUser(Long userId, UserOnboardTopArtistsDTO topArtists) {
@@ -76,24 +102,15 @@ public class UserOnboardFacade {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
 
-        userOnboardService.cacheTopArtists(userId, UserOnboardCacheTopArtistsDTO.from(topArtists));
+        userOnboardService.cacheTopArtists(userId, UserOnboardCacheDTO.from(topArtists));
     }
 
     public void cacheTopArtist(long userId, String artistId) {
-        Set<String> topArtistIds = userOnboardService.getCachedTopArtists(userId);
+        Set<String> topArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
         topArtistIds.add(artistId);
-        userOnboardService.cacheTopArtists(userId, UserOnboardCacheTopArtistsDTO.from(topArtistIds));
-    }
 
-    private void cacheTopArtists(long userId, List<ConfetiArtist> artists) {
-        Set<String> topArtistIds = userOnboardService.getCachedTopArtists(userId);
-
-        List<String> artistIds = artists.stream()
-                .map(ConfetiArtist::getId)
-                .toList();
-        topArtistIds.addAll(artistIds);
-
-        userOnboardService.cacheTopArtists(userId, UserOnboardCacheTopArtistsDTO.from(topArtistIds));
+        userOnboardService.cacheTopArtists(userId,
+            UserOnboardCacheDTO.createWithExposedArtistIds(topArtistIds));
     }
 
     @Transactional(readOnly = true)

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -1,0 +1,32 @@
+package org.sopt.confeti.api.user.facade.dto.response.onboard;
+
+import java.util.Collections;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+
+public record UserOnboardCacheDTO(
+    Set<String> favoriteArtistIds,
+    Set<String> exposedArtistIds
+) {
+
+    public static UserOnboardCacheDTO createWithExposedArtistIds(Set<String> exposedArtistIds) {
+        return new UserOnboardCacheDTO(Collections.emptySet(), exposedArtistIds);
+    }
+
+    public static UserOnboardCacheDTO from(UserOnboardTopArtistsDTO topArtists) {
+        return createWithExposedArtistIds(
+            topArtists.artists().stream()
+                .map(UserOnboardTopArtistDTO::id)
+                .collect(Collectors.toSet())
+        );
+    }
+
+    public static UserOnboardCacheDTO of(
+        Set<String> favoriteArtistIds,
+        Set<String> exposedArtistIds
+    ) {
+        return new UserOnboardCacheDTO(favoriteArtistIds, exposedArtistIds);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardFavoriteArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardFavoriteArtistDTO.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.api.user.facade.dto.response.onboard;
+
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardFavoriteArtistDTO(
+    String id,
+    String profileUrl,
+    String name
+) {
+
+    public static UserOnboardFavoriteArtistDTO from(ConfetiArtist confetiArtist) {
+        return new UserOnboardFavoriteArtistDTO(
+            confetiArtist.getId(),
+            confetiArtist.getProfileUrl(),
+            confetiArtist.getName()
+        );
+    }
+
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardFavoriteArtistsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardFavoriteArtistsDTO.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.facade.dto.response.onboard;
+
+import java.util.List;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardFavoriteArtistsDTO(
+    List<UserOnboardFavoriteArtistDTO> favoriteArtistIds
+) {
+
+    public static UserOnboardFavoriteArtistsDTO from(List<ConfetiArtist> confetiArtists) {
+        return new UserOnboardFavoriteArtistsDTO(
+            confetiArtists.stream()
+                .map(UserOnboardFavoriteArtistDTO::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardFavoriteArtistsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardFavoriteArtistsDTO.java
@@ -4,7 +4,7 @@ import java.util.List;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 
 public record UserOnboardFavoriteArtistsDTO(
-    List<UserOnboardFavoriteArtistDTO> favoriteArtistIds
+    List<UserOnboardFavoriteArtistDTO> artists
 ) {
 
     public static UserOnboardFavoriteArtistsDTO from(List<ConfetiArtist> confetiArtists) {

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.domain.user.application;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collections;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +42,11 @@ public class UserOnboardService {
     }
 
     public Set<String> getCachedExposedArtistIds(long userId) {
-        return getCachedArtists(userId).exposedArtistIds();
+        try {
+            return getCachedArtists(userId).exposedArtistIds();
+        } catch (NotFoundException e) {
+            return Collections.emptySet();
+        }
     }
 
     public void cacheTopArtists(long userId, UserOnboardCacheDTO artistsDTO) {

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
@@ -49,7 +49,7 @@ public class UserOnboardService {
         }
     }
 
-    public void cacheTopArtists(long userId, UserOnboardCacheDTO artistsDTO) {
+    public void cacheOnboardArtists(long userId, UserOnboardCacheDTO artistsDTO) {
         redisTemplate.opsForValue().set("TEST:" + userId, "test", REDIS_TTL_DAY, TimeUnit.DAYS);
         redisTemplate.opsForValue()
             .set(generateRedisKey(userId), artistsDTO, REDIS_TTL_DAY, TimeUnit.DAYS);

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
@@ -50,7 +50,6 @@ public class UserOnboardService {
     }
 
     public void cacheOnboardArtists(long userId, UserOnboardCacheDTO artistsDTO) {
-        redisTemplate.opsForValue().set("TEST:" + userId, "test", REDIS_TTL_DAY, TimeUnit.DAYS);
         redisTemplate.opsForValue()
             .set(generateRedisKey(userId), artistsDTO, REDIS_TTL_DAY, TimeUnit.DAYS);
     }

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
@@ -1,13 +1,12 @@
 package org.sopt.confeti.domain.user.application;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.confeti.domain.user.application.dto.request.UserOnboardCacheTopArtistsDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardCacheDTO;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -29,7 +28,7 @@ public class UserOnboardService {
         return String.format(REDIS_KEY_PREFIX, userId);
     }
 
-    public Set<String> getCachedTopArtists(long userId) {
+    public UserOnboardCacheDTO getCachedArtists(long userId) {
         String key = generateRedisKey(userId);
 
         Object raw = redisTemplate.opsForValue().get(key);
@@ -38,13 +37,17 @@ public class UserOnboardService {
             throw new NotFoundException(ErrorMessage.NOT_FOUND);
         }
 
-        return objectMapper.convertValue(raw, new TypeReference<>() {
-        });
+        return objectMapper.convertValue(raw, UserOnboardCacheDTO.class);
     }
 
-    public void cacheTopArtists(long userId, UserOnboardCacheTopArtistsDTO artistsDTO) {
+    public Set<String> getCachedExposedArtistIds(long userId) {
+        return getCachedArtists(userId).exposedArtistIds();
+    }
+
+    public void cacheTopArtists(long userId, UserOnboardCacheDTO artistsDTO) {
         redisTemplate.opsForValue().set("TEST:" + userId, "test", REDIS_TTL_DAY, TimeUnit.DAYS);
-        redisTemplate.opsForValue().set(generateRedisKey(userId), artistsDTO.artistIds(), REDIS_TTL_DAY, TimeUnit.DAYS);
+        redisTemplate.opsForValue()
+            .set(generateRedisKey(userId), artistsDTO, REDIS_TTL_DAY, TimeUnit.DAYS);
     }
 
     public void flushCachedTopArtists(long userId) {

--- a/src/main/java/org/sopt/confeti/global/common/BaseResponse.java
+++ b/src/main/java/org/sopt/confeti/global/common/BaseResponse.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.global.common;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.message.SuccessMessage;
@@ -12,6 +13,8 @@ public class BaseResponse<T> {
     private final String message;
     @JsonInclude(value = JsonInclude.Include.NON_NULL)
     private final T data;
+
+    @Schema(hidden = true)
     @JsonInclude(value = JsonInclude.Include.NON_DEFAULT)
     private final Exception exception;
 
@@ -80,4 +83,3 @@ public class BaseResponse<T> {
         }
     }
 }
-

--- a/src/main/java/org/sopt/confeti/global/config/ThreadPoolConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/ThreadPoolConfig.java
@@ -9,6 +9,9 @@ import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 public class ThreadPoolConfig {
 
     public static final String SQS_WORKER_PREFIX = "sqs-worker-";
+    public static final String SQS_WORKER_PROVIDER_PREFIX = SQS_WORKER_PREFIX + "provider-";
+    public static final String SQS_WORKER_CONSUMER_PREFIX = SQS_WORKER_PREFIX + "consumer-";
+
     public static final String MESSAGE_PROVIDER_POOL = "providerThreadPool";
     public static final String MESSAGE_CONSUMER_POOL = "consumerThreadPool";
 
@@ -17,7 +20,7 @@ public class ThreadPoolConfig {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 
         MessageExecutionThreadFactory threadFactory = new MessageExecutionThreadFactory();
-        threadFactory.setThreadNamePrefix(SQS_WORKER_PREFIX);
+        threadFactory.setThreadNamePrefix(SQS_WORKER_PROVIDER_PREFIX);
         executor.setThreadFactory(threadFactory);
 
         executor.setCorePoolSize(20);
@@ -32,7 +35,7 @@ public class ThreadPoolConfig {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
 
         MessageExecutionThreadFactory threadFactory = new MessageExecutionThreadFactory();
-        threadFactory.setThreadNamePrefix(SQS_WORKER_PREFIX);
+        threadFactory.setThreadNamePrefix(SQS_WORKER_CONSUMER_PREFIX);
         executor.setThreadFactory(threadFactory);
 
         executor.setCorePoolSize(20);

--- a/src/main/java/org/sopt/confeti/global/util/RedisKey.java
+++ b/src/main/java/org/sopt/confeti/global/util/RedisKey.java
@@ -13,6 +13,7 @@ public enum RedisKey {
     MUSIC_ARTISTS_TOP_MUSICS("apple-music-api:artists:top-musics:%s"),
     MUSIC_MUSICS("apple-music-api:musics:%s"),
     MUSIC_TOP_MUSICS("apple-music-api:top-musics"),
+    MUSIC_TOP_ARTISTS("apple-music-api:top-artists"),
     MUSIC_PAGE_ARTIST_OFFSET_LIMIT("apple-music-api:music-page:artists:%s:%d:%d"),
     MUSIC_PAGE_KEYWORD_OFFSET_LIMIT("apple-music-api:music-page:keyword:%s:%d:%d"),
 


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->

- 기존 온보딩에서 이전에 조회했던 아티스트 목록을 set으로 관리하던 부분을 UserOnboardCacheDTO 객체로 변경하여 선택한(==좋아요 누른) 아티스트 목록, 조회했던 아티스트 목록을 하나의 레코드에서 관리하도록 변경
  - 변경 이유는
  1. 온보딩 진행 중에 유저 이탈
  2. 이후 해당 유저가 다시 온보딩 진입 시 좋아요를 눌렀었던 목록은 없는데, 이전에 조회했던 아티스트 목록만 redis에 남아서 제대로 온보딩이 불가할 수 있었음
  - 위 상황을 방지하기 위해 선택한 아티스트와 조회했던 아티스트 목록을 한번에 관리함 
- 선택한(==좋아요 누른) 아티스트 목록을 조회하는 API 추가

- topArtist를 가져올 때 캐시를 사용하도록 변경
  - apple-music-api:top-artists 캐시 추가
  - topArtist 를 가져올 경우 우선적으로 캐시를 확인함
  - topArtist 가 캐싱되어 있지 않아 AppleMusicApi 로 가져올 경우 캐싱하는 로직 추가
- topArtist를 가져올 때 기존에 유저가 조회했던 아티스트 목록은 제외하도록 변경

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
