### PR TITLE
CONFETI-52 refactor: SQS 네이밍 및 전략 패턴 리팩토링

### DIFF
--- a/src/main/java/org/sopt/confeti/domain/applemusic/artist/application/ArtistService.java
+++ b/src/main/java/org/sopt/confeti/domain/applemusic/artist/application/ArtistService.java
@@ -19,7 +19,7 @@ public class ArtistService {
     }
 
     public boolean isExistByArtistId(String artistId) {
-        return artistRepository.existsById(artistId);
+        return artistRepository.existsByArtistId(artistId);
     }
 
 }

--- a/src/main/java/org/sopt/confeti/global/config/SqsConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/SqsConfig.java
@@ -41,7 +41,7 @@ public class SqsConfig {
      * 애플리케이션 실행 이후에 수동으로 지정
      */
     @Bean
-    public SqsMessageListenerContainerFactory createEventSqsListenerContainerFactory(
+    public SqsMessageListenerContainerFactory createMessageSqsListenerContainerFactory(
         SqsAsyncClient sqsAsyncClient,
         @Qualifier(MESSAGE_CONSUMER_POOL) TaskExecutor consumerExecutor
     ) {

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBroker.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBroker.java
@@ -1,9 +1,9 @@
 package org.sopt.confeti.global.messagebroker;
 
-import org.sopt.confeti.global.messagebroker.message.Event;
+import org.sopt.confeti.global.messagebroker.message.Message;
 
 public interface MessageBroker {
 
-    void sendEvent(Event event);
+    void sendMessage(Message message);
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerProvider.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerProvider.java
@@ -1,0 +1,45 @@
+package org.sopt.confeti.global.messagebroker;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.global.exception.ConfetiException;
+import org.sopt.confeti.global.message.ErrorMessage;
+import org.sopt.confeti.global.messagebroker.message.Event;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public final class MessageBrokerProvider {
+
+    private final Map<Class<? extends Event>, MessageBrokerStrategy> strategyByEventClass;
+
+    private MessageBrokerProvider(List<MessageBrokerStrategy> messageBrokerStrategies) {
+        this.strategyByEventClass = messageBrokerStrategies.stream()
+            .flatMap(strategy ->
+                strategy.getEventHandlerByEventClass().keySet().stream()
+                    .map(eventClass -> Map.entry(eventClass, strategy))
+            )
+            .collect(Collectors.toUnmodifiableMap(
+                Entry::getKey,
+                Entry::getValue,
+                (strategy1, strategy2) -> {
+                    log.error("Duplicate message class in {}, {}", strategy1.getClass(),
+                        strategy2.getClass());
+                    throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
+                }
+            ));
+    }
+
+    public MessageBrokerStrategy getStrategyByEventClass(Class<? extends Event> eventClass) {
+        MessageBrokerStrategy strategy = strategyByEventClass.get(eventClass);
+        if (strategy == null) {
+            log.error("No strategy about message: {}", eventClass.getName());
+            throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
+        }
+        return strategy;
+    }
+
+}

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerProvider.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerProvider.java
@@ -7,19 +7,19 @@ import java.util.stream.Collectors;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.messagebroker.message.Event;
+import org.sopt.confeti.global.messagebroker.message.Message;
 import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
 public final class MessageBrokerProvider {
 
-    private final Map<Class<? extends Event>, MessageBrokerStrategy> strategyByEventClass;
+    private final Map<Class<? extends Message>, MessageBrokerStrategy> strategyByEventClass;
 
     private MessageBrokerProvider(List<MessageBrokerStrategy> messageBrokerStrategies) {
         this.strategyByEventClass = messageBrokerStrategies.stream()
             .flatMap(strategy ->
-                strategy.getEventHandlerByEventClass().keySet().stream()
+                strategy.getMessageHandlerByMessageClass().keySet().stream()
                     .map(eventClass -> Map.entry(eventClass, strategy))
             )
             .collect(Collectors.toUnmodifiableMap(
@@ -33,7 +33,7 @@ public final class MessageBrokerProvider {
             ));
     }
 
-    public MessageBrokerStrategy getStrategyByEventClass(Class<? extends Event> eventClass) {
+    public MessageBrokerStrategy getStrategyByMessageClass(Class<? extends Message> eventClass) {
         MessageBrokerStrategy strategy = strategyByEventClass.get(eventClass);
         if (strategy == null) {
             log.error("No strategy about message: {}", eventClass.getName());

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerResolver.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerResolver.java
@@ -10,10 +10,10 @@ import org.sopt.confeti.global.messagebroker.message.Message;
 @RequiredArgsConstructor
 public class MessageBrokerResolver {
 
-    private final MessageBrokerProvider messageBrokerProvider;
+    private final MessageStrategyProvider messageStrategyProvider;
 
     public void publish(Message message) {
-        MessageBrokerStrategy strategy = messageBrokerProvider.getStrategyByMessageClass(
+        MessageBrokerStrategy strategy = messageStrategyProvider.getStrategyByMessageClass(
             message.getClass());
         strategy.publish(message);
     }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerResolver.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerResolver.java
@@ -1,41 +1,20 @@
 package org.sopt.confeti.global.messagebroker;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
-import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.global.annotation.Resolver;
-import org.sopt.confeti.global.exception.ConfetiException;
-import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.messagebroker.message.Event;
 
 @Slf4j
 @Resolver
+@RequiredArgsConstructor
 public class MessageBrokerResolver {
 
-    private final Map<Class<? extends Event>, MessageBrokerStrategy> strategyByEventClass;
-
-    protected MessageBrokerResolver(List<MessageBrokerStrategy> messageBrokerStrategies) {
-
-        this.strategyByEventClass = messageBrokerStrategies.stream()
-            .flatMap(strategy ->
-                strategy.getEventHandlerByEventClass().keySet().stream()
-                    .map(eventClass -> Map.entry(eventClass, strategy))
-            )
-            .collect(Collectors.toUnmodifiableMap(
-                Entry::getKey,
-                Entry::getValue,
-                (strategy1, strategy2) -> {
-                    log.error("Duplicate event class in {}, {}", strategy1.getClass(),
-                        strategy2.getClass());
-                    throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
-                }
-            ));
-    }
+    private final MessageBrokerProvider messageBrokerProvider;
 
     public void sendMessage(Event event) {
-        MessageBrokerStrategy strategy = strategyByEventClass.get(event.getClass());
+        MessageBrokerStrategy strategy = messageBrokerProvider.getStrategyByEventClass(
+            event.getClass());
         strategy.sendEvent(event);
     }
 

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerResolver.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerResolver.java
@@ -12,10 +12,10 @@ public class MessageBrokerResolver {
 
     private final MessageBrokerProvider messageBrokerProvider;
 
-    public void sendMessage(Message message) {
+    public void publish(Message message) {
         MessageBrokerStrategy strategy = messageBrokerProvider.getStrategyByMessageClass(
             message.getClass());
-        strategy.sendMessage(message);
+        strategy.publish(message);
     }
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerResolver.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerResolver.java
@@ -3,7 +3,7 @@ package org.sopt.confeti.global.messagebroker;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.global.annotation.Resolver;
-import org.sopt.confeti.global.messagebroker.message.Event;
+import org.sopt.confeti.global.messagebroker.message.Message;
 
 @Slf4j
 @Resolver
@@ -12,10 +12,10 @@ public class MessageBrokerResolver {
 
     private final MessageBrokerProvider messageBrokerProvider;
 
-    public void sendMessage(Event event) {
-        MessageBrokerStrategy strategy = messageBrokerProvider.getStrategyByEventClass(
-            event.getClass());
-        strategy.sendEvent(event);
+    public void sendMessage(Message message) {
+        MessageBrokerStrategy strategy = messageBrokerProvider.getStrategyByMessageClass(
+            message.getClass());
+        strategy.sendMessage(message);
     }
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerStrategy.java
@@ -2,25 +2,38 @@ package org.sopt.confeti.global.messagebroker;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
-import lombok.Getter;
 import org.sopt.confeti.global.messagebroker.handler.MessageHandler;
 import org.sopt.confeti.global.messagebroker.message.Message;
 
-@Getter
 public abstract class MessageBrokerStrategy implements MessagePublisher {
 
-    private final Map<String, ? extends MessageHandler<? extends Message>> messageHandlers;
+    private final Map<String, ? extends MessageHandler<? extends Message>> messageHandlerByTypeId;
     private final Map<Class<? extends Message>, MessageHandler<? extends Message>> messageHandlerByMessageClass;
 
     protected MessageBrokerStrategy(
         List<? extends MessageHandler<? extends Message>> messageHandlers) {
-        this.messageHandlers = messageHandlers.stream().collect(Collectors.toUnmodifiableMap(
+        this.messageHandlerByTypeId = messageHandlers.stream().collect(Collectors.toUnmodifiableMap(
             MessageHandler::getSupportedTypeId, Function.identity()));
         this.messageHandlerByMessageClass = messageHandlers.stream()
             .collect(Collectors.toUnmodifiableMap(
                 MessageHandler::getSupportedType, Function.identity()));
+    }
+
+    public final Set<Class<? extends Message>> getSupportedMessageClasses() {
+        return messageHandlerByMessageClass.keySet();
+    }
+
+    protected final MessageHandler<? extends Message> getHandlerByMessageClass(
+        Class<? extends Message> messageClass) {
+        return messageHandlerByMessageClass.get(messageClass);
+
+    }
+
+    protected final MessageHandler<? extends Message> getHandlerByTypeId(String typeId) {
+        return messageHandlerByTypeId.get(typeId);
     }
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerStrategy.java
@@ -9,7 +9,7 @@ import org.sopt.confeti.global.messagebroker.handler.MessageHandler;
 import org.sopt.confeti.global.messagebroker.message.Message;
 
 @Getter
-public abstract class MessageBrokerStrategy implements MessageBroker {
+public abstract class MessageBrokerStrategy implements MessagePublisher {
 
     private final Map<String, ? extends MessageHandler<? extends Message>> messageHandlers;
     private final Map<Class<? extends Message>, MessageHandler<? extends Message>> messageHandlerByMessageClass;

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageBrokerStrategy.java
@@ -2,31 +2,25 @@ package org.sopt.confeti.global.messagebroker;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.Getter;
-import org.sopt.confeti.global.messagebroker.handler.EventHandler;
-import org.sopt.confeti.global.messagebroker.message.Event;
+import org.sopt.confeti.global.messagebroker.handler.MessageHandler;
+import org.sopt.confeti.global.messagebroker.message.Message;
 
 @Getter
 public abstract class MessageBrokerStrategy implements MessageBroker {
 
-    private final Map<String, ? extends EventHandler<? extends Event>> eventHandlers;
-    private final Map<Class<? extends Event>, EventHandler<? extends Event>> eventHandlerByEventClass;
+    private final Map<String, ? extends MessageHandler<? extends Message>> messageHandlers;
+    private final Map<Class<? extends Message>, MessageHandler<? extends Message>> messageHandlerByMessageClass;
 
-    protected MessageBrokerStrategy(List<? extends EventHandler<? extends Event>> eventHandlers) {
-        this.eventHandlers = eventHandlers.stream().collect(Collectors.toUnmodifiableMap(
-            EventHandler::getSupportedTypeId, Function.identity()));
-        this.eventHandlerByEventClass = eventHandlers.stream()
+    protected MessageBrokerStrategy(
+        List<? extends MessageHandler<? extends Message>> messageHandlers) {
+        this.messageHandlers = messageHandlers.stream().collect(Collectors.toUnmodifiableMap(
+            MessageHandler::getSupportedTypeId, Function.identity()));
+        this.messageHandlerByMessageClass = messageHandlers.stream()
             .collect(Collectors.toUnmodifiableMap(
-                EventHandler::getSupportedType, Function.identity()));
-    }
-
-    public boolean isSupported(Class<? extends Event> eventClass) {
-        Optional<EventHandler<? extends Event>> eventHandler = Optional.ofNullable(
-            eventHandlerByEventClass.get(eventClass));
-        return eventHandler.isPresent();
+                MessageHandler::getSupportedType, Function.identity()));
     }
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessagePublisher.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessagePublisher.java
@@ -2,8 +2,8 @@ package org.sopt.confeti.global.messagebroker;
 
 import org.sopt.confeti.global.messagebroker.message.Message;
 
-public interface MessageBroker {
+public interface MessagePublisher {
 
-    void sendMessage(Message message);
+    void publish(Message message);
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageStrategyProvider.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageStrategyProvider.java
@@ -19,7 +19,7 @@ public final class MessageStrategyProvider {
     private MessageStrategyProvider(List<MessageBrokerStrategy> messageBrokerStrategies) {
         this.strategyByMessageClass = messageBrokerStrategies.stream()
             .flatMap(strategy ->
-                strategy.getMessageHandlerByMessageClass().keySet().stream()
+                strategy.getSupportedMessageClasses().stream()
                     .map(messageClass -> Map.entry(messageClass, strategy))
             )
             .collect(Collectors.toUnmodifiableMap(

--- a/src/main/java/org/sopt/confeti/global/messagebroker/MessageStrategyProvider.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/MessageStrategyProvider.java
@@ -12,15 +12,15 @@ import org.springframework.stereotype.Component;
 
 @Slf4j
 @Component
-public final class MessageBrokerProvider {
+public final class MessageStrategyProvider {
 
-    private final Map<Class<? extends Message>, MessageBrokerStrategy> strategyByEventClass;
+    private final Map<Class<? extends Message>, MessageBrokerStrategy> strategyByMessageClass;
 
-    private MessageBrokerProvider(List<MessageBrokerStrategy> messageBrokerStrategies) {
-        this.strategyByEventClass = messageBrokerStrategies.stream()
+    private MessageStrategyProvider(List<MessageBrokerStrategy> messageBrokerStrategies) {
+        this.strategyByMessageClass = messageBrokerStrategies.stream()
             .flatMap(strategy ->
                 strategy.getMessageHandlerByMessageClass().keySet().stream()
-                    .map(eventClass -> Map.entry(eventClass, strategy))
+                    .map(messageClass -> Map.entry(messageClass, strategy))
             )
             .collect(Collectors.toUnmodifiableMap(
                 Entry::getKey,
@@ -33,10 +33,10 @@ public final class MessageBrokerProvider {
             ));
     }
 
-    public MessageBrokerStrategy getStrategyByMessageClass(Class<? extends Message> eventClass) {
-        MessageBrokerStrategy strategy = strategyByEventClass.get(eventClass);
+    public MessageBrokerStrategy getStrategyByMessageClass(Class<? extends Message> messageClass) {
+        MessageBrokerStrategy strategy = strategyByMessageClass.get(messageClass);
         if (strategy == null) {
-            log.error("No strategy about message: {}", eventClass.getName());
+            log.error("No strategy about message: {}", messageClass.getName());
             throw new ConfetiException(ErrorMessage.INTERNAL_SERVER_ERROR);
         }
         return strategy;

--- a/src/main/java/org/sopt/confeti/global/messagebroker/handler/CreateEventHandler.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/handler/CreateEventHandler.java
@@ -1,8 +1,0 @@
-package org.sopt.confeti.global.messagebroker.handler;
-
-import org.sopt.confeti.global.messagebroker.message.CreateEvent;
-
-public interface CreateEventHandler<T extends CreateEvent> extends EventHandler<T> {
-
-}
-

--- a/src/main/java/org/sopt/confeti/global/messagebroker/handler/CreateMessageHandler.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/handler/CreateMessageHandler.java
@@ -1,0 +1,8 @@
+package org.sopt.confeti.global.messagebroker.handler;
+
+import org.sopt.confeti.global.messagebroker.message.CreateMessage;
+
+public interface CreateMessageHandler<T extends CreateMessage> extends MessageHandler<T> {
+
+}
+

--- a/src/main/java/org/sopt/confeti/global/messagebroker/handler/MessageHandler.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/handler/MessageHandler.java
@@ -1,8 +1,8 @@
 package org.sopt.confeti.global.messagebroker.handler;
 
-import org.sopt.confeti.global.messagebroker.message.Event;
+import org.sopt.confeti.global.messagebroker.message.Message;
 
-public interface EventHandler<T extends Event> {
+public interface MessageHandler<T extends Message> {
 
     void handle(T event);
 

--- a/src/main/java/org/sopt/confeti/global/messagebroker/handler/MessageHandler.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/handler/MessageHandler.java
@@ -4,7 +4,7 @@ import org.sopt.confeti.global.messagebroker.message.Message;
 
 public interface MessageHandler<T extends Message> {
 
-    void handle(T event);
+    void handle(T message);
 
     Class<T> getSupportedType();
 

--- a/src/main/java/org/sopt/confeti/global/messagebroker/message/CreateMessage.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/message/CreateMessage.java
@@ -1,5 +1,5 @@
 package org.sopt.confeti.global.messagebroker.message;
 
-public interface CreateEvent extends Event {
+public interface CreateMessage extends Message {
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/message/Message.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/message/Message.java
@@ -1,5 +1,5 @@
 package org.sopt.confeti.global.messagebroker.message;
 
-public interface Event {
+public interface Message {
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/event/artist/CreateArtistMessage.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/event/artist/CreateArtistMessage.java
@@ -2,15 +2,15 @@ package org.sopt.confeti.global.messagebroker.sqs.event.artist;
 
 
 import org.sopt.confeti.domain.applemusic.artist.application.dto.request.CreateArtistDTO;
-import org.sopt.confeti.global.messagebroker.message.CreateEvent;
+import org.sopt.confeti.global.messagebroker.message.CreateMessage;
 
-public record CreateArtistEvent(
+public record CreateArtistMessage(
     String artistId,
     String name,
     String artworkUrl,
     Integer artworkWidth,
     Integer artworkHeight
-) implements CreateEvent {
+) implements CreateMessage {
 
     public CreateArtistDTO toCreateDTO() {
         return CreateArtistDTO.builder()

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/event/song/CreateSongMessage.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/event/song/CreateSongMessage.java
@@ -2,15 +2,15 @@ package org.sopt.confeti.global.messagebroker.sqs.event.song;
 
 
 import org.sopt.confeti.domain.applemusic.song.application.dto.request.CreateSongDTO;
-import org.sopt.confeti.global.messagebroker.message.CreateEvent;
+import org.sopt.confeti.global.messagebroker.message.CreateMessage;
 
-public record CreateSongEvent(
+public record CreateSongMessage(
     String songId,
     String name,
     String artworkUrl,
     Integer artworkWidth,
     Integer artworkHeight
-) implements CreateEvent {
+) implements CreateMessage {
 
     public CreateSongDTO toCreateDTO() {
         return CreateSongDTO.builder()

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/SqsMessageHandler.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/SqsMessageHandler.java
@@ -1,5 +1,5 @@
 package org.sopt.confeti.global.messagebroker.sqs.handler;
 
-public interface SqsEventHandler {
+public interface SqsMessageHandler {
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/artist/CreateArtistMessageHandler.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/artist/CreateArtistMessageHandler.java
@@ -4,8 +4,8 @@ package org.sopt.confeti.global.messagebroker.sqs.handler.artist;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.applemusic.artist.application.ArtistService;
 import org.sopt.confeti.global.messagebroker.handler.CreateMessageHandler;
-import org.sopt.confeti.global.messagebroker.sqs.event.artist.CreateArtistMessage;
 import org.sopt.confeti.global.messagebroker.sqs.handler.SqsMessageHandler;
+import org.sopt.confeti.global.messagebroker.sqs.message.artist.CreateArtistMessage;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -18,9 +18,9 @@ public class CreateArtistMessageHandler implements CreateMessageHandler<CreateAr
 
     @Override
     @Transactional
-    public void handle(CreateArtistMessage event) {
-        if (!artistService.isExistByArtistId(event.artistId())) {
-            artistService.create(event.toCreateDTO());
+    public void handle(CreateArtistMessage message) {
+        if (!artistService.isExistByArtistId(message.artistId())) {
+            artistService.create(message.toCreateDTO());
         }
     }
 

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/artist/CreateArtistMessageHandler.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/artist/CreateArtistMessageHandler.java
@@ -3,30 +3,30 @@ package org.sopt.confeti.global.messagebroker.sqs.handler.artist;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.applemusic.artist.application.ArtistService;
-import org.sopt.confeti.global.messagebroker.handler.CreateEventHandler;
-import org.sopt.confeti.global.messagebroker.sqs.event.artist.CreateArtistEvent;
-import org.sopt.confeti.global.messagebroker.sqs.handler.SqsEventHandler;
+import org.sopt.confeti.global.messagebroker.handler.CreateMessageHandler;
+import org.sopt.confeti.global.messagebroker.sqs.event.artist.CreateArtistMessage;
+import org.sopt.confeti.global.messagebroker.sqs.handler.SqsMessageHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-public class CreateArtistEventHandler implements CreateEventHandler<CreateArtistEvent>,
-    SqsEventHandler {
+public class CreateArtistMessageHandler implements CreateMessageHandler<CreateArtistMessage>,
+    SqsMessageHandler {
 
     private final ArtistService artistService;
 
     @Override
     @Transactional
-    public void handle(CreateArtistEvent event) {
+    public void handle(CreateArtistMessage event) {
         if (!artistService.isExistByArtistId(event.artistId())) {
             artistService.create(event.toCreateDTO());
         }
     }
 
     @Override
-    public Class<CreateArtistEvent> getSupportedType() {
-        return CreateArtistEvent.class;
+    public Class<CreateArtistMessage> getSupportedType() {
+        return CreateArtistMessage.class;
     }
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/song/CreateSongMessageHandler.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/song/CreateSongMessageHandler.java
@@ -3,8 +3,8 @@ package org.sopt.confeti.global.messagebroker.sqs.handler.song;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.applemusic.song.application.SongService;
 import org.sopt.confeti.global.messagebroker.handler.CreateMessageHandler;
-import org.sopt.confeti.global.messagebroker.sqs.event.song.CreateSongMessage;
 import org.sopt.confeti.global.messagebroker.sqs.handler.SqsMessageHandler;
+import org.sopt.confeti.global.messagebroker.sqs.message.song.CreateSongMessage;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,9 +17,9 @@ public class CreateSongMessageHandler implements CreateMessageHandler<CreateSong
 
     @Override
     @Transactional
-    public void handle(CreateSongMessage event) {
-        if (!songService.isExistBySongId(event.songId())) {
-            songService.create(event.toCreateDTO());
+    public void handle(CreateSongMessage message) {
+        if (!songService.isExistBySongId(message.songId())) {
+            songService.create(message.toCreateDTO());
         }
     }
 

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/song/CreateSongMessageHandler.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/handler/song/CreateSongMessageHandler.java
@@ -2,30 +2,30 @@ package org.sopt.confeti.global.messagebroker.sqs.handler.song;
 
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.applemusic.song.application.SongService;
-import org.sopt.confeti.global.messagebroker.handler.CreateEventHandler;
-import org.sopt.confeti.global.messagebroker.sqs.event.song.CreateSongEvent;
-import org.sopt.confeti.global.messagebroker.sqs.handler.SqsEventHandler;
+import org.sopt.confeti.global.messagebroker.handler.CreateMessageHandler;
+import org.sopt.confeti.global.messagebroker.sqs.event.song.CreateSongMessage;
+import org.sopt.confeti.global.messagebroker.sqs.handler.SqsMessageHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-public class CreateSongEventHandler implements CreateEventHandler<CreateSongEvent>,
-    SqsEventHandler {
+public class CreateSongMessageHandler implements CreateMessageHandler<CreateSongMessage>,
+    SqsMessageHandler {
 
     private final SongService songService;
 
     @Override
     @Transactional
-    public void handle(CreateSongEvent event) {
+    public void handle(CreateSongMessage event) {
         if (!songService.isExistBySongId(event.songId())) {
             songService.create(event.toCreateDTO());
         }
     }
 
     @Override
-    public Class<CreateSongEvent> getSupportedType() {
-        return CreateSongEvent.class;
+    public Class<CreateSongMessage> getSupportedType() {
+        return CreateSongMessage.class;
     }
 
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/message/artist/CreateArtistMessage.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/message/artist/CreateArtistMessage.java
@@ -1,25 +1,24 @@
-package org.sopt.confeti.global.messagebroker.sqs.event.song;
+package org.sopt.confeti.global.messagebroker.sqs.message.artist;
 
 
-import org.sopt.confeti.domain.applemusic.song.application.dto.request.CreateSongDTO;
+import org.sopt.confeti.domain.applemusic.artist.application.dto.request.CreateArtistDTO;
 import org.sopt.confeti.global.messagebroker.message.CreateMessage;
 
-public record CreateSongMessage(
-    String songId,
+public record CreateArtistMessage(
+    String artistId,
     String name,
     String artworkUrl,
     Integer artworkWidth,
     Integer artworkHeight
 ) implements CreateMessage {
 
-    public CreateSongDTO toCreateDTO() {
-        return CreateSongDTO.builder()
-            .songId(songId)
+    public CreateArtistDTO toCreateDTO() {
+        return CreateArtistDTO.builder()
+            .artistId(artistId)
             .name(name)
             .artworkUrl(artworkUrl)
             .artworkWidth(artworkWidth)
             .artworkHeight(artworkHeight)
             .build();
     }
-
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/message/song/CreateSongMessage.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/message/song/CreateSongMessage.java
@@ -1,24 +1,25 @@
-package org.sopt.confeti.global.messagebroker.sqs.event.artist;
+package org.sopt.confeti.global.messagebroker.sqs.message.song;
 
 
-import org.sopt.confeti.domain.applemusic.artist.application.dto.request.CreateArtistDTO;
+import org.sopt.confeti.domain.applemusic.song.application.dto.request.CreateSongDTO;
 import org.sopt.confeti.global.messagebroker.message.CreateMessage;
 
-public record CreateArtistMessage(
-    String artistId,
+public record CreateSongMessage(
+    String songId,
     String name,
     String artworkUrl,
     Integer artworkWidth,
     Integer artworkHeight
 ) implements CreateMessage {
 
-    public CreateArtistDTO toCreateDTO() {
-        return CreateArtistDTO.builder()
-            .artistId(artistId)
+    public CreateSongDTO toCreateDTO() {
+        return CreateSongDTO.builder()
+            .songId(songId)
             .name(name)
             .artworkUrl(artworkUrl)
             .artworkWidth(artworkWidth)
             .artworkHeight(artworkHeight)
             .build();
     }
+
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
@@ -24,7 +24,7 @@ public class CreateSqsStrategy<T extends CreateMessageHandler<? extends CreateMe
     extends SqsStrategy {
 
     protected CreateSqsStrategy(
-        List<T> createEventHandlers,
+        List<T> createMessageHandlers,
         @Value("${message-broker.sqs.create-event}") String queueUrl,
         SqsTemplate sqsTemplate,
         NotificationAgent notificationAgent,
@@ -32,7 +32,7 @@ public class CreateSqsStrategy<T extends CreateMessageHandler<? extends CreateMe
         SqsAsyncClient sqsAsyncClient,
         JsonMapper jsonMapper
     ) {
-        super(createEventHandlers, queueUrl, sqsTemplate, notificationAgent,
+        super(createMessageHandlers, queueUrl, sqsTemplate, notificationAgent,
             messageConsumeExecutor, sqsAsyncClient, jsonMapper);
     }
 
@@ -42,7 +42,7 @@ public class CreateSqsStrategy<T extends CreateMessageHandler<? extends CreateMe
     }
 
     @Override
-    @SqsListener(value = "${message-broker.sqs.create-event}", factory = "createEventSqsListenerContainerFactory")
+    @SqsListener(value = "${message-broker.sqs.create-event}", factory = "createMessageSqsListenerContainerFactory")
     protected void listen(List<org.springframework.messaging.Message<String>> messages) {
         consumeSqsMessages(messages);
     }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
@@ -6,22 +6,21 @@ import io.awspring.cloud.sqs.annotation.SqsListener;
 import io.awspring.cloud.sqs.operations.SqsTemplate;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
-import org.sopt.confeti.global.messagebroker.handler.CreateEventHandler;
-import org.sopt.confeti.global.messagebroker.message.CreateEvent;
-import org.sopt.confeti.global.messagebroker.message.Event;
-import org.sopt.confeti.global.messagebroker.sqs.handler.SqsEventHandler;
+import org.sopt.confeti.global.messagebroker.handler.CreateMessageHandler;
+import org.sopt.confeti.global.messagebroker.message.CreateMessage;
+import org.sopt.confeti.global.messagebroker.message.Message;
+import org.sopt.confeti.global.messagebroker.sqs.handler.SqsMessageHandler;
 import org.sopt.confeti.global.notification.NotificationAgent;
 import org.sopt.confeti.global.util.JsonMapper;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.messaging.Message;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 
 @Slf4j
 @Component
-public class CreateSqsStrategy<T extends CreateEventHandler<? extends CreateEvent> & SqsEventHandler>
+public class CreateSqsStrategy<T extends CreateMessageHandler<? extends CreateMessage> & SqsMessageHandler>
     extends SqsStrategy {
 
     protected CreateSqsStrategy(
@@ -38,13 +37,13 @@ public class CreateSqsStrategy<T extends CreateEventHandler<? extends CreateEven
     }
 
     @Override
-    public void sendEvent(Event event) {
-        asyncSend(super.getQueueUrl(), event);
+    public void sendMessage(Message message) {
+        asyncSend(super.getQueueUrl(), message);
     }
 
     @Override
     @SqsListener(value = "${message-broker.sqs.create-event}", factory = "createEventSqsListenerContainerFactory")
-    protected void listen(List<Message<String>> messages) {
+    protected void listen(List<org.springframework.messaging.Message<String>> messages) {
         consumeSqsMessages(messages);
     }
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/CreateSqsStrategy.java
@@ -37,7 +37,7 @@ public class CreateSqsStrategy<T extends CreateMessageHandler<? extends CreateMe
     }
 
     @Override
-    public void sendMessage(Message message) {
+    public void publish(Message message) {
         asyncSend(super.getQueueUrl(), message);
     }
 

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
@@ -35,12 +35,12 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
     private final JsonMapper jsonMapper;
 
     private static final String ATTRIBUTE_DATA_TYPE_STRING = "string";
-    private static final String ATTRIBUTE_EVENT_TYPE = "event";
+    private static final String ATTRIBUTE_MESSAGE_TYPE = "message";
     private static final String ATTRIBUTE_TRACE_ID = "traceId";
-    private static final String ATTRIBUTE_TYPE_ID = "confetiEventType";
+    private static final String ATTRIBUTE_TYPE_ID = "confetiMessageType";
 
     protected SqsStrategy(
-        List<? extends MessageHandler<? extends Message>> eventHandlers,
+        List<? extends MessageHandler<? extends Message>> messageHandlers,
         String queueUrl,
         SqsTemplate sqsTemplate,
         NotificationAgent notificationAgent,
@@ -48,7 +48,7 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
         SqsAsyncClient sqsAsyncClient,
         JsonMapper jsonMapper
     ) {
-        super(eventHandlers);
+        super(messageHandlers);
         this.queueUrl = queueUrl;
         this.sqsTemplate = sqsTemplate;
         this.notificationAgent = notificationAgent;
@@ -77,23 +77,23 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
     }
 
     private Map<String, Object> createMessageAttributes(Message message) {
-        String eventType = message.getClass().getSimpleName();
-        String eventTraceId = UUID.randomUUID().toString();
+        String messageType = message.getClass().getSimpleName();
+        String messageTraceId = UUID.randomUUID().toString();
 
         return Map.of(
-            ATTRIBUTE_EVENT_TYPE, MessageAttributeValue.builder()
-                .stringValue(eventType)
+            ATTRIBUTE_MESSAGE_TYPE, MessageAttributeValue.builder()
+                .stringValue(messageType)
                 .dataType(ATTRIBUTE_DATA_TYPE_STRING)
                 .build(),
             ATTRIBUTE_TRACE_ID, MessageAttributeValue.builder()
-                .stringValue(eventTraceId)
+                .stringValue(messageTraceId)
                 .dataType(ATTRIBUTE_DATA_TYPE_STRING)
                 .build(),
-            ATTRIBUTE_TYPE_ID, getEventTypeId(message)
+            ATTRIBUTE_TYPE_ID, getMessageTypeId(message)
         );
     }
 
-    private String getEventTypeId(Message message) {
+    private String getMessageTypeId(Message message) {
         MessageHandler<? extends Message> messageHandler = getHandlerByMessageClass(
             message.getClass());
         return messageHandler.getSupportedTypeId();
@@ -110,7 +110,7 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
         return CompletableFuture.runAsync(() -> {
                 String type = message.getHeaders().get(ATTRIBUTE_TYPE_ID, String.class);
                 String payload = message.getPayload().toString();
-                handleEvent(type, payload);
+                handleMessage(type, payload);
             }, messageConsumeExecutor)
             .thenRun(() -> deleteMessage(message))
             .exceptionally(e -> {
@@ -119,22 +119,22 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
             });
     }
 
-    protected void handleEvent(String typeId, String payload) {
+    protected void handleMessage(String typeId, String payload) {
         MessageHandler<? extends Message> messageHandler = getHandlerByTypeId(typeId);
         if (messageHandler == null) {
-            log.error("Cannot find event handler: {}. Payload: {}", typeId, payload);
+            log.error("Cannot find message handler: {}. Payload: {}", typeId, payload);
             throw new ConfetiException(INTERNAL_SERVER_ERROR);
         }
 
-        processEvent(messageHandler, payload);
+        processMessage(messageHandler, payload);
     }
 
-    protected <T extends Message> void processEvent(MessageHandler<T> messageHandler,
+    protected <T extends Message> void processMessage(MessageHandler<T> messageHandler,
         String payload) {
-        Class<T> supportedEventType = messageHandler.getSupportedType();
-        T event = jsonMapper.fromJson(supportedEventType, payload);
+        Class<T> supportedMessageType = messageHandler.getSupportedType();
+        T message = jsonMapper.fromJson(supportedMessageType, payload);
 
-        messageHandler.handle(event);
+        messageHandler.handle(message);
     }
 
     public void consumeSqsMessages(

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
@@ -94,7 +94,7 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
     }
 
     private String getEventTypeId(Message message) {
-        MessageHandler<? extends Message> messageHandler = getMessageHandlerByMessageClass().get(
+        MessageHandler<? extends Message> messageHandler = getHandlerByMessageClass(
             message.getClass());
         return messageHandler.getSupportedTypeId();
     }
@@ -120,7 +120,7 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
     }
 
     protected void handleEvent(String typeId, String payload) {
-        MessageHandler<? extends Message> messageHandler = super.getMessageHandlers().get(typeId);
+        MessageHandler<? extends Message> messageHandler = getHandlerByTypeId(typeId);
         if (messageHandler == null) {
             log.error("Cannot find event handler: {}. Payload: {}", typeId, payload);
             throw new ConfetiException(INTERNAL_SERVER_ERROR);

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/strategy/SqsStrategy.java
@@ -12,13 +12,12 @@ import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.messagebroker.MessageBrokerStrategy;
-import org.sopt.confeti.global.messagebroker.handler.EventHandler;
-import org.sopt.confeti.global.messagebroker.message.Event;
+import org.sopt.confeti.global.messagebroker.handler.MessageHandler;
+import org.sopt.confeti.global.messagebroker.message.Message;
 import org.sopt.confeti.global.notification.NotificationAgent;
 import org.sopt.confeti.global.notification.SlackNotificationType;
 import org.sopt.confeti.global.util.JsonMapper;
 import org.springframework.core.task.TaskExecutor;
-import org.springframework.messaging.Message;
 import software.amazon.awssdk.services.sqs.SqsAsyncClient;
 import software.amazon.awssdk.services.sqs.model.DeleteMessageRequest;
 import software.amazon.awssdk.services.sqs.model.MessageAttributeValue;
@@ -41,7 +40,7 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
     private static final String ATTRIBUTE_TYPE_ID = "confetiEventType";
 
     protected SqsStrategy(
-        List<? extends EventHandler<? extends Event>> eventHandlers,
+        List<? extends MessageHandler<? extends Message>> eventHandlers,
         String queueUrl,
         SqsTemplate sqsTemplate,
         NotificationAgent notificationAgent,
@@ -58,11 +57,11 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
         this.jsonMapper = jsonMapper;
     }
 
-    abstract void listen(List<Message<String>> messages);
+    abstract void listen(List<org.springframework.messaging.Message<String>> messages);
 
-    protected void asyncSend(String queueName, Event event) {
-        Map<String, Object> messageAttributes = createMessageAttributes(event);
-        String serializedData = jsonMapper.toJson(event);
+    protected void asyncSend(String queueName, Message message) {
+        Map<String, Object> messageAttributes = createMessageAttributes(message);
+        String serializedData = jsonMapper.toJson(message);
 
         sqsTemplate.sendAsync(to -> to
                 .queue(queueName)
@@ -70,15 +69,15 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
                 .headers(messageAttributes)
             )
             .exceptionally(exception -> {
-                String errorMessage = extractExceptionMessage(exception, event);
+                String errorMessage = extractExceptionMessage(exception, message);
                 notificationAgent.notify(SlackNotificationType.HIGH_ERROR, errorMessage);
                 log.error("[SqsService send exception] {}", errorMessage, exception);
                 return null;
             });
     }
 
-    private Map<String, Object> createMessageAttributes(Event event) {
-        String eventType = event.getClass().getSimpleName();
+    private Map<String, Object> createMessageAttributes(Message message) {
+        String eventType = message.getClass().getSimpleName();
         String eventTraceId = UUID.randomUUID().toString();
 
         return Map.of(
@@ -90,14 +89,14 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
                 .stringValue(eventTraceId)
                 .dataType(ATTRIBUTE_DATA_TYPE_STRING)
                 .build(),
-            ATTRIBUTE_TYPE_ID, getEventTypeId(event)
+            ATTRIBUTE_TYPE_ID, getEventTypeId(message)
         );
     }
 
-    private String getEventTypeId(Event event) {
-        EventHandler<? extends Event> eventHandler = getEventHandlerByEventClass().get(
-            event.getClass());
-        return eventHandler.getSupportedTypeId();
+    private String getEventTypeId(Message message) {
+        MessageHandler<? extends Message> messageHandler = getMessageHandlerByMessageClass().get(
+            message.getClass());
+        return messageHandler.getSupportedTypeId();
     }
 
     private <T> String extractExceptionMessage(Throwable exception, T data) {
@@ -106,7 +105,8 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
             data.toString());
     }
 
-    protected CompletableFuture<Void> processMessageAndDelete(Message<?> message) {
+    protected CompletableFuture<Void> processMessageAndDelete(
+        org.springframework.messaging.Message<?> message) {
         return CompletableFuture.runAsync(() -> {
                 String type = message.getHeaders().get(ATTRIBUTE_TYPE_ID, String.class);
                 String payload = message.getPayload().toString();
@@ -120,23 +120,25 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
     }
 
     protected void handleEvent(String typeId, String payload) {
-        EventHandler<? extends Event> eventHandler = super.getEventHandlers().get(typeId);
-        if (eventHandler == null) {
+        MessageHandler<? extends Message> messageHandler = super.getMessageHandlers().get(typeId);
+        if (messageHandler == null) {
             log.error("Cannot find event handler: {}. Payload: {}", typeId, payload);
             throw new ConfetiException(INTERNAL_SERVER_ERROR);
         }
 
-        processEvent(eventHandler, payload);
+        processEvent(messageHandler, payload);
     }
 
-    protected <T extends Event> void processEvent(EventHandler<T> eventHandler, String payload) {
-        Class<T> supportedEventType = eventHandler.getSupportedType();
+    protected <T extends Message> void processEvent(MessageHandler<T> messageHandler,
+        String payload) {
+        Class<T> supportedEventType = messageHandler.getSupportedType();
         T event = jsonMapper.fromJson(supportedEventType, payload);
 
-        eventHandler.handle(event);
+        messageHandler.handle(event);
     }
 
-    public void consumeSqsMessages(List<Message<String>> receivedMessages) {
+    public void consumeSqsMessages(
+        List<org.springframework.messaging.Message<String>> receivedMessages) {
         List<CompletableFuture<Void>> futures = receivedMessages.stream()
             .map(this::processMessageAndDelete)
             .toList();
@@ -144,7 +146,7 @@ public abstract class SqsStrategy extends MessageBrokerStrategy {
         CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])).join();
     }
 
-    private void deleteMessage(Message<?> message) {
+    private void deleteMessage(org.springframework.messaging.Message<?> message) {
         String receiptHandle = (String) message.getHeaders()
             .get(SqsHeaders.SQS_RECEIPT_HANDLE_HEADER);
 


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 메세지 전략 클래스 관리를 MessageStrategyProvider 로 분리
  - strategy 에서 message Handler를 provider 빈으로 관리하도록 변경하지 않은 이유는 현재 구조가 MessageHandler 가 처리하는 Message 종류는 MessageHandler 만 알고 있고, 어떤 Message를 어떤 publisher 에서 발행하는 지는 publisher 를 구현한 strategy 에서 초기화 시 제네릭 upper bound로 주입받은 MessageHandler를 통해 알고 있기 때문입니다.
- 전체적으로 메세지 큐에서 사용하고 있던 Event 네이밍을 Message 로 변경


## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
