### PR TITLE
CONFETI-46 feat: 온보딩 API 플로우 수정 및 캐싱 방식 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.api.user.controller;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.controller.docs.UserOnboardControllerV4Docs;
 import org.sopt.confeti.api.user.dto.request.onboard.AddOnboardFavoriteArtistRequest;
@@ -23,7 +24,6 @@ import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -64,13 +64,8 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
         @RequestParam(required = false, defaultValue = "50") @Min(1) @Max(200) int limit,
         @RequestParam(required = false) String targetArtistId
     ) {
-        UserOnboardArtistsDTO onboardArtists;
-        if (StringUtils.hasText(targetArtistId)) {
-            onboardArtists = userOnboardFacade.getRelatedArtistsV4(userId,
-                targetArtistId, limit);
-        } else {
-            onboardArtists = userOnboardFacade.getTopArtists(limit, userId);
-        }
+        UserOnboardArtistsDTO onboardArtists = userOnboardFacade.getOnboardArtists(limit, userId,
+            Optional.ofNullable(targetArtistId));
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             UserOnboardArtistsResponse.from(onboardArtists));
     }

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -6,7 +6,7 @@ import jakarta.validation.constraints.Min;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.controller.docs.UserOnboardControllerV4Docs;
-import org.sopt.confeti.api.user.dto.request.PatchOnboardFavoriteArtistsRequest;
+import org.sopt.confeti.api.user.dto.request.onboard.PatchOnboardFavoriteArtistsRequest;
 import org.sopt.confeti.api.user.dto.response.onboard.GetOnboardStatusResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardArtistsResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -3,7 +3,6 @@ package org.sopt.confeti.api.user.controller;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.controller.docs.UserOnboardControllerV4Docs;
 import org.sopt.confeti.api.user.dto.request.onboard.AddOnboardFavoriteArtistRequest;
@@ -24,6 +23,7 @@ import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
 import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -64,8 +64,13 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
         @RequestParam(required = false, defaultValue = "50") @Min(1) @Max(200) int limit,
         @RequestParam(required = false) String targetArtistId
     ) {
-        UserOnboardArtistsDTO onboardArtists = userOnboardFacade.getOnboardArtists(limit, userId,
-            Optional.ofNullable(targetArtistId));
+        UserOnboardArtistsDTO onboardArtists;
+        if (StringUtils.hasText(targetArtistId)) {
+            onboardArtists = userOnboardFacade.getRelatedArtistsV4(userId,
+                targetArtistId, limit);
+        } else {
+            onboardArtists = userOnboardFacade.getTopArtists(limit, userId);
+        }
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             UserOnboardArtistsResponse.from(onboardArtists));
     }

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -3,16 +3,17 @@ package org.sopt.confeti.api.user.controller;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
+import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.controller.docs.UserOnboardControllerV4Docs;
 import org.sopt.confeti.api.user.dto.request.PatchOnboardFavoriteArtistsRequest;
-import org.sopt.confeti.api.user.dto.response.UserOnboardTopArtistsResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.GetOnboardStatusResponse;
+import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardArtistsResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardRelatedArtistsResponse;
 import org.sopt.confeti.api.user.facade.UserOnboardFacade;
-import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.GetOnboardStatusDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardFavoriteArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
 import org.sopt.confeti.domain.user.constant.Role;
@@ -40,22 +41,6 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
 
     private final UserOnboardFacade userOnboardFacade;
 
-    /**
-     * 개발을 위해 임시로 Role.GENERAL 접근 허용
-     */
-    @Permission(role = {Role.ONBOARDING, Role.GENERAL})
-    @GetMapping("/artists/{artistId}/related")
-    public ResponseEntity<BaseResponse<UserOnboardRelatedArtistsResponse>> getRelatedArtists(
-        @UserId Long userId,
-        @PathVariable String artistId,
-        @RequestParam(defaultValue = "1") @Min(1) @Max(30) Integer limit
-    ) {
-        UserOnboardRelatedArtistsDTO relatedArtists = userOnboardFacade.getRelatedArtists(userId,
-            artistId, limit);
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-            UserOnboardRelatedArtistsResponse.from(relatedArtists));
-    }
-
     @GetMapping("/artists/search")
     public ResponseEntity<BaseResponse<UserOnboardRelatedArtistsResponse>> getArtistsRelatedTerm(
         @UserId Long userId,
@@ -73,13 +58,15 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
      */
     @Permission(role = {Role.ONBOARDING, Role.GENERAL})
     @GetMapping("/artists")
-    public ResponseEntity<BaseResponse<UserOnboardTopArtistsResponse>> getTopArtists(
+    public ResponseEntity<BaseResponse<UserOnboardArtistsResponse>> getOnboardArtists(
         @UserId Long userId,
-        @RequestParam(required = false, defaultValue = "100") @Min(1) @Max(200) int limit
+        @RequestParam(required = false, defaultValue = "50") @Min(1) @Max(200) int limit,
+        @RequestParam String targetArtistId
     ) {
-        UserOnboardTopArtistsDTO topArtists = userOnboardFacade.getTopArtists(limit, userId);
+        UserOnboardArtistsDTO onboardArtists = userOnboardFacade.getOnboardArtists(limit, userId,
+            Optional.ofNullable(targetArtistId));
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
-            UserOnboardTopArtistsResponse.from(topArtists));
+            UserOnboardArtistsResponse.from(onboardArtists));
     }
 
     /**

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardControllerV4.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.Min;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.controller.docs.UserOnboardControllerV4Docs;
+import org.sopt.confeti.api.user.dto.request.onboard.AddOnboardFavoriteArtistRequest;
 import org.sopt.confeti.api.user.dto.request.onboard.PatchOnboardFavoriteArtistsRequest;
 import org.sopt.confeti.api.user.dto.response.onboard.GetOnboardStatusResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardArtistsResponse;
@@ -61,7 +62,7 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
     public ResponseEntity<BaseResponse<UserOnboardArtistsResponse>> getOnboardArtists(
         @UserId Long userId,
         @RequestParam(required = false, defaultValue = "50") @Min(1) @Max(200) int limit,
-        @RequestParam String targetArtistId
+        @RequestParam(required = false) String targetArtistId
     ) {
         UserOnboardArtistsDTO onboardArtists = userOnboardFacade.getOnboardArtists(limit, userId,
             Optional.ofNullable(targetArtistId));
@@ -129,6 +130,21 @@ public class UserOnboardControllerV4 implements UserOnboardControllerV4Docs {
     ) {
         userOnboardFacade.patchFavoriteArtist(userId, request.toDto());
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
+    /**
+     * 개발을 위해 임시로 Role.GENERAL 접근 허용
+     */
+    @Permission(role = {Role.ONBOARDING, Role.GENERAL})
+    @PostMapping("/artists/favorite")
+    public ResponseEntity<BaseResponse<UserOnboardFavoriteArtistsResponse>> addFavoriteArtists(
+        @UserId Long userId,
+        @Valid @RequestBody AddOnboardFavoriteArtistRequest request
+    ) {
+        UserOnboardFavoriteArtistsDTO favoriteArtists = userOnboardFacade.addFavoriteArtists(
+            userId, request.toDTO());
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserOnboardFavoriteArtistsResponse.from(favoriteArtists));
     }
 
 }

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
@@ -5,14 +5,20 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import org.sopt.confeti.api.user.dto.request.onboard.AddOnboardFavoriteArtistRequest;
 import org.sopt.confeti.api.user.dto.request.onboard.PatchOnboardFavoriteArtistsRequest;
