### PR TITLE
CONFETI-47 feat: 타임테이블 페스티벌 다건 삭제 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableControllerV4.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableControllerV4.java
@@ -1,0 +1,185 @@
+package org.sopt.confeti.api.user.controller;
+
+import jakarta.validation.constraints.Min;
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.user.controller.docs.UserTimetableControllerV4Docs;
+import org.sopt.confeti.api.user.dto.request.AddTimetableFestivalRequest;
+import org.sopt.confeti.api.user.dto.request.PatchTimetableFestivalRequest;
+import org.sopt.confeti.api.user.dto.request.PatchTimetableRequest;
+import org.sopt.confeti.api.user.dto.response.TimetablesToAddResponse;
+import org.sopt.confeti.api.user.dto.response.UserTimetableDetailFestivalsResponse;
+import org.sopt.confeti.api.user.dto.response.UserTimetableEntireFestivalResponse;
+import org.sopt.confeti.api.user.dto.response.UserTimetableFestivalResponse;
+import org.sopt.confeti.api.user.dto.response.UserTimetableHistoryResponse;
+import org.sopt.confeti.api.user.dto.response.UserTimetablesPreviewResponse;
+import org.sopt.confeti.api.user.dto.response.UserTimetablesResponse;
+import org.sopt.confeti.api.user.facade.UserTimetableFacade;
+import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
+import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableDTO;
+import org.sopt.confeti.api.user.facade.dto.response.TimetableToAddDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetableDetailFestivalsDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetableEntireFestivalDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetableFestivalBasicDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetableHistoryDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetablesDTO;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Permission;
+import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.common.CursorPage;
+import org.sopt.confeti.global.common.constant.RequestConstraint;
+import org.sopt.confeti.global.message.SuccessMessage;
+import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.sopt.confeti.global.util.S3FileHandler;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@Validated
+@RequiredArgsConstructor
+@RequestMapping("/user/timetables/v4")
+public class UserTimetableControllerV4 implements UserTimetableControllerV4Docs {
+
+    private final UserTimetableFacade userTimetableFacade;
+    private final S3FileHandler s3FileHandler;
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/festivals")
+    public ResponseEntity<BaseResponse<UserTimetableDetailFestivalsResponse>> getTimetablesListAndDate(
+        @UserId Long userId
+    ) {
+        UserTimetableDetailFestivalsDTO userTimetableDetailFestivalsDTO = userTimetableFacade.getTimetablesListAndDate(
+            userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetableDetailFestivalsResponse.of(userTimetableDetailFestivalsDTO,
+                s3FileHandler));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/festivals/history")
+    public ResponseEntity<BaseResponse<UserTimetableHistoryResponse>> getHasTimetableHistory(
+        @UserId Long userId
+    ) {
+        UserTimetableHistoryDTO timetableHistoryDTO = userTimetableFacade.getHasTimetableHistory(
+            userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetableHistoryResponse.from(timetableHistoryDTO));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/festivals/add")
+    public ResponseEntity<BaseResponse<TimetablesToAddResponse>> getTimetablesToAdd(
+        @UserId Long userId,
+        @RequestParam(name = "cursor", required = false) Long cursor
+    ) {
+        CursorPage<TimetableToAddDTO> timetablesToAdd = userTimetableFacade.getTimetablesToAdd(
+            userId, cursor);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            TimetablesToAddResponse.of(timetablesToAdd, s3FileHandler));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @PostMapping("/festivals")
+    public ResponseEntity<BaseResponse<Void>> addTimetableFestival(
+        @UserId Long userId,
+        @RequestBody AddTimetableFestivalRequest addTimetableFestivalRequest
+    ) {
+        userTimetableFacade.addTimetableFestivals(userId,
+            AddTimetableFestivalDTO.from(addTimetableFestivalRequest));
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @DeleteMapping("/festivals/{festivalId}")
+    public ResponseEntity<BaseResponse<Void>> removeTimetableFestival(
+        @UserId Long userId,
+        @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) long festivalId
+    ) {
+        userTimetableFacade.removeTimetableFestival(userId, festivalId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/festivals/{festivalDateId}")
+    public ResponseEntity<BaseResponse<UserTimetableFestivalResponse>> getTimetableFestival(
+        @UserId Long userId,
+        @PathVariable(name = "festivalDateId") @Min(RequestConstraint.ID) long festivalDateId
+    ) {
+        UserTimetableFestivalBasicDTO response = userTimetableFacade.getTimetableInfo(userId,
+            festivalDateId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetableFestivalResponse.from(response));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @PatchMapping
+    public ResponseEntity<BaseResponse<Void>> updateTimetable(
+        @UserId Long userId,
+        @RequestBody PatchTimetableRequest patchTimetablerequest
+    ) {
+        userTimetableFacade.patchTimetableFestivals(userId,
+            PatchTimetableDTO.from(patchTimetablerequest));
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
+    @GetMapping
+    public ResponseEntity<BaseResponse<UserTimetablesResponse>> getTimetables(
+        @UserId Long userId,
+        @RequestParam(value = "sortBy", defaultValue = "createdAt") String sortBy
+    ) {
+        UserTimetablesDTO timetables = userTimetableFacade.getTimetables(userId, sortBy);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetablesResponse.of(timetables, s3FileHandler));
+    }
+
+    @GetMapping("/preview")
+    public ResponseEntity<BaseResponse<UserTimetablesPreviewResponse>> getTimetablesPreview(
+        @UserId Long userId
+    ) {
+        UserTimetablesDTO timetables = userTimetableFacade.getTimetablesPreview(userId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetablesPreviewResponse.of(timetables, s3FileHandler));
+    }
+
+    @GetMapping("/archive/{festivalId}")
+    public ResponseEntity<BaseResponse<UserTimetableEntireFestivalResponse>> getEntireFestivalInfo(
+        @UserId Long userId,
+        @PathVariable(name = "festivalId") @Min(RequestConstraint.ID) Long festivalId
+    ) {
+        UserTimetableEntireFestivalDTO entireFestivalDTO = userTimetableFacade.getEntireFestivalInfo(
+            userId, festivalId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetableEntireFestivalResponse.of(entireFestivalDTO, s3FileHandler));
+    }
+
+    @GetMapping("/archive/festival/{festivalDateId}")
+    public ResponseEntity<BaseResponse<UserTimetableFestivalResponse>> getEntireFestivalDateInfo(
+        @UserId Long userId,
+        @PathVariable(name = "festivalDateId") @Min(RequestConstraint.ID) Long festivalDateId
+    ) {
+        UserTimetableFestivalBasicDTO festivalBasicDTO = userTimetableFacade.getEntireFestivalDateInfo(
+            userId, festivalDateId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            UserTimetableFestivalResponse.from(festivalBasicDTO));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @PatchMapping("/festivals")
+    public ResponseEntity<BaseResponse<Void>> updateTimetableFestival(
+        @UserId Long userId,
+        @RequestBody PatchTimetableFestivalRequest patchTimetableFestivalRequest
+    ) {
+        userTimetableFacade.updateTimetableFestivals(userId,
+            patchTimetableFestivalRequest.toDTO());
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserTimetableControllerV4Docs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserTimetableControllerV4Docs.java
@@ -1,0 +1,50 @@
+package org.sopt.confeti.api.user.controller.docs;
+
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.sopt.confeti.api.user.dto.request.AddTimetableFestivalRequest;
+import org.sopt.confeti.api.user.dto.request.PatchTimetableFestivalRequest;
+import org.sopt.confeti.global.annotation.UserId;
+import org.sopt.confeti.global.common.BaseResponse;
+import org.sopt.confeti.global.common.swagger.AuthErrorResponses;
+import org.sopt.confeti.global.common.swagger.CommonErrorResponses;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+
+@Tag(name = "타임테이블")
+public interface UserTimetableControllerV4Docs {
+
+    @Operation(summary = "타임테이블 페스티벌 추가")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<Void>> addTimetableFestival(
+        @UserId Long userId,
+        @RequestBody AddTimetableFestivalRequest addTimetableFestivalRequest
+    );
+
+    @Operation(summary = "타임테이블 페스티벌 다건 삭제")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @PatchMapping("/festivals")
+    ResponseEntity<BaseResponse<Void>> updateTimetableFestival(
+        @UserId Long userId,
+        @RequestBody PatchTimetableFestivalRequest patchTimetableFestivalRequest
+    );
+}

--- a/src/main/java/org/sopt/confeti/api/user/dto/request/PatchTimetableFestivalRequest.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/request/PatchTimetableFestivalRequest.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.api.user.dto.request;
+
+import java.util.Set;
+import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableFestivalDTO;
+
+public record PatchTimetableFestivalRequest(
+    Set<Long> deleteFestivalIds
+) {
+
+    public PatchTimetableFestivalDTO toDTO() {
+        return new PatchTimetableFestivalDTO(deleteFestivalIds);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -7,12 +7,17 @@ import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalArtiestDTO;
 import org.sopt.confeti.api.user.facade.dto.request.AddTimetableFestivalDTO;
 import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableDTO;
+import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableFestivalDTO;
 import org.sopt.confeti.api.user.facade.dto.request.PatchTimetableListDTO;
-import org.sopt.confeti.api.user.facade.dto.response.*;
+import org.sopt.confeti.api.user.facade.dto.response.TimetableToAddDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetableDetailFestivalsDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetableEntireFestivalDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetableFestivalBasicDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetableHistoryDTO;
+import org.sopt.confeti.api.user.facade.dto.response.UserTimetablesDTO;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.FestivalService;
 import org.sopt.confeti.domain.festival.application.dto.FestivalCursorDTO;
@@ -68,17 +73,17 @@ public class UserTimetableFacade {
     public void addTimetableFestivals(final long userId, final AddTimetableFestivalDTO from) {
         User user = userService.findUserTimetablesById(userId);
         List<Festival> addFestivals = festivalService.findFestivalsByIdIn(
-                from.festivals().stream()
-                        .distinct()
-                        .map(AddTimetableFestivalArtiestDTO::festivalId)
-                        .toList()
+            from.festivals().stream()
+                .distinct()
+                .map(AddTimetableFestivalArtiestDTO::festivalId)
+                .toList()
         );
 
         validateDuplicateTimetableFestival(
-                user.getTimetableFestivals().stream()
-                        .map(TimetableFestival::getFestival)
-                        .toList(),
-                addFestivals
+            user.getTimetableFestivals().stream()
+                .map(TimetableFestival::getFestival)
+                .toList(),
+            addFestivals
         );
 
         timetableFestivalService.addTimetableFestivals(user, addFestivals);
@@ -87,11 +92,11 @@ public class UserTimetableFacade {
 
     @Transactional
     protected void validateDuplicateTimetableFestival(final List<Festival> currentFestivals,
-                                                      final List<Festival> addFestivals) {
+        final List<Festival> addFestivals) {
         if (
-                currentFestivals.stream()
-                        .anyMatch(currentFestival -> addFestivals.stream()
-                                .anyMatch(Predicate.isEqual(currentFestival)))
+            currentFestivals.stream()
+                .anyMatch(currentFestival -> addFestivals.stream()
+                    .anyMatch(Predicate.isEqual(currentFestival)))
         ) {
             throw new ConflictException(ErrorMessage.CONFLICT);
         }
@@ -122,29 +127,31 @@ public class UserTimetableFacade {
     public CursorPage<TimetableToAddDTO> getTimetablesToAdd(final long userId, final Long cursor) {
         if (cursor == null) {
             List<Festival> festivals = festivalService.findFestivalsUsingInitCursor(userId,
-                    TIMETABLE_FESTIVALS_TO_ADD_SIZE);
+                TIMETABLE_FESTIVALS_TO_ADD_SIZE);
             return CursorPage.of(
-                    festivals.stream()
-                            .map(TimetableToAddDTO::from)
-                            .toList(),
-                    TIMETABLE_FESTIVALS_TO_ADD_SIZE
+                festivals.stream()
+                    .map(TimetableToAddDTO::from)
+                    .toList(),
+                TIMETABLE_FESTIVALS_TO_ADD_SIZE
             );
         }
 
         // 커서 값 조회
         FestivalCursorDTO festivalCursorDTO = getFestivalCursor(userId, cursor);
 
-        List<Festival> festivals = festivalService.findFestivalsUsingCursor(userId, festivalCursorDTO.cursorTitle(),
-                festivalCursorDTO.cursorIsFavorite(), TIMETABLE_FESTIVALS_TO_ADD_SIZE);
+        List<Festival> festivals = festivalService.findFestivalsUsingCursor(userId,
+            festivalCursorDTO.cursorTitle(),
+            festivalCursorDTO.cursorIsFavorite(), TIMETABLE_FESTIVALS_TO_ADD_SIZE);
         return CursorPage.of(
-                festivals.stream()
-                        .map(TimetableToAddDTO::from)
-                        .toList(),
-                TIMETABLE_FESTIVALS_TO_ADD_SIZE
+            festivals.stream()
+                .map(TimetableToAddDTO::from)
+                .toList(),
+            TIMETABLE_FESTIVALS_TO_ADD_SIZE
         );
     }
 
-    public UserTimetableFestivalBasicDTO getTimetableInfo(final long userId, final long festivalDateId) {
+    public UserTimetableFestivalBasicDTO getTimetableInfo(final long userId,
+        final long festivalDateId) {
         FestivalDate festivalDate = festivalDateService.findFestivalDateId(festivalDateId);
         return getUserTimetableDTO(userId, festivalDate);
     }
@@ -159,9 +166,9 @@ public class UserTimetableFacade {
     @Transactional(readOnly = true)
     public FestivalCursorDTO getFestivalCursor(final long userId, final long cursor) {
         return festivalService.findFestivalCursor(userId, cursor)
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
-                );
+            .orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+            );
     }
 
     @Transactional
@@ -180,7 +187,8 @@ public class UserTimetableFacade {
         validateUserExists(userId);
         validateSortType(sortBy);
 
-        List<TimetableFestival> userTimetables = timetableFestivalService.getTimetables(userId, sortBy);
+        List<TimetableFestival> userTimetables = timetableFestivalService.getTimetables(userId,
+            sortBy);
 
         return UserTimetablesDTO.from(userTimetables);
     }
@@ -189,7 +197,8 @@ public class UserTimetableFacade {
     public UserTimetablesDTO getTimetablesPreview(final long userId) {
         validateUserExists(userId);
 
-        List<TimetableFestival> userTimetables = timetableFestivalService.getTimetablesPreview(userId);
+        List<TimetableFestival> userTimetables = timetableFestivalService.getTimetablesPreview(
+            userId);
         return UserTimetablesDTO.from(userTimetables);
     }
 
@@ -199,14 +208,16 @@ public class UserTimetableFacade {
         }
     }
 
-    private UserTimetableFestivalBasicDTO getUserTimetableDTO(final long userId, FestivalDate festivalDate) {
+    private UserTimetableFestivalBasicDTO getUserTimetableDTO(final long userId,
+        FestivalDate festivalDate) {
         List<Long> festivalTimeIds = festivalDate.getStages().stream()
-                .flatMap(festivalStage -> festivalStage.getTimes().stream())
-                .map(FestivalTime::getId)
-                .toList();
+            .flatMap(festivalStage -> festivalStage.getTimes().stream())
+            .map(FestivalTime::getId)
+            .toList();
         validateExistFestivalTimeIds(festivalTimeIds);
 
-        List<UserTimetable> userTimetables = userTimetableService.getUserTimetablesByFestivalTimeId(userId, festivalTimeIds);
+        List<UserTimetable> userTimetables = userTimetableService.getUserTimetablesByFestivalTimeId(
+            userId, festivalTimeIds);
         validateExistUserTimetables(userTimetables);
 
         Map<Long, UserTimetable> userTimetableMapper = createUserTimetableMapper(userTimetables);
@@ -217,9 +228,9 @@ public class UserTimetableFacade {
 
     private Map<Long, UserTimetable> createUserTimetableMapper(List<UserTimetable> userTimetables) {
         return userTimetables.stream()
-                .collect(Collectors.toMap(userTimetable ->
-                        userTimetable.getFestivalTime().getId(), Function.identity())
-                );
+            .collect(Collectors.toMap(userTimetable ->
+                userTimetable.getFestivalTime().getId(), Function.identity())
+            );
     }
 
     protected void validateExistUserTimetableMapper(Map<Long, UserTimetable> userTimetables) {
@@ -235,10 +246,11 @@ public class UserTimetableFacade {
     }
 
     @Transactional(readOnly = true)
-    protected void validateExistTimetableIds(List<UserTimetable> userTimetables, PatchTimetableDTO timetableDTO) {
+    protected void validateExistTimetableIds(List<UserTimetable> userTimetables,
+        PatchTimetableDTO timetableDTO) {
         Set<Long> existingIds = userTimetables.stream()
-                .map(UserTimetable::getId)
-                .collect(Collectors.toSet());
+            .map(UserTimetable::getId)
+            .collect(Collectors.toSet());
 
         for (PatchTimetableListDTO timetableListDTO : timetableDTO.userTimetables()) {
             if (!existingIds.contains(timetableListDTO.userTimetableId())) {
@@ -261,13 +273,24 @@ public class UserTimetableFacade {
     }
 
     public UserTimetableEntireFestivalDTO getEntireFestivalInfo(long userId, long festivalId) {
-        TimetableFestival festival = timetableFestivalService.getEntireFestivalInfo(userId, festivalId);
+        TimetableFestival festival = timetableFestivalService.getEntireFestivalInfo(userId,
+            festivalId);
         return UserTimetableEntireFestivalDTO.from(festival);
     }
 
-    public UserTimetableFestivalBasicDTO getEntireFestivalDateInfo(final long userId, final long festivalDateId) {
+    public UserTimetableFestivalBasicDTO getEntireFestivalDateInfo(final long userId,
+        final long festivalDateId) {
         FestivalDate festivalDate = festivalDateService.findEntireFestivalDateById(festivalDateId);
         return getUserTimetableDTO(userId, festivalDate);
+    }
+
+    @Transactional
+    public void updateTimetableFestivals(
+        final long userId,
+        final PatchTimetableFestivalDTO patchTimetableFestivalDTO
+    ) {
+        timetableFestivalService.removeTimetableFestivals(
+            userId, patchTimetableFestivalDTO.deleteFestivalIds());
     }
 }
 

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/request/PatchTimetableFestivalDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/request/PatchTimetableFestivalDTO.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.api.user.facade.dto.request;
+
+import java.util.Set;
+
+public record PatchTimetableFestivalDTO(
+    Set<Long> deleteFestivalIds
+) {
+
+}

--- a/src/main/java/org/sopt/confeti/domain/timetable_festival/application/TimetableFestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/timetable_festival/application/TimetableFestivalService.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.domain.timetable_festival.application;
 
+import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
 import lombok.AllArgsConstructor;
@@ -15,6 +16,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @AllArgsConstructor
 public class TimetableFestivalService {
+
     private final TimetableFestivalRepository timetableFestivalRepository;
 
     @Transactional(readOnly = true)
@@ -33,11 +35,19 @@ public class TimetableFestivalService {
     }
 
     @Transactional
+    public void removeTimetableFestivals(
+        final long userId,
+        final Collection<Long> deleteFestivalId
+    ) {
+        timetableFestivalRepository.deleteAllByUserIdAndFestivalIdIn(userId, deleteFestivalId);
+    }
+
+    @Transactional
     public void addTimetableFestivals(final User user, final List<Festival> festivals) {
         timetableFestivalRepository.saveAll(
-                festivals.stream()
-                        .map(festival -> TimetableFestival.create(user, festival))
-                        .toList()
+            festivals.stream()
+                .map(festival -> TimetableFestival.create(user, festival))
+                .toList()
         );
     }
 
@@ -67,6 +77,6 @@ public class TimetableFestivalService {
     @Transactional(readOnly = true)
     public TimetableFestival getEntireFestivalInfo(final long userId, final long festivalId) {
         return timetableFestivalRepository.findByUserIdAndFestivalId(userId, festivalId)
-                .orElseThrow(()->new NotFoundException(ErrorMessage.NOT_FOUND));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/timetable_festival/infra/repository/TimetableFestivalRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/timetable_festival/infra/repository/TimetableFestivalRepository.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.domain.timetable_festival.infra.repository;
 
+import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.sopt.confeti.domain.timetable_festival.TimetableFestival;
@@ -8,6 +9,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 public interface TimetableFestivalRepository extends JpaRepository<TimetableFestival, Long> {
+
     @Query("select tf from TimetableFestival tf join fetch tf.festival f where tf.user.id = :userId and f.endAt >= CURRENT_DATE")
     List<TimetableFestival> findByUserIdWhereEndAtLENow(@Param("userId") Long userId);
 
@@ -17,11 +19,14 @@ public interface TimetableFestivalRepository extends JpaRepository<TimetableFest
 
     void deleteByUserIdAndFestivalId(final long userId, final long festivalId);
 
+    void deleteAllByUserIdAndFestivalIdIn(final long userId, final Collection<Long> festivalIds);
+
     List<TimetableFestival> findTop4ByUserIdOrderByCreatedAt(long userId);
 
     @Query("SELECT tf.festival.id FROM TimetableFestival tf WHERE tf.user.id = :userId")
     List<Long> findFestivalIdsByUserId(@Param("userId") Long userId);
 
     @Query("SELECT tf FROM TimetableFestival tf JOIN FETCH tf.festival f LEFT JOIN FETCH f.dates d WHERE tf.user.id = :userId AND tf.festival.id = :festivalId")
-    Optional<TimetableFestival> findByUserIdAndFestivalId(@Param("userId") Long userId, final long festivalId);
+    Optional<TimetableFestival> findByUserIdAndFestivalId(@Param("userId") Long userId,
+        final long festivalId);
 }


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- festival id 목록으로 timetable의 festival 목록을 삭제하는 api를 구현함
  - 존재하지 않는 페스티벌 아이디나 null을 보내도 fail silent 함
  - API 엔드포인트를
    - PATCH user/timetables/v4/festivals 로 둠. 
  - 기존 (v4 이전)
    - 타임테이블 시간표 수정 - **`PATCH user/timetables/festivals`** 
  - 변경 (v4 이후)
    - 타임테이블 시간표 수정 - **`PATCH user/timetables/v4`**
    - 타임테이블의 페스티벌 다건 삭제  **`PATCH user/timetables/v4/festivals`**

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
- 엔드포인트 관련해서 클라 분들이 헷갈리실 수 있을 것 같다는 등의 문제점이나 더 좋은 방향을 논의해봐도 좋을 것 같아요