### PR TITLE
CONFETI-51 feat: SQS Listener Container 를 애플리케이션이 완전히 실행된 후에 동작하도록 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/global/config/SqsConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/SqsConfig.java
@@ -43,9 +43,10 @@ public class SqsConfig {
         return SqsMessageListenerContainerFactory
             .builder()
             .configure(options -> options
-                .maxConcurrentMessages(2)
-                .maxMessagesPerPoll(2)
-                .pollTimeout(Duration.ofSeconds(20)))
+                .componentsTaskExecutor(consumerExecutor)
+                .maxMessagesPerPoll(10)
+                .pollTimeout(Duration.ofSeconds(20))
+                .autoStartup(false))
             .sqsAsyncClient(sqsAsyncClient)
             .build();
     }

--- a/src/main/java/org/sopt/confeti/global/config/SqsConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/SqsConfig.java
@@ -4,6 +4,7 @@ import static org.sopt.confeti.global.config.ThreadPoolConfig.MESSAGE_CONSUMER_P
 import static org.sopt.confeti.global.config.ThreadPoolConfig.MESSAGE_PROVIDER_POOL;
 
 import io.awspring.cloud.sqs.config.SqsMessageListenerContainerFactory;
+import io.awspring.cloud.sqs.listener.acknowledgement.handler.AcknowledgementMode;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.time.Duration;
 import java.util.concurrent.Executor;
@@ -35,8 +36,12 @@ public class SqsConfig {
             .build();
     }
 
+    /**
+     * AcknowledgementMode.MANUAL: 폴링해온 메세지 목록의 삭제를 개별적으로 수행하기 위함 autoStartup(false): start 시점을
+     * 애플리케이션 실행 이후에 수동으로 지정
+     */
     @Bean