+import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardArtistsResponse;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.common.swagger.AuthErrorResponses;
 import org.sopt.confeti.global.common.swagger.CommonErrorResponses;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 
 @Tag(name = "유저 온보딩")
 public interface UserOnboardControllerV4Docs {
@@ -33,7 +39,7 @@ public interface UserOnboardControllerV4Docs {
     );
 
     @Operation(
-        summary = "회원가입한 유저의 온보딩 완료 요청",
+        summary = "회원가입한 유저의 온보딩 완료 요청 API",
         description =
             """
                 V4 변경사항
@@ -56,7 +62,7 @@ public interface UserOnboardControllerV4Docs {
     );
 
     @Operation(
-        summary = "온보딩 진행 중 favorite 으로 선택했던 아티스트 목록 수정",
+        summary = "온보딩 진행 중 favorite 으로 선택했던 아티스트 목록 수정 API",
         description =
             """
                 V4 기준, 해당 API 는 선택했던 아티스트 목록 중 원하는 아티스트들을 id값으로 삭제하는 것만 가능함
@@ -75,5 +81,55 @@ public interface UserOnboardControllerV4Docs {
     ResponseEntity<BaseResponse<Void>> patchFavoriteArtists(
         @UserId Long userId,
         @Valid @RequestBody PatchOnboardFavoriteArtistsRequest request
+    );
+
+    @Operation(
+        summary = "온보딩 아티스트 목록 조회 API",
+        description =
+            """
+                V4 변경 사항
+                - Query String 으로 전달하는 targetArtistId 유무에 따라서 응답하는 UserOnboardArtistsResponse 데이터가 달라짐
+                    - targetArtistId 가 존재하는 경우, 해당 targetArtist의 Related Artist 목록을 반환
+                    - targetArtistId 가 존재하지 않는 경우, Top Artist 목록을 반환
+                """
+    )
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<UserOnboardArtistsResponse>> getOnboardArtists(
+        @UserId Long userId,
+        @RequestParam(required = false, defaultValue = "50") @Min(1) @Max(200) int limit,
+        @RequestParam(required = false) String targetArtistId
+    );
+
+    @Operation(
+        summary = "온보딩 favorite Artist 추가 API",
+        description =
+            """
+                온보딩 중 favorite 으로 선택한 아티스트 목록을 RequestBody 로 받아서 추가한 후
+                응답으로 현재 온보딩 중 favorite 으로 선택한 아티스트 목록을 반환함
+                """
+    )
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    @PostMapping("/artists/favorite")
+    ResponseEntity<BaseResponse<UserOnboardFavoriteArtistsResponse>> addFavoriteArtists(
+        @UserId Long userId,
+        @Valid @RequestBody AddOnboardFavoriteArtistRequest request
     );
 }

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserOnboardControllerV4Docs.java
@@ -5,7 +5,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
-import org.sopt.confeti.api.user.dto.request.PatchOnboardFavoriteArtistsRequest;
+import org.sopt.confeti.api.user.dto.request.onboard.PatchOnboardFavoriteArtistsRequest;
 import org.sopt.confeti.api.user.dto.response.onboard.UserOnboardFavoriteArtistsResponse;
 import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;

--- a/src/main/java/org/sopt/confeti/api/user/dto/request/onboard/AddOnboardFavoriteArtistRequest.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/request/onboard/AddOnboardFavoriteArtistRequest.java
@@ -1,0 +1,18 @@
+package org.sopt.confeti.api.user.dto.request.onboard;
+
+import jakarta.validation.constraints.NotEmpty;
+import org.sopt.confeti.api.user.facade.dto.request.onboard.AddOnboardFavoriteArtistDTO;
+
+public record AddOnboardFavoriteArtistRequest(
+    @NotEmpty
+    String artistId,
+    @NotEmpty
+    String name,
+    @NotEmpty
+    String profileUrl
+) {
+
+    public AddOnboardFavoriteArtistDTO toDTO() {
+        return new AddOnboardFavoriteArtistDTO(artistId, name, profileUrl);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/request/onboard/AddOnboardFavoriteArtistRequest.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/request/onboard/AddOnboardFavoriteArtistRequest.java
@@ -1,18 +1,15 @@
 package org.sopt.confeti.api.user.dto.request.onboard;
 
 import jakarta.validation.constraints.NotEmpty;
+import java.util.Set;
 import org.sopt.confeti.api.user.facade.dto.request.onboard.AddOnboardFavoriteArtistDTO;
 
 public record AddOnboardFavoriteArtistRequest(
     @NotEmpty
-    String artistId,
-    @NotEmpty
-    String name,
-    @NotEmpty
-    String profileUrl
+    Set<String> artistIds
 ) {
 
     public AddOnboardFavoriteArtistDTO toDTO() {
-        return new AddOnboardFavoriteArtistDTO(artistId, name, profileUrl);
+        return new AddOnboardFavoriteArtistDTO(artistIds);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/dto/request/onboard/PatchOnboardFavoriteArtistsRequest.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/request/onboard/PatchOnboardFavoriteArtistsRequest.java
@@ -1,10 +1,10 @@
-package org.sopt.confeti.api.user.dto.request;
+package org.sopt.confeti.api.user.dto.request.onboard;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import java.util.Set;
-import org.sopt.confeti.api.user.facade.dto.request.PatchOnboardFavoriteArtistsDTO;
+import org.sopt.confeti.api.user.facade.dto.request.onboard.PatchOnboardFavoriteArtistsDTO;
 
 public record PatchOnboardFavoriteArtistsRequest(
     @NotNull

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardArtistResponse.java
@@ -1,0 +1,18 @@
+package org.sopt.confeti.api.user.dto.response.onboard;
+
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardArtistDTO;
+
+public record UserOnboardArtistResponse(
+    String Id,
+    String profileUrl,
+    String name
+) {
+
+    public static UserOnboardArtistResponse from(UserOnboardArtistDTO artistDTO) {
+        return new UserOnboardArtistResponse(
+            artistDTO.id(),
+            artistDTO.profileUrl(),
+            artistDTO.name()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardArtistResponse.java
@@ -3,7 +3,7 @@ package org.sopt.confeti.api.user.dto.response.onboard;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardArtistDTO;
 
 public record UserOnboardArtistResponse(
-    String Id,
+    String artistId,
     String profileUrl,
     String name
 ) {

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardArtistsResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardArtistsResponse.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.dto.response.onboard;
+
+import java.util.List;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardArtistsDTO;
+
+public record UserOnboardArtistsResponse(
+    List<UserOnboardArtistResponse> artists
+) {
+
+    public static UserOnboardArtistsResponse from(UserOnboardArtistsDTO artistsDTO) {
+        return new UserOnboardArtistsResponse(
+            artistsDTO.artists().stream()
+                .map(UserOnboardArtistResponse::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardFavoriteArtistResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/onboard/UserOnboardFavoriteArtistResponse.java
@@ -3,7 +3,7 @@ package org.sopt.confeti.api.user.dto.response.onboard;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardFavoriteArtistDTO;
 
 public record UserOnboardFavoriteArtistResponse(
-    String id,
+    String artistId,
     String profileUrl,
     String name
 ) {

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -103,9 +103,7 @@ public class UserOnboardFacade {
         List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
             FIXED_RELATED_ARTISTS_FETCH_SIZE);
         List<ConfetiArtist> filteredRelatedArtists = getFilteredArtists(
-            relatedArtists,
-            cachedOnboardArtists.favoriteArtists().stream().map(ConfetiArtist::getId)
-                .collect(Collectors.toSet()), limit);
+            relatedArtists, cachedOnboardArtists.favoriteArtistIds(), limit);
 
         return UserOnboardArtistsDTO.from(filteredRelatedArtists);
     }
@@ -121,9 +119,7 @@ public class UserOnboardFacade {
         List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
             FIXED_RELATED_ARTISTS_FETCH_SIZE);
         List<ConfetiArtist> filteredRelatedArtists = getFilteredArtists(
-            relatedArtists,
-            cachedOnboardArtists.favoriteArtists().stream().map(ConfetiArtist::getId)
-                .collect(Collectors.toSet()), limit);
+            relatedArtists, cachedOnboardArtists.favoriteArtistIds(), limit);
 
         return UserOnboardRelatedArtistsDTO.from(filteredRelatedArtists);
     }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,5 +1,8 @@
 package org.sopt.confeti.api.user.facade;
 
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
@@ -210,13 +213,11 @@ public class UserOnboardFacade {
 
     public void patchFavoriteArtist(long userId, PatchOnboardFavoriteArtistsDTO requestDto) {
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedOnboardArtists(userId);
-        Set<String> favoriteArtistIds = new HashSet<>(cachedArtists.favoriteArtistIds());
-        Set<String> deleteFavoriteArtistIds = requestDto.deleteFavoriteArtistIds();
 
-        favoriteArtistIds.removeAll(deleteFavoriteArtistIds);
+        UserOnboardCacheDTO newUserOnboardCacheDTO
+            = cachedArtists.deleteFavoriteArtistIds(requestDto.deleteFavoriteArtistIds());
 
-        userOnboardService.cacheOnboardArtists(
-            userId, UserOnboardCacheDTO.of(favoriteArtistIds, cachedArtists.exposedArtistIds()));
+        userOnboardService.cacheOnboardArtists(userId, newUserOnboardCacheDTO);
     }
 
     private List<ConfetiArtist> getAllTopArtists() {
@@ -251,11 +252,10 @@ public class UserOnboardFacade {
         String requestArtistId,
         UserOnboardCacheDTO userOnboardCacheDTO
     ) {
-        Set<String> newFavoriteArtistIds = new HashSet<>(userOnboardCacheDTO.favoriteArtistIds());
-        newFavoriteArtistIds.add(requestArtistId);
+        UserOnboardCacheDTO newUserOnboardCacheDTO = userOnboardCacheDTO.withAddFavoriteArtistIds(
+            new LinkedHashSet<>(List.of(requestArtistId)));
 
-        userOnboardService.cacheOnboardArtists(userId,
-            UserOnboardCacheDTO.createWithFavoriteArtistIds(newFavoriteArtistIds));
+        userOnboardService.cacheOnboardArtists(userId, newUserOnboardCacheDTO);
     }
 
     /**

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -3,7 +3,7 @@ package org.sopt.confeti.api.user.facade;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -130,9 +130,11 @@ public class UserOnboardFacade {
         List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
             FIXED_RELATED_ARTISTS_FETCH_SIZE);
         List<ConfetiArtist> filteredRelatedArtists = getFilteredArtists(
-            relatedArtists, cachedOnboardArtists.favoriteArtistIds(), limit);
+            relatedArtists,
+            cachedOnboardArtists.favoriteArtists().stream().map(ConfetiArtist::getId)
+                .collect(Collectors.toSet()), limit);
 
-        cacheFavoriteArtists(userId, requestArtistId, cachedOnboardArtists);
+//        cacheFavoriteArtists(userId, requestArtistId, cachedOnboardArtists);
 
         return UserOnboardRelatedArtistsDTO.from(filteredRelatedArtists);
     }
@@ -168,7 +170,7 @@ public class UserOnboardFacade {
 
     public void cacheExposedArtist(long userId, String artistId) {
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedOnboardArtists(userId);
-        Set<String> favoriteArtistIds = cachedArtists.favoriteArtistIds();
+        Set<ConfetiArtist> favoriteArtistIds = cachedArtists.favoriteArtists();
         Set<String> exposedArtistIds = cachedArtists.exposedArtistIds();
 
         exposedArtistIds.add(artistId);
@@ -185,9 +187,7 @@ public class UserOnboardFacade {
 
     public UserOnboardFavoriteArtistsDTO getFavoriteArtists(long userId) {
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedOnboardArtists(userId);
-        List<ConfetiArtist> favoriteArtists = musicAPIHandler.getArtistsByArtistIds(
-            cachedArtists.favoriteArtistIds());
-
+        List<ConfetiArtist> favoriteArtists = cachedArtists.favoriteArtists().stream().toList();
         return UserOnboardFavoriteArtistsDTO.from(favoriteArtists);
     }
 
@@ -249,11 +249,11 @@ public class UserOnboardFacade {
 
     private void cacheFavoriteArtists(
         long userId,
-        String requestArtistId,
+        ConfetiArtist requestArtist,
         UserOnboardCacheDTO userOnboardCacheDTO
     ) {
         UserOnboardCacheDTO newUserOnboardCacheDTO = userOnboardCacheDTO.withAddFavoriteArtistIds(
-            new LinkedHashSet<>(List.of(requestArtistId)));
+            new LinkedHashSet<>(List.of(requestArtist)));
 
         userOnboardService.cacheOnboardArtists(userId, newUserOnboardCacheDTO);
     }
@@ -282,7 +282,7 @@ public class UserOnboardFacade {
     }
 
     private void validOnboardArtists(UserOnboardCacheDTO userOnboardCacheDTO) {
-        Set<String> favoriteArtistIds = userOnboardCacheDTO.favoriteArtistIds();
+        Set<ConfetiArtist> favoriteArtistIds = userOnboardCacheDTO.favoriteArtists();
 
         if (favoriteArtistIds == null || favoriteArtistIds.isEmpty()) {
             throw new BadRequestException(ErrorMessage.BAD_REQUEST);

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,12 +1,12 @@
 package org.sopt.confeti.api.user.facade;
 
-import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.api.user.facade.dto.request.onboard.AddOnboardFavoriteArtistDTO;
 import org.sopt.confeti.api.user.facade.dto.request.onboard.PatchOnboardFavoriteArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.GetOnboardStatusDTO;
@@ -189,6 +189,20 @@ public class UserOnboardFacade {
         userOnboardService.cacheOnboardArtists(userId, newUserOnboardCacheDTO);
     }
 
+    public UserOnboardFavoriteArtistsDTO addFavoriteArtists(
+        long userId,
+        AddOnboardFavoriteArtistDTO requestDTO
+    ) {
+        UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedOnboardArtists(userId);
+        UserOnboardCacheDTO newUserOnboardCacheDTO = cachedArtists.withAddFavoriteArtists(
+            List.of(requestDTO.toConfetiArtist()));
+        userOnboardService.cacheOnboardArtists(userId, newUserOnboardCacheDTO);
+
+        List<ConfetiArtist> favoriteArtists = newUserOnboardCacheDTO.favoriteArtists().stream()
+            .toList();
+        return UserOnboardFavoriteArtistsDTO.from(favoriteArtists);
+    }
+
     private List<ConfetiArtist> getAllTopArtists() {
         List<ConfetiArtist> cachedTopArtists = redisHandler.getList(
             RedisKey.MUSIC_TOP_ARTISTS.createKeyInfo());
@@ -215,17 +229,6 @@ public class UserOnboardFacade {
         List<ConfetiArtist> topArtists = musicAPIHandler.getArtistsByArtistIds(topArtistIds);
         cacheTopArtists(topArtists);
         return topArtists;
-    }
-
-    private void cacheFavoriteArtists(
-        long userId,
-        ConfetiArtist requestArtist,
-        UserOnboardCacheDTO userOnboardCacheDTO
-    ) {
-        UserOnboardCacheDTO newUserOnboardCacheDTO = userOnboardCacheDTO.withAddFavoriteArtistIds(
-            new LinkedHashSet<>(List.of(requestArtist)));
-
-        userOnboardService.cacheOnboardArtists(userId, newUserOnboardCacheDTO);
     }
 
     private void validOnboardArtists(UserOnboardCacheDTO userOnboardCacheDTO) {

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -58,20 +58,6 @@ public class UserOnboardFacade {
         return UserOnboardRelatedArtistsDTO.from(filteredArtists);
     }
 
-    /**
-     * exposed Artist 사용할 경우의 온보딩 아티스트 검색 메서드
-     */
-    public UserOnboardRelatedArtistsDTO getArtistsRelatedTermWhenControlExposed(long userId,
-        String term, int limit) {
-        Set<String> exposedArtistIds = userOnboardService.getCachedExposedArtistIds(userId);
-        List<ConfetiArtist> searchedArtists = musicAPIHandler.findArtistsByKeyword(term,
-            FIXED_SEARCH_ARTISTS_FETCH_SIZE);
-        List<ConfetiArtist> filteredArtists = getFilteredArtists(searchedArtists, exposedArtistIds,
-            limit);
-
-        return UserOnboardRelatedArtistsDTO.from(filteredArtists);
-    }
-
     @Deprecated
     public UserOnboardTopArtistsDTO getTopArtists(int limit) {
         List<ConfetiMusic> topMusics = musicAPIHandler.getTopMusics(limit);
@@ -100,27 +86,6 @@ public class UserOnboardFacade {
         return userOnboardTopArtistsDTO;
     }
 
-    /**
-     * exposed Artist 사용할 경우의 Top Artist 목록 조회 메서드
-     */
-    public UserOnboardTopArtistsDTO getTopArtistsWhenControlExposed(int limit, long userId) {
-        List<ConfetiArtist> topArtists = getAllTopArtists();
-        UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedOnboardArtists(userId);
-        Set<String> favoriteArtistIds = new HashSet<>(cachedArtists.favoriteArtistIds());
-        Set<String> exposedArtistIds = new HashSet<>(cachedArtists.exposedArtistIds());
-
-        UserOnboardTopArtistsDTO userOnboardTopArtistsDTO = UserOnboardTopArtistsDTO.from(
-            getFilteredArtists(topArtists, favoriteArtistIds, limit));
-
-        userOnboardTopArtistsDTO.artists()
-            .forEach(artist -> exposedArtistIds.add(artist.id()));
-
-        userOnboardService.cacheOnboardArtists(userId,
-            UserOnboardCacheDTO.of(favoriteArtistIds, exposedArtistIds));
-
-        return userOnboardTopArtistsDTO;
-    }
-
     public UserOnboardRelatedArtistsDTO getRelatedArtists(
         long userId,
         String requestArtistId,
@@ -137,26 +102,6 @@ public class UserOnboardFacade {
 //        cacheFavoriteArtists(userId, requestArtistId, cachedOnboardArtists);
 
         return UserOnboardRelatedArtistsDTO.from(filteredRelatedArtists);
-    }
-
-    /**
-     * exposed Artist 를 사용할 경우의 RelatedArtists 조회 메서드
-     */
-    public UserOnboardRelatedArtistsDTO getRelatedArtistsWhenControlExposed(
-        long userId,
-        String requestArtistId,
-        int limit
-    ) {
-        UserOnboardCacheDTO cachedOnboardArtists = userOnboardService.getCachedOnboardArtists(userId);
-
-        List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
-            FIXED_RELATED_ARTISTS_FETCH_SIZE);
-        List<ConfetiArtist> filteredRelatedArtists = getFilteredArtists(
-            relatedArtists, cachedOnboardArtists.exposedArtistIds(), limit);
-
-        cacheRelatedArtists(userId, requestArtistId, cachedOnboardArtists, filteredRelatedArtists);
-
-        return UserOnboardRelatedArtistsDTO.from(relatedArtists);
     }
 
     @Deprecated
@@ -256,29 +201,6 @@ public class UserOnboardFacade {
             new LinkedHashSet<>(List.of(requestArtist)));
 
         userOnboardService.cacheOnboardArtists(userId, newUserOnboardCacheDTO);
-    }
-
-    /**
-     * exposed Artist 를 사용할 경우의 RelatedArtists 캐싱 메서드
-     */
-    private void cacheRelatedArtists(
-        long userId,
-        String requestArtistId,
-        UserOnboardCacheDTO userOnboardCacheDTO,
-        List<ConfetiArtist> artists
-    ) {
-        Set<String> newFavoriteArtistIds = new HashSet<>(userOnboardCacheDTO.favoriteArtistIds());
-        Set<String> newExposedArtistIds = new HashSet<>(userOnboardCacheDTO.exposedArtistIds());
-
-        List<String> exposedArtistIds = artists.stream()
-            .map(ConfetiArtist::getId)
-            .toList();
-
-        newFavoriteArtistIds.add(requestArtistId);
-        newExposedArtistIds.addAll(exposedArtistIds);
-
-        userOnboardService.cacheOnboardArtists(userId,
-            UserOnboardCacheDTO.of(newFavoriteArtistIds, newExposedArtistIds));
     }
 
     private void validOnboardArtists(UserOnboardCacheDTO userOnboardCacheDTO) {

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -189,9 +189,11 @@ public class UserOnboardFacade {
         long userId,
         AddOnboardFavoriteArtistDTO requestDTO
     ) {
+        List<ConfetiArtist> newFavoriteArtists = musicAPIHandler.getArtistsByArtistIds(
+            requestDTO.artistIds());
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedOnboardArtists(userId);
         UserOnboardCacheDTO newUserOnboardCacheDTO
-            = cachedArtists.withAddFavoriteArtist(requestDTO.toConfetiArtist());
+            = cachedArtists.withAddFavoriteArtists(newFavoriteArtists);
         userOnboardService.cacheOnboardArtists(userId, newUserOnboardCacheDTO);
 
         List<ConfetiArtist> favoriteArtists = newUserOnboardCacheDTO.favoriteArtists().stream()

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,10 +1,8 @@
 package org.sopt.confeti.api.user.facade;
 
-import com.fasterxml.jackson.core.type.TypeReference;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import java.util.Collection;
 import java.util.LinkedHashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -12,6 +10,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.user.facade.dto.request.PatchOnboardFavoriteArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.GetOnboardStatusDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardCacheDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardFavoriteArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardRelatedArtistsDTO;
@@ -75,23 +74,32 @@ public class UserOnboardFacade {
         return UserOnboardTopArtistsDTO.from(topArtists);
     }
 
-    public UserOnboardTopArtistsDTO getTopArtists(int limit, long userId) {
+    public UserOnboardArtistsDTO getOnboardArtists(
+        int limit,
+        long userId,
+        Optional<String> targetArtistId
+    ) {
+        if (targetArtistId.isPresent()) {
+            return getRelatedArtistsV4(userId, targetArtistId.get(), limit);
+        }
+        return getTopArtists(limit, userId);
+    }
+
+    public UserOnboardArtistsDTO getTopArtists(int limit, long userId) {
         List<ConfetiArtist> topArtists = getAllTopArtists();
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedOnboardArtists(userId);
 
-        UserOnboardTopArtistsDTO userOnboardTopArtistsDTO = UserOnboardTopArtistsDTO.from(
-            getFilteredArtists(topArtists, cachedArtists.favoriteArtistIds(), limit)
-        );
-
-        return userOnboardTopArtistsDTO;
+        return UserOnboardArtistsDTO.from(
+            getFilteredArtists(topArtists, cachedArtists.favoriteArtistIds(), limit));
     }
 
-    public UserOnboardRelatedArtistsDTO getRelatedArtists(
+    public UserOnboardArtistsDTO getRelatedArtistsV4(
         long userId,
         String requestArtistId,
         int limit
     ) {
-        UserOnboardCacheDTO cachedOnboardArtists = userOnboardService.getCachedOnboardArtists(userId);
+        UserOnboardCacheDTO cachedOnboardArtists = userOnboardService.getCachedOnboardArtists(
+            userId);
         List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
             FIXED_RELATED_ARTISTS_FETCH_SIZE);
         List<ConfetiArtist> filteredRelatedArtists = getFilteredArtists(
@@ -99,7 +107,23 @@ public class UserOnboardFacade {
             cachedOnboardArtists.favoriteArtists().stream().map(ConfetiArtist::getId)
                 .collect(Collectors.toSet()), limit);
 
-//        cacheFavoriteArtists(userId, requestArtistId, cachedOnboardArtists);
+        return UserOnboardArtistsDTO.from(filteredRelatedArtists);
+    }
+
+    @Deprecated
+    public UserOnboardRelatedArtistsDTO getRelatedArtists(
+        long userId,
+        String requestArtistId,
+        int limit
+    ) {
+        UserOnboardCacheDTO cachedOnboardArtists = userOnboardService.getCachedOnboardArtists(
+            userId);
+        List<ConfetiArtist> relatedArtists = musicAPIHandler.getRelatedArtists(requestArtistId,
+            FIXED_RELATED_ARTISTS_FETCH_SIZE);
+        List<ConfetiArtist> filteredRelatedArtists = getFilteredArtists(
+            relatedArtists,
+            cachedOnboardArtists.favoriteArtists().stream().map(ConfetiArtist::getId)
+                .collect(Collectors.toSet()), limit);
 
         return UserOnboardRelatedArtistsDTO.from(filteredRelatedArtists);
     }
@@ -166,7 +190,8 @@ public class UserOnboardFacade {
     }
 
     private List<ConfetiArtist> getAllTopArtists() {
-        List<ConfetiArtist> cachedTopArtists = redisHandler.getList(RedisKey.MUSIC_TOP_ARTISTS.createKeyInfo());
+        List<ConfetiArtist> cachedTopArtists = redisHandler.getList(
+            RedisKey.MUSIC_TOP_ARTISTS.createKeyInfo());
 
         if (!cachedTopArtists.isEmpty()) {
             return cachedTopArtists;

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -190,8 +190,8 @@ public class UserOnboardFacade {
         AddOnboardFavoriteArtistDTO requestDTO
     ) {
         UserOnboardCacheDTO cachedArtists = userOnboardService.getCachedOnboardArtists(userId);
-        UserOnboardCacheDTO newUserOnboardCacheDTO = cachedArtists.withAddFavoriteArtists(
-            List.of(requestDTO.toConfetiArtist()));
+        UserOnboardCacheDTO newUserOnboardCacheDTO
+            = cachedArtists.withAddFavoriteArtist(requestDTO.toConfetiArtist());
         userOnboardService.cacheOnboardArtists(userId, newUserOnboardCacheDTO);
 
         List<ConfetiArtist> favoriteArtists = newUserOnboardCacheDTO.favoriteArtists().stream()

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -7,7 +7,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.confeti.api.user.facade.dto.request.PatchOnboardFavoriteArtistsDTO;
+import org.sopt.confeti.api.user.facade.dto.request.onboard.PatchOnboardFavoriteArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.GetOnboardStatusDTO;
 import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardArtistsDTO;

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.api.user.facade;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -71,6 +72,17 @@ public class UserOnboardFacade {
 
         List<ConfetiArtist> topArtists = musicAPIHandler.getArtistsByArtistIds(topArtistIds);
         return UserOnboardTopArtistsDTO.from(topArtists);
+    }
+
+    public UserOnboardArtistsDTO getOnboardArtists(
+        int limit,
+        long userId,
+        Optional<String> targetArtistId
+    ) {
+        if (targetArtistId.isPresent()) {
+            return getRelatedArtistsV4(userId, targetArtistId.get(), limit);
+        }
+        return getTopArtists(limit, userId);
     }
 
     public UserOnboardArtistsDTO getTopArtists(int limit, long userId) {

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserOnboardFacade.java
@@ -1,7 +1,6 @@
 package org.sopt.confeti.api.user.facade;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -72,17 +71,6 @@ public class UserOnboardFacade {
 
         List<ConfetiArtist> topArtists = musicAPIHandler.getArtistsByArtistIds(topArtistIds);
         return UserOnboardTopArtistsDTO.from(topArtists);
-    }
-
-    public UserOnboardArtistsDTO getOnboardArtists(
-        int limit,
-        long userId,
-        Optional<String> targetArtistId
-    ) {
-        if (targetArtistId.isPresent()) {
-            return getRelatedArtistsV4(userId, targetArtistId.get(), limit);
-        }
-        return getTopArtists(limit, userId);
     }
 
     public UserOnboardArtistsDTO getTopArtists(int limit, long userId) {

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/request/onboard/AddOnboardFavoriteArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/request/onboard/AddOnboardFavoriteArtistDTO.java
@@ -1,0 +1,15 @@
+package org.sopt.confeti.api.user.facade.dto.request.onboard;
+
+
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record AddOnboardFavoriteArtistDTO(
+    String artistId,
+    String name,
+    String profileUrl
+) {
+
+    public ConfetiArtist toConfetiArtist() {
+        return ConfetiArtist.of(artistId, name, profileUrl);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/request/onboard/AddOnboardFavoriteArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/request/onboard/AddOnboardFavoriteArtistDTO.java
@@ -1,15 +1,10 @@
 package org.sopt.confeti.api.user.facade.dto.request.onboard;
 
 
-import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+import java.util.Set;
 
 public record AddOnboardFavoriteArtistDTO(
-    String artistId,
-    String name,
-    String profileUrl
+    Set<String> artistIds
 ) {
 
-    public ConfetiArtist toConfetiArtist() {
-        return ConfetiArtist.of(artistId, name, profileUrl);
-    }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/request/onboard/PatchOnboardFavoriteArtistsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/request/onboard/PatchOnboardFavoriteArtistsDTO.java
@@ -1,4 +1,4 @@
-package org.sopt.confeti.api.user.facade.dto.request;
+package org.sopt.confeti.api.user.facade.dto.request.onboard;
 
 import java.util.Set;
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardArtistDTO.java
@@ -1,0 +1,19 @@
+package org.sopt.confeti.api.user.facade.dto.response.onboard;
+
+
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardArtistDTO(
+    String id,
+    String profileUrl,
+    String name
+) {
+
+    public static UserOnboardArtistDTO from(ConfetiArtist artist) {
+        return new UserOnboardArtistDTO(
+            artist.getId(),
+            artist.getProfileUrl(),
+            artist.getName()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardArtistsDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardArtistsDTO.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.facade.dto.response.onboard;
+
+import java.util.List;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record UserOnboardArtistsDTO(
+    List<UserOnboardArtistDTO> artists
+) {
+
+    public static UserOnboardArtistsDTO from(List<ConfetiArtist> artists) {
+        return new UserOnboardArtistsDTO(
+            artists.stream()
+                .map(UserOnboardArtistDTO::from)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.api.user.facade.dto.response.onboard;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -45,5 +46,17 @@ public record UserOnboardCacheDTO(
 
     public static UserOnboardCacheDTO createWithFavoriteArtistIds(Set<String> favoriteArtistIds) {
         return new UserOnboardCacheDTO(favoriteArtistIds, Collections.emptySet());
+    }
+
+    public UserOnboardCacheDTO withAddFavoriteArtistIds(Collection<String> newFavoriteArtistIds) {
+        Set<String> currentFavoriteArtistIds = new LinkedHashSet<>(this.favoriteArtistIds);
+        currentFavoriteArtistIds.addAll(newFavoriteArtistIds);
+        return new UserOnboardCacheDTO(currentFavoriteArtistIds, this.exposedArtistIds);
+    }
+
+    public UserOnboardCacheDTO deleteFavoriteArtistIds(Collection<String> targetArtistIds) {
+        Set<String> currentFavoriteArtistIds = new LinkedHashSet<>(this.favoriteArtistIds);
+        currentFavoriteArtistIds.removeAll(targetArtistIds);
+        return new UserOnboardCacheDTO(currentFavoriteArtistIds, this.exposedArtistIds);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -9,8 +9,10 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+import org.sopt.confeti.global.annotation.RedisSerializable;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 
+@RedisSerializable
 public record UserOnboardCacheDTO(
     @JsonDeserialize(as = LinkedHashSet.class)
     Set<ConfetiArtist> favoriteArtists,
@@ -51,11 +53,11 @@ public record UserOnboardCacheDTO(
         return new UserOnboardCacheDTO(Collections.emptySet(), Collections.emptySet());
     }
 
-    public UserOnboardCacheDTO withAddFavoriteArtistIds(
-        Collection<ConfetiArtist> newFavoriteArtistIds
+    public UserOnboardCacheDTO withAddFavoriteArtists(
+        Collection<ConfetiArtist> newFavoriteArtists
     ) {
         Set<ConfetiArtist> currentFavoriteArtistIds = new LinkedHashSet<>(this.favoriteArtists);
-        currentFavoriteArtistIds.addAll(newFavoriteArtistIds);
+        currentFavoriteArtistIds.addAll(newFavoriteArtists);
         return new UserOnboardCacheDTO(currentFavoriteArtistIds, this.exposedArtistIds);
     }
 
@@ -63,7 +65,7 @@ public record UserOnboardCacheDTO(
         Set<String> targetIds = new HashSet<>(targetArtistIds);
         Set<ConfetiArtist> currentFavoriteArtists = new LinkedHashSet<>(this.favoriteArtists);
 
-        currentFavoriteArtists.removeIf(targetIds::contains);
+        currentFavoriteArtists.removeIf(confetiArtist -> targetIds.contains(confetiArtist.getId()));
 
         return new UserOnboardCacheDTO(currentFavoriteArtists, this.exposedArtistIds);
     }

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -9,15 +9,16 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 
 public record UserOnboardCacheDTO(
     @JsonDeserialize(as = LinkedHashSet.class)
-    Set<String> favoriteArtistIds,
+    Set<ConfetiArtist> favoriteArtists,
     Set<String> exposedArtistIds
 ) {
 
     public UserOnboardCacheDTO {
-        favoriteArtistIds = new LinkedHashSet<>(favoriteArtistIds);
+        favoriteArtists = new LinkedHashSet<>(favoriteArtists);
         exposedArtistIds = new HashSet<>(exposedArtistIds);
     }
 
@@ -34,29 +35,30 @@ public record UserOnboardCacheDTO(
     }
 
     public static UserOnboardCacheDTO of(
-        Set<String> favoriteArtistIds,
+        Set<ConfetiArtist> favoriteArtists,
         Set<String> exposedArtistIds
     ) {
-        return new UserOnboardCacheDTO(favoriteArtistIds, exposedArtistIds);
+        return new UserOnboardCacheDTO(favoriteArtists, exposedArtistIds);
     }
 
     public static UserOnboardCacheDTO empty() {
         return new UserOnboardCacheDTO(Collections.emptySet(), Collections.emptySet());
     }
 
-    public static UserOnboardCacheDTO createWithFavoriteArtistIds(Set<String> favoriteArtistIds) {
-        return new UserOnboardCacheDTO(favoriteArtistIds, Collections.emptySet());
-    }
-
-    public UserOnboardCacheDTO withAddFavoriteArtistIds(Collection<String> newFavoriteArtistIds) {
-        Set<String> currentFavoriteArtistIds = new LinkedHashSet<>(this.favoriteArtistIds);
+    public UserOnboardCacheDTO withAddFavoriteArtistIds(
+        Collection<ConfetiArtist> newFavoriteArtistIds
+    ) {
+        Set<ConfetiArtist> currentFavoriteArtistIds = new LinkedHashSet<>(this.favoriteArtists);
         currentFavoriteArtistIds.addAll(newFavoriteArtistIds);
         return new UserOnboardCacheDTO(currentFavoriteArtistIds, this.exposedArtistIds);
     }
 
     public UserOnboardCacheDTO deleteFavoriteArtistIds(Collection<String> targetArtistIds) {
-        Set<String> currentFavoriteArtistIds = new LinkedHashSet<>(this.favoriteArtistIds);
-        currentFavoriteArtistIds.removeAll(targetArtistIds);
-        return new UserOnboardCacheDTO(currentFavoriteArtistIds, this.exposedArtistIds);
+        Set<String> targetIds = new HashSet<>(targetArtistIds);
+        Set<ConfetiArtist> currentFavoriteArtists = new LinkedHashSet<>(this.favoriteArtists);
+
+        currentFavoriteArtists.removeIf(targetIds::contains);
+
+        return new UserOnboardCacheDTO(currentFavoriteArtists, this.exposedArtistIds);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -5,6 +5,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistDTO;
@@ -59,6 +60,12 @@ public record UserOnboardCacheDTO(
         Set<ConfetiArtist> currentFavoriteArtistIds = new LinkedHashSet<>(this.favoriteArtists);
         currentFavoriteArtistIds.addAll(newFavoriteArtists);
         return new UserOnboardCacheDTO(currentFavoriteArtistIds, this.exposedArtistIds);
+    }
+
+    public UserOnboardCacheDTO withAddFavoriteArtist(
+        ConfetiArtist newFavoriteArtist
+    ) {
+        return withAddFavoriteArtists(List.of(newFavoriteArtist));
     }
 
     public UserOnboardCacheDTO deleteFavoriteArtistIds(Collection<String> targetArtistIds) {

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -1,6 +1,8 @@
 package org.sopt.confeti.api.user.facade.dto.response.onboard;
 
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistDTO;
@@ -10,6 +12,11 @@ public record UserOnboardCacheDTO(
     Set<String> favoriteArtistIds,
     Set<String> exposedArtistIds
 ) {
+
+    public UserOnboardCacheDTO {
+        favoriteArtistIds = new LinkedHashSet<>(favoriteArtistIds);
+        exposedArtistIds = new HashSet<>(exposedArtistIds);
+    }
 
     public static UserOnboardCacheDTO createWithExposedArtistIds(Set<String> exposedArtistIds) {
         return new UserOnboardCacheDTO(Collections.emptySet(), exposedArtistIds);

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.api.user.facade.dto.response.onboard;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.LinkedHashSet;
@@ -9,6 +10,7 @@ import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistDTO;
 import org.sopt.confeti.api.user.facade.dto.response.UserOnboardTopArtistsDTO;
 
 public record UserOnboardCacheDTO(
+    @JsonDeserialize(as = LinkedHashSet.class)
     Set<String> favoriteArtistIds,
     Set<String> exposedArtistIds
 ) {

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/onboard/UserOnboardCacheDTO.java
@@ -22,6 +22,12 @@ public record UserOnboardCacheDTO(
         exposedArtistIds = new HashSet<>(exposedArtistIds);
     }
 
+    public Set<String> favoriteArtistIds() {
+        return favoriteArtists.stream()
+            .map(ConfetiArtist::getId)
+            .collect(Collectors.toCollection(LinkedHashSet::new));
+    }
+
     public static UserOnboardCacheDTO createWithExposedArtistIds(Set<String> exposedArtistIds) {
         return new UserOnboardCacheDTO(Collections.emptySet(), exposedArtistIds);
     }

--- a/src/main/java/org/sopt/confeti/global/common/redis/RedisKey.java
+++ b/src/main/java/org/sopt/confeti/global/common/redis/RedisKey.java
@@ -7,6 +7,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.setlist.facade.dto.request.SetlistMusicEditDTO;
+import org.sopt.confeti.api.user.facade.dto.response.onboard.UserOnboardCacheDTO;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.resolver.music_api.music.vo.ConfetiMusic;
 import org.sopt.confeti.global.util.music.dto.music.MusicPage;
@@ -14,6 +15,7 @@ import org.springframework.util.StringUtils;
 
 /**
  * When adding a new key, if you add a new object, register it with the Pool.
+ *
  * @see RedisSerializePool
  */
 @Slf4j
@@ -21,19 +23,24 @@ import org.springframework.util.StringUtils;
 public enum RedisKey {
     // music api handler
     MUSIC_ARTISTS("apple-music-api:artists:%s", ConfetiArtist.class, Duration.ofHours(1)),
-    MUSIC_ARTISTS_RELATED("apple-music-api:artists-related:%s:%d", ConfetiArtist.class, Duration.ofHours(1)),
-    MUSIC_ARTISTS_TOP_MUSICS("apple-music-api:artists:top-musics:%s", ConfetiMusic.class, Duration.ofHours(1)),
+    MUSIC_ARTISTS_RELATED("apple-music-api:artists-related:%s:%d", ConfetiArtist.class,
+        Duration.ofHours(1)),
+    MUSIC_ARTISTS_TOP_MUSICS("apple-music-api:artists:top-musics:%s", ConfetiMusic.class,
+        Duration.ofHours(1)),
     MUSIC_MUSICS("apple-music-api:musics:%s", ConfetiMusic.class, Duration.ofHours(1)),
     MUSIC_TOP_MUSICS("apple-music-api:top-musics", ConfetiMusic.class, Duration.ofHours(1)),
     MUSIC_TOP_ARTISTS("apple-music-api:top-artists", ConfetiArtist.class, Duration.ofHours(1)),
-    MUSIC_PAGE_ARTIST_OFFSET_LIMIT("apple-music-api:music-page:artists:%s:%d:%d", MusicPage.class, Duration.ofHours(1)),
-    MUSIC_PAGE_KEYWORD_OFFSET_LIMIT("apple-music-api:music-page:keyword:%s:%d:%d", MusicPage.class, Duration.ofHours(1)),
+    MUSIC_PAGE_ARTIST_OFFSET_LIMIT("apple-music-api:music-page:artists:%s:%d:%d", MusicPage.class,
+        Duration.ofHours(1)),
+    MUSIC_PAGE_KEYWORD_OFFSET_LIMIT("apple-music-api:music-page:keyword:%s:%d:%d", MusicPage.class,
+        Duration.ofHours(1)),
 
     // user refresh token
     USER_REFRESH_TOKEN("user:refresh-token:%d", String.class, Duration.ofHours(1)),
 
     // user onboard
-    USER_ONBOARD_TOP_ARTISTS("user:onboard:top-artists:%d", String.class, Duration.ofHours(1)),
+    USER_ONBOARD_TOP_ARTISTS("user:onboard:top-artists:%d", UserOnboardCacheDTO.class,
+        Duration.ofHours(1)),
 
     // setlist
     SETLIST_EDIT("edit:setlist:%d:%d", SetlistMusicEditDTO.class, Duration.ofHours(1)),
@@ -76,12 +83,14 @@ public enum RedisKey {
             String key = String.format(format, firstArg, secondArg, thirdArg);
 
             return KeyInfo.<T>builder()
-                    .type((Class<T>) type)
-                    .key(key)
-                    .ttl(ttl)
-                    .build();
+                .type((Class<T>) type)
+                .key(key)
+                .ttl(ttl)
+                .build();
         } catch (IllegalFormatException e) {
-            log.warn("RedisKey.createKeyInfo : Format String not matched with arguments. format : {}, first arg : {}, second arg : {}, third arg : {}", format, firstArg, secondArg, thirdArg);
+            log.warn(
+                "RedisKey.createKeyInfo : Format String not matched with arguments. format : {}, first arg : {}, second arg : {}, third arg : {}",
+                format, firstArg, secondArg, thirdArg);
             return null;
         }
     }

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
@@ -3,7 +3,6 @@ package org.sopt.confeti.global.resolver.music_api.artist.vo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Transient;
-import java.util.Objects;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -40,19 +39,20 @@ public class ConfetiArtist {
     }
 
     public static ConfetiArtist from(final AppleMusicArtistResponse artist) {
-        Optional<AppleMusicArtistAttributesResponse> optAttributes = Optional.ofNullable(artist.attributes());
+        Optional<AppleMusicArtistAttributesResponse> optAttributes = Optional.ofNullable(
+            artist.attributes());
         String name = optAttributes.map(AppleMusicArtistAttributesResponse::name).orElse(null);
         String profileUrl = optAttributes.map(AppleMusicArtistAttributesResponse::artwork)
-                .map(AppleMusicArtistArtworkResponse::url)
-                .map(url -> UriComponentsBuilder.fromUriString(url)
-                        .buildAndExpand(ArtistConstant.PROFILE_IMG_SIZE)
-                        .toUriString()
-                ).orElse(null);
+            .map(AppleMusicArtistArtworkResponse::url)
+            .map(url -> UriComponentsBuilder.fromUriString(url)
+                .buildAndExpand(ArtistConstant.PROFILE_IMG_SIZE)
+                .toUriString()
+            ).orElse(null);
 
         return new ConfetiArtist(
-                artist.id(),
-                name,
-                profileUrl
+            artist.id(),
+            name,
+            profileUrl
         );
     }
 
@@ -62,5 +62,10 @@ public class ConfetiArtist {
 
     public static ConfetiArtist empty() {
         return new ConfetiArtist();
+    }
+
+    public static ConfetiArtist of(final String artistId, final String name,
+        final String profileUrl) {
+        return new ConfetiArtist(artistId, name, profileUrl);
     }
 }

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
@@ -72,6 +72,9 @@ public class ConfetiArtist {
 
     @Override
     public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
         if (!(o instanceof ConfetiArtist that)) {
             return false;
         }

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.global.resolver.music_api.artist.vo;
 import jakarta.persistence.Column;
 import jakarta.persistence.Embeddable;
 import jakarta.persistence.Transient;
+import java.util.Objects;
 import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -67,5 +68,18 @@ public class ConfetiArtist {
     public static ConfetiArtist of(final String artistId, final String name,
         final String profileUrl) {
         return new ConfetiArtist(artistId, name, profileUrl);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (!(o instanceof ConfetiArtist that)) {
+            return false;
+        }
+        return Objects.equals(id, that.id);
+    }
+
+    @Override
+    public int hashCode() {
+        return Objects.hashCode(id);
     }
 }


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 온보딩 API 플로우 수정
  - 클라 측 요구사항에 맞춰 기존 온보딩 API 를 수정
  - 기존 API
    - Top Artist 조회
    - Related Artist 조회 - 해당 API의 path variable이 자동으로 Favorite Artist에 추가되는 형태였음
  - 수정 후 API
    - Onboard Artist 조회 - 쿼리스트링으로 targetArtistId 를 받으며, 해당 값의 존재 유무에 따라 Top 혹은 Related Artist 가 반환됨 
    - Favorite Artist 추가 - 응답으로 요청한 Artist 를 추가한 후 현재의 Favorite Artist 목록을 반환함.
- 온보딩 아티스트 캐싱 방식 수정
  - LinkedHashSet 을 사용하도록 수정
  - 매번 AppleMusic 에 의존하지 않도록 ConfetiArtist 자체를 캐싱하도록 수정

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
- ~현재 Post로 onboardArtist 를 받고 있는데,,, 사용자가 profileUrl이나 name을 자기 맘대로 커스텀해서 requestBody 에 넣으면 대응할 수단이 없네요… 그래도 이게 요청 사용자의 응답에만 영향을 미치고 전파되진 않으므로 우선 이렇게 두었습니다~ 
  - artist ID 목록을 request Body 로 받은 후 Apple Music API 에서 데이터를 가져옴
- onboard 아티스트 조회 API로 Top 혹은 Related Artist 조회를 서버 측에서 다루다보니 DTO가 통일되었습니다. 원래는 상위 DTO 추상 클래스 등으로 만든 후에 각각을 상속받는 UserOnboardTopArtistDto, UserOnboardRelatedDto 로 두고 다형성을 사용해서 Facade 반환값을 처리한 후 Response만 공통으로 가져가는 구조를 고민했는데, Record는 상속이 안돼서 이 부분만 Class로 통일성을 깨야하는게 좀 걸렸고 현재 기준으로는 필드값이 동일하기 때문에 급하게 나눌 필요성이 없다고 느껴서 공통으로 사용하는 DTO 및 Response를 두었습니다. 
