### PR TITLE
CONFETI-68 refactor: 홈 공연 미리듣기 조회 API 성능 병목 지점 개선

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -16,6 +16,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.performance.facade.dto.request.GetExpectedPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDetailDTO;
@@ -63,6 +64,7 @@ import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.transaction.annotation.Transactional;
 
+@Slf4j
 @Facade
 public class PerformanceFacade {
 
@@ -449,7 +451,14 @@ public class PerformanceFacade {
 
         List<CompletableFuture<PerformanceRecommendDTO>> futures = performances.stream()
             .map(performance -> CompletableFuture.supplyAsync(
-                () -> getPerformanceRecommend(performance, songLimit), performanceExecutor))
+                    () -> getPerformanceRecommend(performance, songLimit), performanceExecutor)
+                .exceptionally(ex -> {
+                    log.warn(
+                        "PerformanceFacade.getPerformancesRecommend : Performance id : {}, Message : {}",
+                        performance.id(), ex.getMessage());
+                    return PerformanceRecommendDTO.of(performance, Collections.emptyList());
+                })
+            )
             .toList();
 
         List<PerformanceRecommendDTO> performancesRecommend = futures.stream()

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -12,9 +12,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.performance.facade.dto.request.GetExpectedPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDetailDTO;
@@ -38,7 +39,6 @@ import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.application.ConcertService;
 import org.sopt.confeti.domain.concert_favorite.application.ConcertFavoriteService;
 import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
-import org.sopt.confeti.domain.elastic_search.application.SearchTermService;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.FestivalService;
 import org.sopt.confeti.domain.festival_favorite.application.FestivalFavoriteService;
@@ -52,6 +52,7 @@ import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceArtistDTO;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.common.ExecutorName;
 import org.sopt.confeti.global.common.constant.PerformanceStatus;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.exception.NotFoundException;
@@ -59,10 +60,10 @@ import org.sopt.confeti.global.exception.UnauthorizedException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.music_api.song.vo.ConfetiSong;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.transaction.annotation.Transactional;
 
 @Facade