-    public SqsMessageListenerContainerFactory defaultSqsListenerContainerFactory(
+    public SqsMessageListenerContainerFactory createEventSqsListenerContainerFactory(
         SqsAsyncClient sqsAsyncClient,
         @Qualifier(MESSAGE_CONSUMER_POOL) TaskExecutor consumerExecutor
     ) {
@@ -44,6 +49,7 @@ public class SqsConfig {
             .builder()
             .configure(options -> options
                 .componentsTaskExecutor(consumerExecutor)
+                .acknowledgementMode(AcknowledgementMode.MANUAL)
                 .maxMessagesPerPoll(10)
                 .pollTimeout(Duration.ofSeconds(20))
                 .autoStartup(false))

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/SqsListenerStarter.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/SqsListenerStarter.java
@@ -1,0 +1,28 @@
+package org.sopt.confeti.global.messagebroker.sqs;
+
+import io.awspring.cloud.sqs.listener.DefaultListenerContainerRegistry;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.event.ApplicationReadyEvent;
+import org.springframework.context.ApplicationListener;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SqsListenerStarter implements ApplicationListener<ApplicationReadyEvent> {
+
+    @SuppressWarnings("SpringJavaInjectionPointsAutowiringInspection")
+    private final DefaultListenerContainerRegistry registry;
+
+    @Override
+    public void onApplicationEvent(ApplicationReadyEvent event) {
+        log.info("registered SQS Listener Container count: {}",
+            registry.getListenerContainers().size());
+        registry.getListenerContainers().forEach(c -> {
+            log.info("SQS Listener Container [{}] starting...", c.getId());
+            c.start();
+            log.info("SQS Listener Container [{}] running: {}", c.getId(), c.isRunning());
+        });
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
@@ -45,6 +45,6 @@ public class CreateSqsStrategy<T extends CreateEventHandler<? extends CreateEven
     @Override
     @SqsListener(value = "${message-broker.sqs.create-event}", factory = "createEventSqsListenerContainerFactory")
     protected void listen(List<Message<String>> messages) {
-        pollSqsMessages(messages);
+        consumeSqsMessages(messages);
     }
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.global.messagebroker.sqs.strategy;
 
 import static org.sopt.confeti.global.config.ThreadPoolConfig.MESSAGE_CONSUMER_POOL;
 
+import io.awspring.cloud.sqs.annotation.SqsListener;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
@@ -14,6 +15,7 @@ import org.sopt.confeti.global.util.JsonMapper;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.TaskExecutor;
+import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
@@ -40,4 +42,9 @@ public class CreateSqsStrategy<T extends CreateEventHandler<? extends CreateEven
         asyncSend(super.getQueueUrl(), event);
     }
 
+    @Override
+    @SqsListener(value = "${message-broker.sqs.create-event}", factory = "createEventSqsListenerContainerFactory")
+    protected void listen(List<Message<String>> messages) {
+        pollSqsMessages(messages);
+    }
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
@@ -4,8 +4,6 @@ import static org.sopt.confeti.global.message.ErrorMessage.INTERNAL_SERVER_ERROR
 
 import io.awspring.cloud.sqs.listener.SqsHeaders;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
-import java.time.Duration;
-import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -21,7 +19,6 @@ import org.sopt.confeti.global.notification.SlackNotificationType;
 import org.sopt.confeti.global.util.JsonMapper;
 import org.springframework.core.task.TaskExecutor;
 import org.springframework.messaging.Message;
-import org.springframework.scheduling.annotation.Scheduled;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
@@ -43,9 +40,6 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
     private static final String ATTRIBUTE_TRACE_ID = "traceId";
     private static final String ATTRIBUTE_TYPE_ID = "confetiEventType";
 
-    private static final int MAX_POLLING_MESSAGE_SIZE = 10;
-    private static final int POLLING_TIMEOUT = 20;
-
     protected SqsStrategy(
         List<? extends EventHandler<? extends Event>> eventHandlers,
         String queueUrl,
@@ -63,6 +57,8 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
         this.sqsAsyncClient = sqsAsyncClient;
         this.jsonMapper = jsonMapper;
     }
+
+    abstract void listen(List<Message<String>> messages);
 
     protected void asyncSend(String queueName, Event event) {
         Map<String, Object> messageAttributes = createMessageAttributes(event);
@@ -123,7 +119,6 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
             });
     }
 
-
     protected void handleEvent(String typeId, String payload) {
         EventHandler<? extends Event> eventHandler = super.getEventHandlers().get(typeId);
         if (eventHandler == null) {
@@ -141,19 +136,7 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
         eventHandler.handle(event);
     }
 
-    @Scheduled(fixedDelay = 1000)
-    public void pollSqsMessages() {
-
-        Collection<Message<?>> receivedMessages = sqsTemplate.receiveMany(options -> options
-            .queue(queueUrl)
-            .maxNumberOfMessages(MAX_POLLING_MESSAGE_SIZE)
-            .pollTimeout(Duration.ofSeconds(POLLING_TIMEOUT))
-        );
-
-        if (receivedMessages.isEmpty()) {
-            return;
-        }
-
+    public void pollSqsMessages(List<Message<String>> receivedMessages) {
         List<CompletableFuture<Void>> futures = receivedMessages.stream()
             .map(this::processMessageAndDelete)
             .toList();

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
@@ -136,7 +136,7 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
         eventHandler.handle(event);
     }
 
-    public void pollSqsMessages(List<Message<String>> receivedMessages) {
+    public void consumeSqsMessages(List<Message<String>> receivedMessages) {
         List<CompletableFuture<Void>> futures = receivedMessages.stream()
             .map(this::processMessageAndDelete)
             .toList();


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->

- 서버를 AWS 에서 Oracle 로 옮기면서 재배포 시 서버 리소스가 딸려서 Http 커넥션 풀 타임아웃 오류가 발생했던 것 같아요. 그래서 이번에 애플리케이션이 완전히 실행된 후에 polling을 하도록 설정을 변경했습니다.
- polling 하는 스레드와 consume 하는 스레드를 별도로 관리하기 위함 + 메세지 폴링 제어 시간을 좀 더 세밀하게 컨트롤 할 수 있겠다 는 생각으로 스케줄러로 폴링을 하던 방식에서 SQS Listener Container 를 사용하는 방식으로 다시 회귀했습니다. 큰 불편함이나 단점이 있었던 건 아니고 Listener Container 의 polling 을 start, stop 하는 게 더 관리가 편할 것 같아서 입니다.
- 방식 자체는 기존 스케줄링을 사용할 때와 똑같습니다. 
  -  20초 Long polling 
  - 작업 스레드는 별도 스레드풀을 사용 (sqs-worker-consumer)
  - 메세지는 성공 시 수동으로 개별 삭제

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
