### PR TITLE
CONFETI-66 deploy: 배포 워크플로우 SSH Action 타임아웃 설정

### DIFF
--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -5,8 +5,6 @@ name: CD workflow
 on:
   push:
     branches: [ "develop" ]
-  pull_request:
-    branches: [ "main" ]
 
 permissions: # 워크플로우 권한
   id-token: write
@@ -188,6 +186,7 @@ jobs:
           username: ${{ secrets.USERNAME }}
           key: ${{ secrets.PRIVATE_KEY }}
           port: ${{ secrets.PORT }}
+          command_timeout: '30m'
           script: |
             cd ~
             docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 기존에 설정된 타임아웃은 ssh action의 전체에 대한 타임아웃임.
- 이번에 추가된 타임아웃은 ssh command에 대한 타임아웃임.
- ssh command 타임아웃의 기본 값은 10분 (변경 : -> 30분)

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
서버 가용 메모리가 낮아 스왑 메모리를 사용하고 있는데, 블루 그린 배포 시 두 배의 리소스를 사용함에 따라 애플리케이션 초기화가 오래 걸리고 있습니다.
이로 인해 ssh command 타임아웃 시간을 늘립니다.
