### PR TITLE
CONFETI-36 feat: [홈 뷰] 공연 미리듣기 조회 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -146,6 +146,7 @@ public class PerformanceController {
             SearchACPerformancesResponse.of(performancesDTO, s3FileHandler));
     }
 
+    @Deprecated
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend/performance")
     public ResponseEntity<BaseResponse<RecommendMusicsPerformanceResponse>> getRecommendPerformanceId(
@@ -158,6 +159,7 @@ public class PerformanceController {
         );
     }
 
+    @Deprecated
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend/musics")
     public ResponseEntity<BaseResponse<RecommendMusicsResponse>> getRecommendMusics(

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceController.java
@@ -59,6 +59,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 @Validated
 @RequestMapping("/performances")
+@Deprecated
 public class PerformanceController {
 
     private final PerformanceFacade performanceFacade;

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4.java
@@ -5,7 +5,6 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.dto.request.GetExpectedPerformanceRequest;
 import org.sopt.confeti.api.performance.dto.response.ArtistPerformancesResponse;
@@ -17,8 +16,6 @@ import org.sopt.confeti.api.performance.dto.response.PerformanceIdsResponse;
 import org.sopt.confeti.api.performance.dto.response.PerformanceReservationResponse;
 import org.sopt.confeti.api.performance.dto.response.PerformancesRecommendResponse;
 import org.sopt.confeti.api.performance.dto.response.RecentPerformancesResponse;
-import org.sopt.confeti.api.performance.dto.response.RecommendMusicsPerformanceResponse;
-import org.sopt.confeti.api.performance.dto.response.RecommendMusicsResponse;
 import org.sopt.confeti.api.performance.dto.response.RecommendPerformancesResponse;
 import org.sopt.confeti.api.performance.dto.response.SearchACPerformancesResponse;
 import org.sopt.confeti.api.performance.facade.PerformanceFacade;
@@ -32,8 +29,6 @@ import org.sopt.confeti.api.performance.facade.dto.response.PerformanceIdsDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformancesRecommendDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsDTO;
-import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsPerformanceDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.SearchACPerformancesDTO;
 import org.sopt.confeti.domain.user.constant.Role;
@@ -144,9 +139,12 @@ public class PerformanceControllerV4 implements PerformanceControllerV4Docs {
     }
 
     @Permission(role = {Role.GENERAL})
-    @GetMapping("/music/recommend")
-    public ResponseEntity<BaseResponse<PerformancesRecommendResponse>> getMusicRecommend() {
-        PerformancesRecommendDTO performancesRecommendDTO = performanceFacade.getPerformancesRecommend();
+    @GetMapping("/song/recommend")
+    public ResponseEntity<BaseResponse<PerformancesRecommendResponse>> getSongRecommend(
+            @RequestParam(defaultValue = "3") @Min(1) @Max(5) Integer performanceLimit,
+            @RequestParam(defaultValue = "3") @Min(1) @Max(5) Integer songLimit
+    ) {
+        PerformancesRecommendDTO performancesRecommendDTO = performanceFacade.getPerformancesRecommend(performanceLimit, songLimit);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 PerformancesRecommendResponse.of(performancesRecommendDTO, s3FileHandler)
         );

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4.java
@@ -15,6 +15,7 @@ import org.sopt.confeti.api.performance.dto.response.ExpectedPerformancesRespons
 import org.sopt.confeti.api.performance.dto.response.FestivalDetailResponse;
 import org.sopt.confeti.api.performance.dto.response.PerformanceIdsResponse;
 import org.sopt.confeti.api.performance.dto.response.PerformanceReservationResponse;
+import org.sopt.confeti.api.performance.dto.response.PerformancesRecommendResponse;
 import org.sopt.confeti.api.performance.dto.response.RecentPerformancesResponse;
 import org.sopt.confeti.api.performance.dto.response.RecommendMusicsPerformanceResponse;
 import org.sopt.confeti.api.performance.dto.response.RecommendMusicsResponse;
@@ -29,6 +30,7 @@ import org.sopt.confeti.api.performance.facade.dto.response.ExpectedPerformances
 import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceIdsDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.PerformancesRecommendDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsPerformanceDTO;
@@ -131,7 +133,7 @@ public class PerformanceControllerV4 implements PerformanceControllerV4Docs {
     @GetMapping("/search/ac")
     public ResponseEntity<BaseResponse<SearchACPerformancesResponse>> searchAutoComplete(
             @UserId(require = false) Long userId,
-            @RequestParam @NotBlank String term,
+            @RequestParam @NotBlank  String term,
             @RequestParam(required = false, defaultValue = "1") @Min(1) @Max(10) Integer limit,
             @RequestParam(required = false, defaultValue = Default.PERFORMANCE_STATUS) String status
     ) {
@@ -141,6 +143,7 @@ public class PerformanceControllerV4 implements PerformanceControllerV4Docs {
                 SearchACPerformancesResponse.of(performancesDTO, s3FileHandler));
     }
 
+    @Deprecated
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend/performance")
     public ResponseEntity<BaseResponse<RecommendMusicsPerformanceResponse>> getRecommendPerformanceId(
@@ -153,6 +156,7 @@ public class PerformanceControllerV4 implements PerformanceControllerV4Docs {
         );
     }
 
+    @Deprecated
     @Permission(role = {Role.GENERAL})
     @GetMapping("/recommend/musics")
     public ResponseEntity<BaseResponse<RecommendMusicsResponse>> getRecommendMusics(
@@ -162,6 +166,15 @@ public class PerformanceControllerV4 implements PerformanceControllerV4Docs {
         RecommendMusicsDTO recommendMusicsDTO = performanceFacade.getNewRecommendMusics(performanceId, musicIds);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
                 RecommendMusicsResponse.from(recommendMusicsDTO));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/music/recommend")
+    public ResponseEntity<BaseResponse<PerformancesRecommendResponse>> getMusicRecommend() {
+        PerformancesRecommendDTO performancesRecommendDTO = performanceFacade.getPerformancesRecommend();
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+                PerformancesRecommendResponse.of(performancesRecommendDTO, s3FileHandler)
+        );
     }
 
     @Permission(role = {Role.GENERAL})

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4.java
@@ -143,31 +143,6 @@ public class PerformanceControllerV4 implements PerformanceControllerV4Docs {
                 SearchACPerformancesResponse.of(performancesDTO, s3FileHandler));
     }
 
-    @Deprecated
-    @Permission(role = {Role.GENERAL})
-    @GetMapping("/recommend/performance")
-    public ResponseEntity<BaseResponse<RecommendMusicsPerformanceResponse>> getRecommendPerformanceId(
-            @UserId(require = false) Long userId
-    ) {
-        Optional<RecommendMusicsPerformanceDTO> recommendMusicsDTO = performanceFacade.getRecommendPerformanceId(
-                userId);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                recommendMusicsDTO.map(RecommendMusicsPerformanceResponse::from).orElse(null)
-        );
-    }
-
-    @Deprecated
-    @Permission(role = {Role.GENERAL})
-    @GetMapping("/recommend/musics")
-    public ResponseEntity<BaseResponse<RecommendMusicsResponse>> getRecommendMusics(
-            @RequestParam Long performanceId,
-            @RequestParam(required = false) List<String> musicIds
-    ) {
-        RecommendMusicsDTO recommendMusicsDTO = performanceFacade.getNewRecommendMusics(performanceId, musicIds);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-                RecommendMusicsResponse.from(recommendMusicsDTO));
-    }
-
     @Permission(role = {Role.GENERAL})
     @GetMapping("/music/recommend")
     public ResponseEntity<BaseResponse<PerformancesRecommendResponse>> getMusicRecommend() {

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4Docs.java
@@ -8,10 +8,15 @@ import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import org.sopt.confeti.api.performance.dto.response.PerformancesRecommendResponse;
 import org.sopt.confeti.api.performance.dto.response.RecommendPerformancesResponse;
+import org.sopt.confeti.api.performance.facade.dto.response.PerformancesRecommendDTO;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.common.swagger.CommonErrorResponses;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "공연")
@@ -37,4 +42,25 @@ public interface PerformanceControllerV4Docs {
     ResponseEntity<BaseResponse<RecommendPerformancesResponse>> getRecommendPerformances(
             @RequestParam(defaultValue = "5") @Min(1) @Max(20) int limit
     );
+
+    @Operation(
+            summary = "공연 미리듣기 조회",
+            description =
+                    """
+                    V4 변경사항
+                    - 랜덤한 공연 3개, 각 공연 당 랜덤한 음악 3개를 조회
+                    - 공연이 3개 이하일 수도, 음악이 3개 이하일 수도 있음
+                    - 아예 조회된 값이 없을 수도 있음        
+                    """
+    )
+    @ApiResponses(
+            value = {
+                    @ApiResponse(
+                            responseCode = "200",
+                            description = "성공"
+                    )
+            }
+    )
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<PerformancesRecommendResponse>> getMusicRecommend();
 }

--- a/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/performance/controller/PerformanceControllerV4Docs.java
@@ -62,5 +62,8 @@ public interface PerformanceControllerV4Docs {
             }
     )
     @CommonErrorResponses