-@RequiredArgsConstructor
 public class PerformanceFacade {
 
     private static final int RECENT_PERFORMANCES_SIZE = 7;
@@ -82,7 +83,33 @@ public class PerformanceFacade {
     private final MusicAPIHandler musicAPIHandler;
     private final TimetableFestivalService timetableFestivalService;
     private final SetlistService setlistService;
-    private final SearchTermService searchTermService;
+    private final Executor performanceExecutor;
+
+    public PerformanceFacade(ConcertService concertService,
+        FestivalService festivalService,
+        UserService userService,
+        FestivalFavoriteService festivalFavoriteService,
+        PerformanceService performanceService,
+        ConcertFavoriteService concertFavoriteService,
+        ArtistFavoriteService artistFavoriteService,
+        PerformanceSearchService performanceSearchService,
+        MusicAPIHandler musicAPIHandler,
+        TimetableFestivalService timetableFestivalService,
+        SetlistService setlistService,
+        @Qualifier(ExecutorName.PERFORMANCE_EXECUTOR) Executor performanceExecutor) {
+        this.concertService = concertService;
+        this.festivalService = festivalService;
+        this.userService = userService;
+        this.festivalFavoriteService = festivalFavoriteService;
+        this.performanceService = performanceService;
+        this.concertFavoriteService = concertFavoriteService;
+        this.artistFavoriteService = artistFavoriteService;
+        this.performanceSearchService = performanceSearchService;
+        this.musicAPIHandler = musicAPIHandler;
+        this.timetableFestivalService = timetableFestivalService;
+        this.setlistService = setlistService;
+        this.performanceExecutor = performanceExecutor;
+    }
 
     @Transactional(readOnly = true)
     public ConcertDetailDTO getConcertDetailInfo(final Long userId, final long concertId) {
@@ -311,6 +338,7 @@ public class PerformanceFacade {
         return new HashSet<>(artistList.subList(0, artistCount));
     }
 
+    @Deprecated
     @Transactional(readOnly = true)
     public RecommendSongsDTO getNewRecommendSongs(long performanceId, List<String> songIds) {
         Performance performance = performanceService.getPerformanceById(performanceId);
@@ -327,6 +355,7 @@ public class PerformanceFacade {
         return RecommendSongsDTO.from(recommendSongs);
     }
 
+    @Deprecated
     private List<ConfetiSong> recommendSongsByArtistCount(List<String> artistIdList,
         Set<String> existingSongIds) {
         int artistCount = artistIdList.size();
@@ -339,6 +368,7 @@ public class PerformanceFacade {
         return recommendForMultipleArtists(artistIdList, existingSongIds);
     }
 
+    @Deprecated
     private List<ConfetiSong> recommendForSingleArtist(List<String> artistIdList,
         Set<String> existingSongIds) {
         return musicAPIHandler.getFilteredTopSongsByArtist(
@@ -346,6 +376,7 @@ public class PerformanceFacade {
         );
     }
 
+    @Deprecated
     private List<ConfetiSong> recommendForTwoArtists(List<String> artistIdList,
         Set<String> existingSongIds) {
         List<ConfetiSong> songs = new ArrayList<>();
@@ -356,6 +387,7 @@ public class PerformanceFacade {
         return songs;
     }
 
+    @Deprecated
     private List<ConfetiSong> recommendForMultipleArtists(List<String> artistIdList,
         Set<String> existingSongIds) {
         List<ConfetiSong> songs = new ArrayList<>();
@@ -415,8 +447,13 @@ public class PerformanceFacade {
             performances = performanceService.getRandomUpcomingPerformances(performanceLimit);
         }
 
-        List<PerformanceRecommendDTO> performancesRecommend = performances.stream()
-            .map(performance -> getPerformanceRecommend(performance, songLimit))
+        List<CompletableFuture<PerformanceRecommendDTO>> futures = performances.stream()
+            .map(performance -> CompletableFuture.supplyAsync(
+                () -> getPerformanceRecommend(performance, songLimit), performanceExecutor))
+            .toList();
+
+        List<PerformanceRecommendDTO> performancesRecommend = futures.stream()
+            .map(CompletableFuture::join)
             .toList();
 
         return PerformancesRecommendDTO.from(performancesRecommend);
@@ -457,8 +494,14 @@ public class PerformanceFacade {
 
     private List<SongRecommendDTO> getSongsRecommend(List<PerformanceArtistDTO> artists,
         int songLimit) {
-        List<ConfetiSong> topSongs = artists.stream()
-            .map(this::getArtistTopSongs)
+        List<CompletableFuture<List<ConfetiSong>>> futures = artists.stream()
+            .map(artist -> CompletableFuture.supplyAsync(
+                () -> getArtistTopSongs(artist),
+                performanceExecutor))
+            .toList();
+
+        List<ConfetiSong> topSongs = futures.stream()
+            .map(CompletableFuture::join)
             .flatMap(Collection::stream)
             .toList();
 

--- a/src/main/java/org/sopt/confeti/global/common/ExecutorName.java
+++ b/src/main/java/org/sopt/confeti/global/common/ExecutorName.java
@@ -1,0 +1,10 @@
+package org.sopt.confeti.global.common;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public final class ExecutorName {
+
+    public static final String PERFORMANCE_EXECUTOR = "performanceExecutor";
+}

--- a/src/main/java/org/sopt/confeti/global/config/AsyncConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/AsyncConfig.java
@@ -1,5 +1,7 @@
 package org.sopt.confeti.global.config;
 
+import java.util.concurrent.Executor;
+import org.sopt.confeti.global.common.ExecutorName;
 import org.sopt.confeti.global.common.mdc.MDCTaskDecorator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -16,5 +18,17 @@ public class AsyncConfig {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setTaskDecorator(new MDCTaskDecorator());
         return threadPoolTaskExecutor;
+    }
+
+    @Bean(ExecutorName.PERFORMANCE_EXECUTOR)
+    public Executor performanceExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(10);
+        executor.setMaxPoolSize(20);
+        executor.setQueueCapacity(50);
+        executor.setThreadNamePrefix("performance-");
+        executor.setTaskDecorator(new MDCTaskDecorator());
+        executor.initialize();
+        return executor;
     }
 }

--- a/src/main/java/org/sopt/confeti/global/config/AsyncConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/AsyncConfig.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.global.config;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.ThreadPoolExecutor;
 import org.sopt.confeti.global.common.ExecutorName;
 import org.sopt.confeti.global.common.mdc.MDCTaskDecorator;
 import org.springframework.context.annotation.Bean;
@@ -17,6 +18,7 @@ public class AsyncConfig {
     public TaskExecutor getTaskExecutor() {
         ThreadPoolTaskExecutor threadPoolTaskExecutor = new ThreadPoolTaskExecutor();
         threadPoolTaskExecutor.setTaskDecorator(new MDCTaskDecorator());
+        threadPoolTaskExecutor.initialize();
         return threadPoolTaskExecutor;
     }
 
@@ -28,6 +30,7 @@ public class AsyncConfig {
         executor.setQueueCapacity(50);
         executor.setThreadNamePrefix("performance-");
         executor.setTaskDecorator(new MDCTaskDecorator());
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
         executor.initialize();
         return executor;
     }


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 홈 공연 미리듣기 조회 API의 성능을 개선했습니다.

아래는 변경 내용 요약과 테스트 결과입니다.
현재 `confeti-external` 서버의 Apple Music API Rate Limit 설정은 40tps로 되어있습니다.
`홈 공연 미리듣기 조회 API`의 Apple Music API 호출량은 단건 조회당 9회입니다.
따라서, 데이터 이중화가 안된 현재로써 4tps로 25번 반복하여 100번 호출량을 비교했습니다.

그리고 Apple Music 조회 에이전트에 붙어있는 Redis 캐시를 비활성화하고 테스트한 결과입니다.

### [AS-IS]
- 랜덤 공연 3개 + 각 공연의 랜덤 노래 조회 (외부 API 호출 - Apple Music API)
- 공연마다, 노래마다 동기적으로 처리되었기 때문에 성능 병목

<img width="1137" height="220" alt="image" src="https://github.com/user-attachments/assets/a1667bde-044c-4cfe-9b11-b2150dba97a3" />

### [TO-BE]
- 공연마다, 노래마다 비동기 병렬 호출 (공연 조회 -> 노래 조회의 Task 3개가 거의 동시 호출이라고 보면 됨)

<img width="1137" height="220" alt="image" src="https://github.com/user-attachments/assets/51b8ba79-3ff2-4022-9850-91f4ae068eff" />

### [결론]
약 38%의 조회 성능이 향상되었습니다.
여기에 캐시 활성화, 데이터 이중화를 한다면 성능은 대폭 개선될 것이라 예상됩니다.

스레드 풀은 다음과 같이 설정했습니다.
기본 : 10개
최대 : 20개
큐 사이즈 : 50
-> 서버 자원 및 실험적으로 고려해서 설정한거라 나중에 병목이 생긴다면 재조정하면 좋을 것 같습니다.

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
