### PR TITLE
CONFETI-33 feat: [온보딩 뷰] 선택된 아티스트 다건 삭제 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -1,9 +1,11 @@
 package org.sopt.confeti.api.user.controller;
 
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.controller.docs.UserOnboardControllerV4Docs;
+import org.sopt.confeti.api.user.dto.request.PatchOnboardFavoriteArtistsRequest;
 import org.sopt.confeti.api.user.dto.response.UserOnboardTopArtistsResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.GetOnboardStatusResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;
@@ -22,8 +24,10 @@ import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -112,6 +116,19 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
             userId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             UserOnboardFavoriteArtistsResponse.from(favoriteArtists));
+    }
+
+    /**
+     * 개발을 위해 임시로 Role.GENERAL 접근 허용
+     */
+    @Permission(role = {Role.ONBOARDING, Role.GENERAL})
+    @PatchMapping("/artists/favorite")
+    public ResponseEntity<BaseResponse<Void>> patchFavoriteArtists(
+        @UserId Long userId,
+        @Valid @RequestBody PatchOnboardFavoriteArtistsRequest request
+    ) {
+        userOnboardFacade.patchFavoriteArtist(userId, request.toDto());
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
 }

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.confeti.api.user.dto.request.PatchOnboardFavoriteArtistsRequest;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.common.swagger.AuthErrorResponses;
@@ -28,4 +29,25 @@ public interface UserOnboardControllerV4Docs {
         Long userId
     );
 
+    @Operation(
+        summary = "온보딩 진행 중 favorite 으로 선택했던 아티스트 목록 수정",
+        description =
+            """
+                V4 기준, 해당 API 는 선택했던 아티스트 목록 중 원하는 아티스트들을 id값으로 삭제하는 것만 가능함
+                """
+    )
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<Void>> patchFavoriteArtists(
+        Long userIdm,
+        PatchOnboardFavoriteArtistsRequest request
+    );
 }

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
@@ -47,7 +47,7 @@ public interface UserOnboardControllerV4Docs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<Void>> patchFavoriteArtists(
-        Long userIdm,
+        Long userId,
         PatchOnboardFavoriteArtistsRequest request
     );
 }

--- a/src/main/java/org/sopt/confeti/api/user/dto/request/PatchOnboardFavoriteArtistsRequest.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/request/PatchOnboardFavoriteArtistsRequest.java
@@ -1,0 +1,15 @@
+package org.sopt.confeti.api.user.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import java.util.Set;
+import org.sopt.confeti.api.user.facade.dto.request.PatchOnboardFavoriteArtistsDTO;
+
+public record PatchOnboardFavoriteArtistsRequest(
+    @NotNull
+    Set<String> deleteFavoriteArtistIds
+) {
+
+    public PatchOnboardFavoriteArtistsDTO toDto() {
+        return new PatchOnboardFavoriteArtistsDTO(deleteFavoriteArtistIds);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/request/PatchOnboardFavoriteArtistsRequest.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/request/PatchOnboardFavoriteArtistsRequest.java
@@ -1,12 +1,15 @@
 package org.sopt.confeti.api.user.dto.request;
 
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
 import org.sopt.confeti.api.user.facade.dto.request.PatchOnboardFavoriteArtistsDTO;
 
 public record PatchOnboardFavoriteArtistsRequest(
     @NotNull
-    Set<String> deleteFavoriteArtistIds
+    @Valid
+    Set<@NotBlank String> deleteFavoriteArtistIds
 ) {
 
     public PatchOnboardFavoriteArtistsDTO toDto() {

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -10,6 +10,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.api.user.facade.dto.request.PatchOnboardFavoriteArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.GetOnboardStatusDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardCacheDTO;
@@ -151,6 +152,20 @@ public class UserOnboardFacade {
 
     public void cacheTopArtists(List<ConfetiArtist> topArtists) {
         redisTemplate.opsForValue().set(RedisKey.MUSIC_TOP_ARTISTS.get(), topArtists);
+    }
+
+    public void patchFavoriteArtist(long userId, PatchOnboardFavoriteArtistsDTO requestDto) {
+        UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
+        Set<String> favoriteArtistIds = new HashSet<>(cachedArtists.favoriteArtistIds());
+        Set<String> deleteFavoriteArtistIds = requestDto.deleteFavoriteArtistIds();
+
+        boolean isRemoved = favoriteArtistIds.removeAll(deleteFavoriteArtistIds);
+        if (!isRemoved) {
+            throw new NotFoundException(ErrorMessage.NOT_FOUND);
+        }
+
+        userOnboardService.cacheOnboardArtists(
+            userId, UserOnboardCacheDTO.of(favoriteArtistIds, cachedArtists.exposedArtistIds()));
     }
 
     private List<ConfetiArtist> getAllTopArtists() {

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -159,10 +159,7 @@ public class UserOnboardFacade {
         Set<String> favoriteArtistIds = new HashSet<>(cachedArtists.favoriteArtistIds());
         Set<String> deleteFavoriteArtistIds = requestDto.deleteFavoriteArtistIds();
 
-        boolean isRemoved = favoriteArtistIds.removeAll(deleteFavoriteArtistIds);
-        if (!isRemoved) {
-            throw new NotFoundException(ErrorMessage.NOT_FOUND);
-        }
+        favoriteArtistIds.removeAll(deleteFavoriteArtistIds);
 
         userOnboardService.cacheOnboardArtists(
             userId, UserOnboardCacheDTO.of(favoriteArtistIds, cachedArtists.exposedArtistIds()));

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/request/PatchOnboardFavoriteArtistsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/request/PatchOnboardFavoriteArtistsDTO.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.api.user.facade.dto.request;
+
+import java.util.Set;
+
+public record PatchOnboardFavoriteArtistsDTO(
+    Set<String> deleteFavoriteArtistIds
+) {
+
+}


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 선택된 아티스트 다건 삭제 API 구현
  - 현재 해당 api는 목록 삭제를 위해 존재함. 처음에는 HTTP DELETE를 사용하고자 했으나 DELETE 의 경우 RequestBody를 사용하는 것이 표준적이지 않음. 스프링은 지원하지만, 지원하지 않는 서버나 미들웨어 등이 존재하므로 PATCH 메서드를 통해 RequestBody로 목록을 받아서 처리하도록 구현함

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