-    ResponseEntity<BaseResponse<PerformancesRecommendResponse>> getMusicRecommend();
+    ResponseEntity<BaseResponse<PerformancesRecommendResponse>> getSongRecommend(
+            @RequestParam(defaultValue = "3") @Min(1) @Max(5) Integer performanceLimit,
+            @RequestParam(defaultValue = "3") @Min(1) @Max(5) Integer songLimit
+    );
 }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/PerformanceRecommendResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/PerformanceRecommendResponse.java
@@ -1,0 +1,28 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.api.performance.facade.dto.response.PerformanceRecommendDTO;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record PerformanceRecommendResponse(
+        long typeId,
+        String type,
+        String title,
+        String posterUrl,
+        List<SongRecommendResponse> songs
+) {
+    public static PerformanceRecommendResponse of(PerformanceRecommendDTO performance, S3FileHandler s3FileHandler) {
+        FolderPath topFolder = FolderPath.getFolderPathByPerformanceType(performance.type());
+
+        return new PerformanceRecommendResponse(
+                performance.typeId(),
+                performance.type().getName(),
+                performance.title(),
+                s3FileHandler.getFileUrl(FolderPath.combine(topFolder, FolderPath.POSTER), performance.posterPath()).toString(),
+                performance.songs().stream()
+                        .map(SongRecommendResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/PerformancesRecommendResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/PerformancesRecommendResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.api.performance.facade.dto.response.PerformancesRecommendDTO;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record PerformancesRecommendResponse(
+        List<PerformanceRecommendResponse> performances
+) {
+    public static PerformancesRecommendResponse of(PerformancesRecommendDTO performances, S3FileHandler s3FileHandler) {
+        return new PerformancesRecommendResponse(
+                performances.performances().stream()
+                        .map(performance -> PerformanceRecommendResponse.of(performance, s3FileHandler))
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/SongRecommendResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/SongRecommendResponse.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.api.performance.dto.response;
+
+import org.sopt.confeti.api.performance.facade.dto.response.SongRecommendDTO;
+
+public record SongRecommendResponse(
+        String id,
+        String artistName,
+        String artworkUrl,
+        String previewUrl
+) {
+    public static SongRecommendResponse from(SongRecommendDTO song) {
+        return new SongRecommendResponse(
+                song.id(),
+                song.artistName(),
+                song.artworkUrl(),
+                song.previewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.api.performance.facade;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -10,8 +11,10 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Random;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.performance.facade.dto.request.GetExpectedPerformancesDTO;
@@ -22,12 +25,15 @@ import org.sopt.confeti.api.performance.facade.dto.response.ConfetiRecordDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ExpectedPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceIdsDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.PerformanceRecommendDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.PerformancesRecommendDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendMusicsPerformanceDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecommendPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.SearchACPerformancesDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.SongRecommendDTO;
 import org.sopt.confeti.domain.artist_favorite.ArtistFavorite;
 import org.sopt.confeti.domain.artist_favorite.application.ArtistFavoriteService;
 import org.sopt.confeti.domain.concert.Concert;
@@ -45,6 +51,7 @@ import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceArtist;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceArtistDTO;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.common.constant.PerformanceStatus;
@@ -52,6 +59,7 @@ import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.transaction.annotation.Transactional;
@@ -63,6 +71,9 @@ public class PerformanceFacade {
 
     private static final int RECENT_PERFORMANCES_SIZE = 7;
     private static final int RECOMMEND_MUSIC_SIZE = 3;
+    private static final int RECOMMEND_SONG_SIZE = 3;
+    private static final int RECOMMEND_SONG_FETCH_SIZE = 20;
+    private static final int RECOMMEND_PERFORMANCE_SIZE = 3;
     private static final boolean PERSONALIZED = true;
     private static final boolean UNPERSONALIZED = false;
 
@@ -380,5 +391,42 @@ public class PerformanceFacade {
         return PerformanceIdsDTO.from(
                 performanceService.getPerformances()
         );
+    }
+
+    public PerformancesRecommendDTO getPerformancesRecommend() {
+        List<PerformanceRecommendDTO> performancesRecommend = performanceService.getRandomPerformances(RECOMMEND_PERFORMANCE_SIZE).stream()
+                .map(this::getPerformanceRecommend)
+                .toList();
+
+        return PerformancesRecommendDTO.from(performancesRecommend);
+    }
+
+    private PerformanceRecommendDTO getPerformanceRecommend(PerformanceDTO performance) {
+        List<SongRecommendDTO> songsRecommend = getSongsRecommend(
+                performanceService.getRandomPerformanceArtists(performance.id(), RECOMMEND_SONG_SIZE)
+        );
+
+        return PerformanceRecommendDTO.of(performance, songsRecommend);
+    }
+
+    private List<SongRecommendDTO> getSongsRecommend(List<PerformanceArtistDTO> artists) {
+        List<ConfetiMusic> topSongs = artists.stream()
+                .map(this::getArtistTopSongs)
+                .flatMap(Collection::stream)
+                .toList();
+
+        return pickRandomSongs(topSongs, RECOMMEND_SONG_SIZE).stream()
+                .map(SongRecommendDTO::from)
+                .toList();
+    }
+
+    private List<ConfetiMusic> getArtistTopSongs(PerformanceArtistDTO artist) {
+        return musicAPIHandler.getArtistTopSongs(artist.artistId(), RECOMMEND_SONG_FETCH_SIZE);
+    }
+
+    private List<ConfetiMusic> pickRandomSongs(List<ConfetiMusic> songs, int size) {
+        List<ConfetiMusic> copiedSongs = new ArrayList<>(songs);
+        Collections.shuffle(copiedSongs);
+        return copiedSongs.subList(0, Math.min(size, copiedSongs.size()));
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -71,9 +71,7 @@ public class PerformanceFacade {
 
     private static final int RECENT_PERFORMANCES_SIZE = 7;
     private static final int RECOMMEND_MUSIC_SIZE = 3;
-    private static final int RECOMMEND_SONG_SIZE = 3;
     private static final int RECOMMEND_SONG_FETCH_SIZE = 20;
-    private static final int RECOMMEND_PERFORMANCE_SIZE = 3;
     private static final boolean PERSONALIZED = true;
     private static final boolean UNPERSONALIZED = false;
 
@@ -393,29 +391,29 @@ public class PerformanceFacade {
         );
     }
 
-    public PerformancesRecommendDTO getPerformancesRecommend() {
-        List<PerformanceRecommendDTO> performancesRecommend = performanceService.getRandomPerformances(RECOMMEND_PERFORMANCE_SIZE).stream()
-                .map(this::getPerformanceRecommend)
+    public PerformancesRecommendDTO getPerformancesRecommend(int performanceLimit, int songLimit) {
+        List<PerformanceRecommendDTO> performancesRecommend = performanceService.getRandomPerformances(performanceLimit).stream()
+                .map(performance -> getPerformanceRecommend(performance, songLimit))
                 .toList();
 
         return PerformancesRecommendDTO.from(performancesRecommend);
     }
 
-    private PerformanceRecommendDTO getPerformanceRecommend(PerformanceDTO performance) {
+    private PerformanceRecommendDTO getPerformanceRecommend(PerformanceDTO performance, int songLimit) {
         List<SongRecommendDTO> songsRecommend = getSongsRecommend(
-                performanceService.getRandomPerformanceArtists(performance.id(), RECOMMEND_SONG_SIZE)
+                performanceService.getRandomPerformanceArtists(performance.id(), songLimit), songLimit
         );
 
         return PerformanceRecommendDTO.of(performance, songsRecommend);
     }
 
-    private List<SongRecommendDTO> getSongsRecommend(List<PerformanceArtistDTO> artists) {
+    private List<SongRecommendDTO> getSongsRecommend(List<PerformanceArtistDTO> artists, int songLimit) {
         List<ConfetiMusic> topSongs = artists.stream()
                 .map(this::getArtistTopSongs)
                 .flatMap(Collection::stream)
                 .toList();
 
-        return pickRandomSongs(topSongs, RECOMMEND_SONG_SIZE).stream()
+        return pickRandomSongs(topSongs, songLimit).stream()
                 .map(SongRecommendDTO::from)
                 .toList();
     }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/PerformanceRecommendDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/PerformanceRecommendDTO.java
@@ -1,0 +1,23 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+public record PerformanceRecommendDTO(
+        long typeId,
+        PerformanceType type,
+        String title,
+        String posterPath,
+        List<SongRecommendDTO> songs
+) {
+    public static PerformanceRecommendDTO of(PerformanceDTO performance, List<SongRecommendDTO> songsRecommend) {
+        return new PerformanceRecommendDTO(
+                performance.typeId(),
+                performance.type(),
+                performance.title(),
+                performance.posterPath(),
+                songsRecommend
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/PerformancesRecommendDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/PerformancesRecommendDTO.java
@@ -1,0 +1,11 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import java.util.List;
+
+public record PerformancesRecommendDTO(
+        List<PerformanceRecommendDTO> performances
+) {
+    public static PerformancesRecommendDTO from(List<PerformanceRecommendDTO> performancesRecommend) {
+        return new PerformancesRecommendDTO(performancesRecommend);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/SongRecommendDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/SongRecommendDTO.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.api.performance.facade.dto.response;
+
+import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
+
+public record SongRecommendDTO(
+        String id,
+        String artistName,
+        String artworkUrl,
+        String previewUrl
+) {
+    public static SongRecommendDTO from(ConfetiMusic song) {
+        return new SongRecommendDTO(
+                song.getId(),
+                song.getArtistName(),
+                song.getArtworkUrl(),
+                song.getPreviewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -8,11 +8,11 @@ import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.performance.facade.dto.request.GetExpectedPerformancesDTO;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceArtist;
 import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceArtistDTO;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformancePreviewDTO;
 import org.sopt.confeti.domain.view.performance.infra.repository.PerformanceCriteriaRepository;
@@ -28,7 +28,6 @@ import org.springframework.data.util.Pair;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-@Slf4j
 @Service
 @RequiredArgsConstructor
 public class PerformanceService {
@@ -139,7 +138,7 @@ public class PerformanceService {
 
     @Transactional(readOnly = true)
     public List<Performance> getRecommendPerformances(int limit) {
-        return performanceRepository.findTopByRand(limit);
+        return performanceRepository.findPerformancesByRand(limit);
     }
 
     @Transactional(readOnly = true)
@@ -219,5 +218,19 @@ public class PerformanceService {
     @Transactional(readOnly = true)
     public List<Performance> getPerformances() {
         return performanceRepository.findByEndAtGreaterThanEqual(LocalDate.now());
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceDTO> getRandomPerformances(int fetchSize) {
+        return performanceRepository.findPerformancesByRand(fetchSize).stream()
+                .map(PerformanceDTO::from)
+                .toList();
+    }
+
+    @Transactional(readOnly = true)
+    public List<PerformanceArtistDTO> getRandomPerformanceArtists(long performanceId, int fetchSize) {
+        return performanceRepository.findPerformanceArtistsByRand(performanceId, fetchSize).stream()
+                .map(PerformanceArtistDTO::from)
+                .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceArtistDTO.java
@@ -1,0 +1,15 @@
+package org.sopt.confeti.domain.view.performance.application.dto.response;
+
+import org.sopt.confeti.domain.view.performance.PerformanceArtist;
+
+public record PerformanceArtistDTO(
+        long id,
+        String artistId
+) {
+    public static PerformanceArtistDTO from(PerformanceArtist artist) {
+        return new PerformanceArtistDTO(
+                artist.getId(),
+                artist.getArtistId()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceDTO.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.domain.view.performance.application.dto.response;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Objects;
 import org.sopt.confeti.domain.elastic_search.application.dto.response.SearchPerformanceResult;
 import org.sopt.confeti.domain.view.performance.Performance;
@@ -18,7 +19,8 @@ public record PerformanceDTO(
         LocalDate endAt,
         String posterPath,
         LocalDateTime createdAt,
-        LocalDateTime updatedAt
+        LocalDateTime updatedAt,
+        List<PerformanceArtistDTO> artists
 ) {
     public static PerformanceDTO from(final Performance performance) {
         return new PerformanceDTO(
@@ -32,7 +34,10 @@ public record PerformanceDTO(
                 performance.getEndAt(),
                 performance.getPosterPath(),
                 performance.getCreatedAt(),
-                performance.getUpdatedAt()
+                performance.getUpdatedAt(),
+                performance.getArtists().stream()
+                        .map(PerformanceArtistDTO::from)
+                        .toList()
         );
     }
 
@@ -48,7 +53,8 @@ public record PerformanceDTO(
                 searchedPerformance.endAt(),
                 searchedPerformance.posterPath(),
                 null,
-                null
+                null,
+                List.of()
         );
     }
 

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -4,7 +4,9 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
 import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.domain.view.performance.PerformanceArtist;
 import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
@@ -81,7 +83,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     List<Performance> findTop5ByRand();
 
     @Query(value = "SELECT p FROM Performance p WHERE p.endAt >= CURRENT_DATE ORDER BY RAND() LIMIT :limit")
-    List<Performance> findTopByRand(@Param("limit") int limit);
+    List<Performance> findPerformancesByRand(@Param("limit") int limit);
 
     Optional<Performance> findPerformanceByIdAndEndAtGreaterThanEqual(long performanceId, LocalDate date);
 
@@ -100,4 +102,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     List<Performance> findRecentPerformancesByEndAtGreaterThanEqual(LocalDate now, PageRequest pageRequest);
 
     List<Performance> findByEndAtGreaterThanEqual(LocalDate now);
+
+    @Query(value = "SELECT pa FROM PerformanceArtist pa JOIN pa.performance p WHERE p.id = :id ORDER BY RAND() LIMIT :limit")
+    List<PerformanceArtist> findPerformanceArtistsByRand(@Param("id") long id, @Param("limit") int limit);
 }

--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -122,7 +122,7 @@ public class S3FileHandler {
      * Public 설정이 된 파일 조회 URL 생성
      */
     public URL getFileUrl(String folderPath, String key) {
-        checkFileExist(folderPath, key);
+//        checkFileExist(folderPath, key);
 
         try {
             return new URI(host + folderPath + URLEncoder.encode(key, StandardCharsets.UTF_8)).toURL();

--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -122,7 +122,7 @@ public class S3FileHandler {
      * Public 설정이 된 파일 조회 URL 생성
      */
     public URL getFileUrl(String folderPath, String key) {
-//        checkFileExist(folderPath, key);
+        checkFileExist(folderPath, key);
 
         try {
             return new URI(host + folderPath + URLEncoder.encode(key, StandardCharsets.UTF_8)).toURL();

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIHandler.java
@@ -471,4 +471,20 @@ public class AppleMusicAPIHandler implements MusicAPIHandler {
                                 ).orElseGet(List::of)
                 )).orElseGet(MusicPage::empty);
     }
+
+    @Override
+    public List<ConfetiMusic> getArtistTopSongs(String artistId, int recommendSongFetchSize) {
+        List<ConfetiMusic> songs = new ArrayList<>(getCachedTopMusicsByArtistId(artistId, recommendSongFetchSize));
+
+        if (!songs.isEmpty()) {
+            return songs;
+        }
+
+        List<ConfetiMusic> fetchedSongs = convertToConfetiMusics(
+                client.getArtistTopSongsById(artistId, String.valueOf(recommendSongFetchSize))
+        );
+        cachingTopMusicsByArtistId(artistId, fetchedSongs);
+
+        return fetchedSongs;
+    }
 }

--- a/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/MusicAPIHandler.java
@@ -28,4 +28,6 @@ public interface MusicAPIHandler {
     MusicPage getMusicsByKeyword(String term, int offset, int limit);
 
     MusicPage getArtistMusicsByArtistId(String artistId, int offset, int limit);
+
+    List<ConfetiMusic> getArtistTopSongs(String id, int recommendSongFetchSize);
 }


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 홈 뷰의 공연 미리듣기 조회 API를 구현했습니다.
- 기존의 `랜덤한 공연 조회 API` 및 `랜덤한 음악 조회 API` 를 `Deprecated` 마킹 해두었습니다.

<img width="1364" height="716" alt="image" src="https://github.com/user-attachments/assets/0ce1bd31-660a-4fa9-b001-bbeab036ae6d" />

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
