### PR TITLE
CONFETI-45 feat: 온보딩 시 선호하는 아티스트만 필터링하도록 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import org.sopt.confeti.api.user.dto.request.PatchOnboardFavoriteArtistsRequest;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;
 import org.sopt.confeti.global.annotation.UserId;
@@ -11,6 +12,7 @@ import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.common.swagger.AuthErrorResponses;
 import org.sopt.confeti.global.common.swagger.CommonErrorResponses;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestBody;
 
 @Tag(name = "유저 온보딩")
 public interface UserOnboardControllerV4Docs {
@@ -27,7 +29,7 @@ public interface UserOnboardControllerV4Docs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<UserOnboardFavoriteArtistsResponse>> getFavoriteArtists(
-        Long userId
+        @UserId Long userId
     );
 
     @Operation(
@@ -71,7 +73,7 @@ public interface UserOnboardControllerV4Docs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<Void>> patchFavoriteArtists(
-        Long userId,
-        PatchOnboardFavoriteArtistsRequest request
+        @UserId Long userId,
+        @Valid @RequestBody PatchOnboardFavoriteArtistsRequest request
     );
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -127,6 +127,27 @@ public class UserOnboardFacade {
 
         List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
                 FIXED_RELATED_ARTISTS_FETCH_SIZE).stream()
+            .filter(artist -> !cachedOnboardArtists.favoriteArtistIds().contains(artist.getId()))
+            .limit(limit)
+            .toList();
+
+        cacheFavoriteArtists(userId, requestArtistId, cachedOnboardArtists);
+
+        return UserOnboardRelatedArtistsDTO.from(relatedArtists);
+    }
+
+    /**
+     * exposed Artist 를 사용할 경우의 RelatedArtists 조회 메서드
+     */
+    public UserOnboardRelatedArtistsDTO getRelatedArtistsWhenControlExposed(
+        long userId,
+        String requestArtistId,
+        int limit
+    ) {
+        UserOnboardCacheDTO cachedOnboardArtists = userOnboardService.getCachedArtists(userId);
+
+        List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
+                FIXED_RELATED_ARTISTS_FETCH_SIZE).stream()
             .filter(artist -> !cachedOnboardArtists.exposedArtistIds().contains(artist.getId()))
             .limit(limit)
             .toList();
@@ -234,13 +255,27 @@ public class UserOnboardFacade {
         return topArtists;
     }
 
+    private void cacheFavoriteArtists(
+        long userId,
+        String requestArtistId,
+        UserOnboardCacheDTO userOnboardCacheDTO
+    ) {
+        Set<String> newFavoriteArtistIds = new HashSet<>(userOnboardCacheDTO.favoriteArtistIds());
+        newFavoriteArtistIds.add(requestArtistId);
+
+        userOnboardService.cacheOnboardArtists(userId,
+            UserOnboardCacheDTO.createWithFavoriteArtistIds(newFavoriteArtistIds));
+    }
+
+    /**
+     * exposed Artist 를 사용할 경우의 RelatedArtists 캐싱 메서드
+     */
     private void cacheRelatedArtists(
         long userId,
         String requestArtistId,
         UserOnboardCacheDTO userOnboardCacheDTO,
         List<ConfetiArtist> artists
     ) {
-
         Set<String> newFavoriteArtistIds = new HashSet<>(userOnboardCacheDTO.favoriteArtistIds());
         Set<String> newExposedArtistIds = new HashSet<>(userOnboardCacheDTO.exposedArtistIds());
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -52,14 +52,12 @@ public class UserOnboardFacade {
 
     public UserOnboardRelatedArtistsDTO getArtistsRelatedTerm(long userId, String term, int limit) {
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
-        List<ConfetiArtist> artists = musicAPIHandler.findArtistsByKeyword(term,
-                FIXED_SEARCH_ARTISTS_FETCH_SIZE)
-            .stream()
-            .filter(artist -> !cachedArtists.favoriteArtistIds().contains(artist.getId()))
-            .limit(limit)
-            .toList();
+        List<ConfetiArtist> searchedArtists = musicAPIHandler.findArtistsByKeyword(term,
+            FIXED_SEARCH_ARTISTS_FETCH_SIZE);
+        List<ConfetiArtist> filteredArtists = getFilteredArtists(searchedArtists,
+            cachedArtists.favoriteArtistIds(), limit);
 
-        return UserOnboardRelatedArtistsDTO.from(artists);
+        return UserOnboardRelatedArtistsDTO.from(filteredArtists);
     }
 
     /**
@@ -67,15 +65,13 @@ public class UserOnboardFacade {
      */
     public UserOnboardRelatedArtistsDTO getArtistsRelatedTermWhenControlExposed(long userId,
         String term, int limit) {
-        Set<String> topArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
-        List<ConfetiArtist> artists = musicAPIHandler.findArtistsByKeyword(term,
-                FIXED_SEARCH_ARTISTS_FETCH_SIZE)
-            .stream()
-            .filter(artist -> !topArtistIds.contains(artist.getId()))
-            .limit(limit)
-            .toList();
+        Set<String> exposedArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
+        List<ConfetiArtist> searchedArtists = musicAPIHandler.findArtistsByKeyword(term,
+            FIXED_SEARCH_ARTISTS_FETCH_SIZE);
+        List<ConfetiArtist> filteredArtists = getFilteredArtists(searchedArtists, exposedArtistIds,
+            limit);
 
-        return UserOnboardRelatedArtistsDTO.from(artists);
+        return UserOnboardRelatedArtistsDTO.from(filteredArtists);
     }
 
     @Deprecated
@@ -100,10 +96,7 @@ public class UserOnboardFacade {
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
 
         UserOnboardTopArtistsDTO userOnboardTopArtistsDTO = UserOnboardTopArtistsDTO.from(
-            topArtists.stream()
-                .filter(artist -> !cachedArtists.favoriteArtistIds().contains(artist.getId()))
-                .limit(limit)
-                .toList()
+            getFilteredArtists(topArtists, cachedArtists.favoriteArtistIds(), limit)
         );
 
         return userOnboardTopArtistsDTO;
@@ -114,17 +107,12 @@ public class UserOnboardFacade {
      */
     public UserOnboardTopArtistsDTO getTopArtistsWhenControlExposed(int limit, long userId) {
         List<ConfetiArtist> topArtists = getAllTopArtists();
-
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
         Set<String> favoriteArtistIds = new HashSet<>(cachedArtists.favoriteArtistIds());
         Set<String> exposedArtistIds = new HashSet<>(cachedArtists.exposedArtistIds());
 
         UserOnboardTopArtistsDTO userOnboardTopArtistsDTO = UserOnboardTopArtistsDTO.from(
-            topArtists.stream()
-                .filter(artist -> !favoriteArtistIds.contains(artist.getId()))
-                .limit(limit)
-                .toList()
-        );
+            getFilteredArtists(topArtists, favoriteArtistIds, limit));
 
         userOnboardTopArtistsDTO.artists()
             .forEach(artist -> exposedArtistIds.add(artist.id()));
@@ -141,16 +129,14 @@ public class UserOnboardFacade {
         int limit
     ) {
         UserOnboardCacheDTO cachedOnboardArtists = userOnboardService.getCachedArtists(userId);
-
         List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
-                FIXED_RELATED_ARTISTS_FETCH_SIZE).stream()
-            .filter(artist -> !cachedOnboardArtists.favoriteArtistIds().contains(artist.getId()))
-            .limit(limit)
-            .toList();
+            FIXED_RELATED_ARTISTS_FETCH_SIZE);
+        List<ConfetiArtist> filteredRelatedArtists = getFilteredArtists(
+            relatedArtists, cachedOnboardArtists.favoriteArtistIds(), limit);
 
         cacheFavoriteArtists(userId, requestArtistId, cachedOnboardArtists);
 
-        return UserOnboardRelatedArtistsDTO.from(relatedArtists);
+        return UserOnboardRelatedArtistsDTO.from(filteredRelatedArtists);
     }
 
     /**
@@ -164,12 +150,11 @@ public class UserOnboardFacade {
         UserOnboardCacheDTO cachedOnboardArtists = userOnboardService.getCachedArtists(userId);
 
         List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
-                FIXED_RELATED_ARTISTS_FETCH_SIZE).stream()
-            .filter(artist -> !cachedOnboardArtists.exposedArtistIds().contains(artist.getId()))
-            .limit(limit)
-            .toList();
+            FIXED_RELATED_ARTISTS_FETCH_SIZE);
+        List<ConfetiArtist> filteredRelatedArtists = getFilteredArtists(
+            relatedArtists, cachedOnboardArtists.exposedArtistIds(), limit);
 
-        cacheRelatedArtists(userId, requestArtistId, cachedOnboardArtists, relatedArtists);
+        cacheRelatedArtists(userId, requestArtistId, cachedOnboardArtists, filteredRelatedArtists);
 
         return UserOnboardRelatedArtistsDTO.from(relatedArtists);
     }
@@ -313,6 +298,14 @@ public class UserOnboardFacade {
         if (favoriteArtistIds == null || favoriteArtistIds.isEmpty()) {
             throw new BadRequestException(ErrorMessage.BAD_REQUEST);
         }
+    }
+
+    private List<ConfetiArtist> getFilteredArtists(List<ConfetiArtist> targetArtists,
+        Set<String> excludeArtistIds, int limit) {
+        return targetArtists.stream()
+            .filter(artist -> !excludeArtistIds.contains(artist.getId()))
+            .limit(limit)
+            .toList();
     }
 
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -97,6 +97,23 @@ public class UserOnboardFacade {
 
     public UserOnboardTopArtistsDTO getTopArtists(int limit, long userId) {
         List<ConfetiArtist> topArtists = getAllTopArtists();
+        UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
+
+        UserOnboardTopArtistsDTO userOnboardTopArtistsDTO = UserOnboardTopArtistsDTO.from(
+            topArtists.stream()
+                .filter(artist -> !cachedArtists.favoriteArtistIds().contains(artist.getId()))
+                .limit(limit)
+                .toList()
+        );
+
+        return userOnboardTopArtistsDTO;
+    }
+
+    /**
+     * exposed Artist 사용할 경우의 Top Artist 목록 조회 메서드
+     */
+    public UserOnboardTopArtistsDTO getTopArtistsWhenControlExposed(int limit, long userId) {
+        List<ConfetiArtist> topArtists = getAllTopArtists();
 
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
         Set<String> favoriteArtistIds = new HashSet<>(cachedArtists.favoriteArtistIds());

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -51,6 +51,22 @@ public class UserOnboardFacade {
     private final ArtistFavoriteService artistFavoriteService;
 
     public UserOnboardRelatedArtistsDTO getArtistsRelatedTerm(long userId, String term, int limit) {
+        UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedArtists(userId);
+        List<ConfetiArtist> artists = musicAPIHandler.findArtistsByKeyword(term,
+                FIXED_SEARCH_ARTISTS_FETCH_SIZE)
+            .stream()
+            .filter(artist -> !cachedArtists.favoriteArtistIds().contains(artist.getId()))
+            .limit(limit)
+            .toList();
+
+        return UserOnboardRelatedArtistsDTO.from(artists);
+    }
+
+    /**
+     * exposed Artist 사용할 경우의 온보딩 아티스트 검색 메서드
+     */
+    public UserOnboardRelatedArtistsDTO getArtistsRelatedTermWhenControlExposed(long userId,
+        String term, int limit) {
         Set<String> topArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
         List<ConfetiArtist> artists = musicAPIHandler.findArtistsByKeyword(term,
                 FIXED_SEARCH_ARTISTS_FETCH_SIZE)

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -33,4 +33,8 @@ public record UserOnboardCacheDTO(
     public static UserOnboardCacheDTO empty() {
         return new UserOnboardCacheDTO(Collections.emptySet(), Collections.emptySet());
     }
+
+    public static UserOnboardCacheDTO createWithFavoriteArtistIds(Set<String> favoriteArtistIds) {
+        return new UserOnboardCacheDTO(favoriteArtistIds, Collections.emptySet());
+    }
 }


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 온보딩 시 선택한 아티스트만 필터링하도록 변경. 기존에는 선택한 아티스트와 한번이라도 조회한 아티스트를 필터링한 목록을 반환했음. 그런데 현재 플로우 상 이미 조회한 아티스트를 필터링할 경우 온보딩이 정상적으로 진행되지 않는 케이스가 존재하여 선택한 아티스트만 필터링하도록 변경함
- 단 추후 기존에 기획 측에서 원하던 플로우로 온보딩 과정이 다시 롤백될 수 있으므로 OnboardArtistsDTO는 기존 구조를 유지함. 메서드도 주석으로 남긴 뒤 분리해둠
- 수정된 부분은 아래와 같음
  - 온보딩 아티스트 검색 - favoriteArtist 만 제외하고 응답하도록 변경
  - TopArtist 목록 조회 - favoriteArtist 만 캐싱하도록 변경
  - RelatedArtist 목록 조회 - favoriteArtist 만 제외하고 응답하며 favoriteArtist 만 캐싱하도록 변경

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
