### PR TITLE
CONFETI-42 feat: 온보딩 캐시가 존재하지 않을 경우의 방어 로직 추가

### DIFF
--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -168,6 +168,7 @@ jobs:
       # 원격 서버에 배포
       - name: docker container deploy
         uses: appleboy/ssh-action@master
+        timeout-minutes: 20
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,5 +1,7 @@
 package org.sopt.confeti.api.user.facade;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
@@ -41,6 +43,7 @@ public class UserOnboardFacade {
     private final UserService userService;
     private final UserOnboardService userOnboardService;
     private final RedisTemplate<String, Object> redisTemplate;
+    private final ObjectMapper objectMapper;
 
     public UserOnboardRelatedArtistsDTO getArtistsRelatedTerm(long userId, String term, int limit) {
         Set<String> topArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
@@ -75,8 +78,8 @@ public class UserOnboardFacade {
         List<ConfetiArtist> topArtists = getAllTopArtists();
 
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
-        Set<String> favoriteArtistIds = cachedArtists.favoriteArtistIds();
-        Set<String> exposedArtistIds = cachedArtists.exposedArtistIds();
+        Set<String> favoriteArtistIds = new HashSet<>(cachedArtists.favoriteArtistIds());
+        Set<String> exposedArtistIds = new HashSet<>(cachedArtists.exposedArtistIds());
 
         UserOnboardTopArtistsDTO userOnboardTopArtistsDTO = UserOnboardTopArtistsDTO.from(
             topArtists.stream()
@@ -150,17 +153,14 @@ public class UserOnboardFacade {
         redisTemplate.opsForValue().set(RedisKey.MUSIC_TOP_ARTISTS.get(), topArtists);
     }
 
-    /**
-     * MUSIC_TOP_ARTISTS 캐시는 항상 List<ConfetiArtist> 타입을 캐싱하므로 unchecked 하도록 함
-     */
-    @SuppressWarnings("unchecked")
     private List<ConfetiArtist> getAllTopArtists() {
-        Object cachedTopArtists = redisTemplate.opsForValue().get(RedisKey.MUSIC_TOP_ARTISTS);
+        Object cachedTopArtists = redisTemplate.opsForValue().get(RedisKey.MUSIC_TOP_ARTISTS.get());
 
         if (!Objects.isNull(cachedTopArtists) &&
             (cachedTopArtists instanceof Collection<?> topArtists && !topArtists.isEmpty())) {
             try {
-                return (List<ConfetiArtist>) topArtists;
+                return objectMapper.convertValue(cachedTopArtists, new TypeReference<>() {
+                });
             } catch (ClassCastException e) {
                 log.error("[Casting Exception]", e);
             }

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -29,4 +29,8 @@ public record UserOnboardCacheDTO(
     ) {
         return new UserOnboardCacheDTO(favoriteArtistIds, exposedArtistIds);
     }
+
+    public static UserOnboardCacheDTO empty() {
+        return new UserOnboardCacheDTO(Collections.emptySet(), Collections.emptySet());
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
+++ b/src/main/java/org/sopt/confeti/domain/user/application/UserOnboardService.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardCacheDTO;
 import org.sopt.confeti.global.exception.NotFoundException;
-import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Service;
 
@@ -34,8 +33,7 @@ public class UserOnboardService {
 
         Object raw = redisTemplate.opsForValue().get(key);
         if (Objects.isNull(raw)) {
-            log.info("Get Top Artists from Redis Failed");
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+            return UserOnboardCacheDTO.empty();
         }
 
         return objectMapper.convertValue(raw, UserOnboardCacheDTO.class);


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 온보딩 캐시가 존재하지 않을 경우 EmptySet을 가진 UserOnboardCacheDTO를 반환하도록 변경
- LinkedHashMap을 List로 변환하는 로직 추가

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
- 지난 작업에서 테스트 시엔 로컬에서 이전에 테스트했던 캐시의 유무로 해당 부분의 이슈를 파악하지 못했었어요... 죄송합니당