### PR TITLE
CONFETI 70 gitignore에서 application yml 필터링 제거 및 Secret Manager 도입

### DIFF
--- a/.github/workflows/workflow-claude-code-review.yml
+++ b/.github/workflows/workflow-claude-code-review.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
 
       - name: Run Claude PR Action
         uses: anthropics/claude-code-action@v1

--- a/.github/workflows/workflow-dev.yml
+++ b/.github/workflows/workflow-dev.yml
@@ -1,5 +1,6 @@
 # Workflow 이름
 name: CI workflow
+run-name: confeti-ci-${{ github.ref_name }}-${{ github.run_number }} by @${{ github.actor }}
 
 # Event Trigger 환경
 on:
@@ -17,7 +18,9 @@ jobs:
     # Action을 사용하여 Step을 구성
     steps:
       - name: 체크아웃
-        uses: actions/checkout@v4  # GitHub repository 코드 체크아웃
+        uses: actions/checkout@v6  # GitHub repository 코드 체크아웃
+        with:
+          fetch-depth: 0
 
       # JDK 21 설치
       - name: Set up JDK 21
@@ -33,88 +36,74 @@ jobs:
             mkdir -p ./src/main/resources
           fi
 
-      # application.yml 파일 생성
-      - name: make application.yml
+      # application-prod.yml 파일 생성
+      - name: make application-prod.yml
         run: |
-          touch ./src/main/resources/application.yml
-          echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
+          touch ./src/main/resources/application-prod.yml
+          echo "${{ secrets.APPLICATION_PROD_YML }}" > ./src/main/resources/application-prod.yml
         shell: bash
 
-      # application-common.yml 파일 생성
-      - name: make application-common.yml
+      # common 폴더 생성
+      - name: Create common folder if not exist
         run: |
-          touch ./src/main/resources/application-common.yml
-          echo "${{ secrets.APPLICATION_COMMON_YML }}" > ./src/main/resources/application-common.yml
-        shell: bash
-
-      # cloud 폴더 생성
-      - name: Create cloud folder if not exist
-        run: |
-          if [ ! -d "./src/main/resources/cloud" ]; then
-            mkdir -p ./src/main/resources/cloud
-          fi
-
-      # application-cloud.yml 파일 생성
-      - name: make application-cloud.yml
-        run: |
-          touch ./src/main/resources/cloud/application-cloud.yml
-          echo "${{ secrets.APPLICATION_CLOUD_YML }}" > ./src/main/resources/cloud/application-cloud.yml
-        shell: bash
-
-      # application-elastic-search.yml 파일 생성
-      - name: make application-elastic-search.yml
-        run: |
-          touch ./src/main/resources/cloud/application-elastic-search.yml
-          echo "${{ secrets.APPLICATION_ELASTIC_SEARCH_YML }}" > ./src/main/resources/cloud/application-elastic-search.yml
-        shell: bash
-
-      # openapi 폴더 생성
-      - name: Create openapi folder if not exist
-        run: |
-          if [ ! -d "./src/main/resources/openapi" ]; then
-            mkdir -p ./src/main/resources/openapi
+          if [ ! -d "./src/main/resources/common" ]; then
+            mkdir -p ./src/main/resources/common
           fi
 
       # application-apple-music.yml 파일 생성
       - name: make application-apple-music.yml
         run: |
-          touch ./src/main/resources/openapi/application-apple-music.yml
-          echo "${{ secrets.APPLICATION_APPLE_MUSIC_YML }}" > ./src/main/resources/openapi/application-apple-music.yml
+          touch ./src/main/resources/common/application-apple-music.yml
+          echo "${{ secrets.APPLICATION_APPLE_MUSIC_YML }}" > ./src/main/resources/common/application-apple-music.yml
         shell: bash
 
-      # oauth 폴더 생성
-      - name: Create oauth folder if not exist
+      # application-cloud.yml 파일 생성
+      - name: make application-cloud.yml
         run: |
-          if [ ! -d "./src/main/resources/oauth" ]; then
-            mkdir -p ./src/main/resources/oauth
-          fi
-
-      # application-kakao.yml 파일 생성
-      - name: make application-kakao.yml
-        run: |
-          touch ./src/main/resources/oauth/application-kakao.yml
-          echo "${{ secrets.APPLICATION_KAKAO_YML }}" > ./src/main/resources/oauth/application-kakao.yml
+          touch ./src/main/resources/common/application-cloud.yml
+          echo "${{ secrets.APPLICATION_CLOUD_YML }}" > ./src/main/resources/common/application-cloud.yml
         shell: bash
 
-      # application-apple.yml 파일 생성
-      - name: make application-apple.yml
+      # application-common.yml 파일 생성
+      - name: make application-common.yml
         run: |
-          touch ./src/main/resources/oauth/application-apple.yml
-          echo "${{ secrets.APPLICATION_APPLE_YML }}" > ./src/main/resources/oauth/application-apple.yml
+          touch ./src/main/resources/common/application-common.yml
+          echo "${{ secrets.APPLICATION_COMMON_YML }}" > ./src/main/resources/common/application-common.yml
         shell: bash
 
-      # notification 폴더 생성
-      - name: Create notification folder if not exist
+      # application-dummy.yml 파일 생성
+      - name: make application-dummy.yml
         run: |
-          if [ ! -d "./src/main/resources/notification" ]; then
-               mkdir -p ./src/main/resources/notification
-          fi
+          touch ./src/main/resources/common/application-dummy.yml
+          echo "${{ secrets.APPLICATION_DUMMY_YML }}" > ./src/main/resources/common/application-dummy.yml
+        shell: bash
+
+      # application-elastic-search.yml 파일 생성
+      - name: make application-elastic-search.yml
+        run: |
+          touch ./src/main/resources/common/application-elastic-search.yml
+          echo "${{ secrets.APPLICATION_ELASTIC_SEARCH_YML }}" > ./src/main/resources/common/application-elastic-search.yml
+        shell: bash
+
+      # application-message-broker.yml 파일 생성
+      - name: make application-message-broker.yml
+        run: |
+          touch ./src/main/resources/common/application-message-broker.yml
+          echo "${{ secrets.APPLICATION_MESSAGE_BROKER_YML }}" > ./src/main/resources/common/application-message-broker.yml
+        shell: bash
 
       # application-notification.yml 파일 생성
       - name: make application-notification.yml
         run: |
-          touch ./src/main/resources/notification/application-notification.yml
-          echo "${{ secrets.APPLICATION_NOTIFICATION_YML }}" > ./src/main/resources/notification/application-notification.yml
+          touch ./src/main/resources/common/application-notification.yml
+          echo "${{ secrets.APPLICATION_NOTIFICATION_YML }}" > ./src/main/resources/common/application-notification.yml
+        shell: bash
+
+      # application-oauth.yml 파일 생성
+      - name: make application-oauth.yml
+        run: |
+          touch ./src/main/resources/common/application-oauth.yml
+          echo "${{ secrets.APPLICATION_OAUTH_YML }}" > ./src/main/resources/common/application-oauth.yml
         shell: bash
 
       # 빌드 속도 향상을 위한 Gradle 캐싱

--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -164,5 +164,5 @@ jobs:
           script: |
             cd ~
             docker login -u "${{ secrets.DOCKER_USERNAME }}" -p "${{ secrets.DOCKER_PASSWORD }}"
-            cd server
+            cd confeti-api-server
             bash deploy.sh

--- a/.github/workflows/workflow-main.yml
+++ b/.github/workflows/workflow-main.yml
@@ -1,5 +1,6 @@
 # Workflow 이름
 name: CD workflow
+run-name: confeti-cd-prod-${{ github.ref_name }}-${{ github.run_number }} by @${{ github.actor }}
 
 # Event Trigger 환경
 on:
@@ -19,7 +20,9 @@ jobs:
     steps:
       # GitHub repository 코드 체크아웃
       - name: Checkout the repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
 
       # JDK 21 설치
       - name: Set up JDK 21
@@ -35,103 +38,74 @@ jobs:
             mkdir -p ./src/main/resources
           fi
 
-      # application.yml 파일 생성
-      - name: make application.yml
+      # application-prod.yml 파일 생성
+      - name: make application-prod.yml
         run: |
-          touch ./src/main/resources/application.yml
-          echo "${{ secrets.APPLICATION_YML }}" > ./src/main/resources/application.yml
+          touch ./src/main/resources/application-prod.yml
+          echo "${{ secrets.APPLICATION_PROD_YML }}" > ./src/main/resources/application-prod.yml
         shell: bash
 
-      # application-common.yml 파일 생성
-      - name: make application-common.yml
+      # common 폴더 생성
+      - name: Create common folder if not exist
         run: |
-          touch ./src/main/resources/application-common.yml
-          echo "${{ secrets.APPLICATION_COMMON_YML }}" > ./src/main/resources/application-common.yml
-        shell: bash
-
-      # cloud 폴더 생성
-      - name: Create cloud folder if not exist
-        run: |
-          if [ ! -d "./src/main/resources/cloud" ]; then
-            mkdir -p ./src/main/resources/cloud
-          fi
-
-      # application-cloud.yml 파일 생성
-      - name: make application-cloud.yml
-        run: |
-          touch ./src/main/resources/cloud/application-cloud.yml
-          echo "${{ secrets.APPLICATION_CLOUD_YML }}" > ./src/main/resources/cloud/application-cloud.yml
-        shell: bash
-
-      # application-elastic-search.yml 파일 생성
-      - name: make application-elastic-search.yml
-        run: |
-          touch ./src/main/resources/cloud/application-elastic-search.yml
-          echo "${{ secrets.APPLICATION_ELASTIC_SEARCH_YML }}" > ./src/main/resources/cloud/application-elastic-search.yml
-        shell: bash
-
-      # openapi 폴더 생성
-      - name: Create cloud folder if not exist
-        run: |
-          if [ ! -d "./src/main/resources/openapi" ]; then
-            mkdir -p ./src/main/resources/openapi
+          if [ ! -d "./src/main/resources/common" ]; then
+            mkdir -p ./src/main/resources/common
           fi
 
       # application-apple-music.yml 파일 생성
       - name: make application-apple-music.yml
         run: |
-          touch ./src/main/resources/openapi/application-apple-music.yml
-          echo "${{ secrets.APPLICATION_APPLE_MUSIC_YML }}" > ./src/main/resources/openapi/application-apple-music.yml
+          touch ./src/main/resources/common/application-apple-music.yml
+          echo "${{ secrets.APPLICATION_APPLE_MUSIC_YML }}" > ./src/main/resources/common/application-apple-music.yml
         shell: bash
 
-      # oauth 폴더 생성
-      - name: Create oauth folder if not exist
+      # application-cloud.yml 파일 생성
+      - name: make application-cloud.yml
         run: |
-          if [ ! -d "./src/main/resources/oauth" ]; then
-            mkdir -p ./src/main/resources/oauth
-          fi
-
-      # application-kakao.yml 파일 생성
-      - name: make application-kakao.yml
-        run: |
-          touch ./src/main/resources/oauth/application-kakao.yml
-          echo "${{ secrets.APPLICATION_KAKAO_YML }}" > ./src/main/resources/oauth/application-kakao.yml
-
+          touch ./src/main/resources/common/application-cloud.yml
+          echo "${{ secrets.APPLICATION_CLOUD_YML }}" > ./src/main/resources/common/application-cloud.yml
         shell: bash
 
-      # application-apple.yml 파일 생성
-      - name: make application-apple.yml
+      # application-common.yml 파일 생성
+      - name: make application-common.yml
         run: |
-          touch ./src/main/resources/oauth/application-apple.yml
-          echo "${{ secrets.APPLICATION_APPLE_YML }}" > ./src/main/resources/oauth/application-apple.yml
+          touch ./src/main/resources/common/application-common.yml
+          echo "${{ secrets.APPLICATION_COMMON_YML }}" > ./src/main/resources/common/application-common.yml
         shell: bash
 
-      # notification 폴더 생성
-      - name: Create notification folder if not exist
+      # application-dummy.yml 파일 생성
+      - name: make application-dummy.yml
         run: |
-          if [ ! -d "./src/main/resources/notification" ]; then
-               mkdir -p ./src/main/resources/notification
-          fi
+          touch ./src/main/resources/common/application-dummy.yml
+          echo "${{ secrets.APPLICATION_DUMMY_YML }}" > ./src/main/resources/common/application-dummy.yml
+        shell: bash
+
+      # application-elastic-search.yml 파일 생성
+      - name: make application-elastic-search.yml
+        run: |
+          touch ./src/main/resources/common/application-elastic-search.yml
+          echo "${{ secrets.APPLICATION_ELASTIC_SEARCH_YML }}" > ./src/main/resources/common/application-elastic-search.yml
+        shell: bash
+
+      # application-message-broker.yml 파일 생성
+      - name: make application-message-broker.yml
+        run: |
+          touch ./src/main/resources/common/application-message-broker.yml
+          echo "${{ secrets.APPLICATION_MESSAGE_BROKER_YML }}" > ./src/main/resources/common/application-message-broker.yml
+        shell: bash
 
       # application-notification.yml 파일 생성
       - name: make application-notification.yml
         run: |
-          touch ./src/main/resources/notification/application-notification.yml
-          echo "${{ secrets.APPLICATION_NOTIFICATION_YML }}" > ./src/main/resources/notification/application-notification.yml
+          touch ./src/main/resources/common/application-notification.yml
+          echo "${{ secrets.APPLICATION_NOTIFICATION_YML }}" > ./src/main/resources/common/application-notification.yml
         shell: bash
 
-      # messagebroker 폴더 생성
-      - name: Create messagebroker folder if not exist
+      # application-oauth.yml 파일 생성
+      - name: make application-oauth.yml
         run: |
-          if [ ! -d "./src/main/resources/messagebroker" ]; then
-               mkdir -p ./src/main/resources/messagebroker
-          fi
-
-      # application-messagebroker.yml 파일 생성
-      - name: make application-message-broker.yml
-        run: |
-          touch ./src/main/resources/messagebroker/application-message-broker.yml
-          echo "${{ secrets.APPLICATION_MESSAGE_BROKER_YML }}" > ./src/main/resources/messagebroker/application-message-broker.yml
+          touch ./src/main/resources/common/application-oauth.yml
+          echo "${{ secrets.APPLICATION_OAUTH_YML }}" > ./src/main/resources/common/application-oauth.yml
         shell: bash
 
       # 빌드 속도 향상을 위한 Gradle 캐싱
@@ -180,7 +154,7 @@ jobs:
       # 원격 서버에 배포
       - name: docker container deploy
         uses: appleboy/ssh-action@master
-        timeout-minutes: 20
+        timeout-minutes: 30
         with:
           host: ${{ secrets.HOST }}
           username: ${{ secrets.USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ build/
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/
-application*.yml
+application-local.yml
 **/src/main/resources/static/swagger-ui/openapi3.yaml
 logs/
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM eclipse-temurin:21-jdk
 WORKDIR /app
 COPY build/libs/confeti-0.0.1.jar /app/confeti.jar
 
-ENV JAVA_OPTS="-Xms1g -Xmx1g"
+# Container Memory Limit : 2g, Best Practice of Heap Memory : 512m ~ 1280m (60 ~ 70%)
+ENV JAVA_OPTS="-Xms512m -Xmx1280m"
 
 CMD ["sh", "-c", "java $JAVA_OPTS -Duser.timezone=Asia/Seoul -jar -Dspring.profiles.active=$SPRING_PROFILES_ACTIVE confeti.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,6 @@ FROM eclipse-temurin:21-jdk
 WORKDIR /app
 COPY build/libs/confeti-0.0.1.jar /app/confeti.jar
 
-ENV JAVA_OPTS="-Xms1024m -Xmx1024m"
-ENV SPRING_PROFILES_ACTIVE=prod
+ENV JAVA_OPTS="-Xms1g -Xmx2g"
 
 CMD ["sh", "-c", "java $JAVA_OPTS -Duser.timezone=Asia/Seoul -jar -Dspring.profiles.active=$SPRING_PROFILES_ACTIVE confeti.jar"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,6 @@ FROM eclipse-temurin:21-jdk
 WORKDIR /app
 COPY build/libs/confeti-0.0.1.jar /app/confeti.jar
 
-ENV JAVA_OPTS="-Xms1g -Xmx2g"
+ENV JAVA_OPTS="-Xms1g -Xmx1g"
 
 CMD ["sh", "-c", "java $JAVA_OPTS -Duser.timezone=Asia/Seoul -jar -Dspring.profiles.active=$SPRING_PROFILES_ACTIVE confeti.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -42,15 +42,15 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // AWS S3
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.1.1'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.1.1'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.3.1'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.1'
 
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
 
     // Grafana
     runtimeOnly("io.micrometer:micrometer-registry-prometheus")
-    
+
     // lombok
     compileOnly 'org.projectlombok:lombok'
     annotationProcessor 'org.projectlombok:lombok'
@@ -105,6 +105,9 @@ dependencies {
 
     // Spring Cloud AWS SQS Starter
     implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs:3.3.1'
+
+    // Secret Manager
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-secrets-manager:3.3.1'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -9,6 +9,7 @@ version = '0.0.1'
 
 ext {
     set('confetiApplication', 'org.sopt.confeti.ConfetiApplication')
+    set('awspringVersion', '3.3.1')
 }
 
 bootRun {
@@ -42,8 +43,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // AWS S3
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter:3.3.1'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:3.3.1'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter:${awspringVersion}'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:${awspringVersion}'
 
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -104,10 +105,10 @@ dependencies {
     implementation("com.slack.api:slack-api-client:1.45.3")
 
     // Spring Cloud AWS SQS Starter
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs:3.3.1'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs:${awspringVersion}'
 
     // Secret Manager
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-secrets-manager:3.3.1'
+    implementation 'io.awspring.cloud:spring-cloud-aws-starter-secrets-manager:${awspringVersion}'
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -43,8 +43,8 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-validation'
 
     // AWS S3
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter:${awspringVersion}'
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-s3:${awspringVersion}'
+    implementation "io.awspring.cloud:spring-cloud-aws-starter:${awspringVersion}"
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-s3:${awspringVersion}"
 
     // actuator
     implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -105,10 +105,10 @@ dependencies {
     implementation("com.slack.api:slack-api-client:1.45.3")
 
     // Spring Cloud AWS SQS Starter
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-sqs:${awspringVersion}'
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs:${awspringVersion}"
 
     // Secret Manager
-    implementation 'io.awspring.cloud:spring-cloud-aws-starter-secrets-manager:${awspringVersion}'
+    implementation "io.awspring.cloud:spring-cloud-aws-starter-secrets-manager:${awspringVersion}"
 }
 
 dependencyManagement {

--- a/build.gradle
+++ b/build.gradle
@@ -102,7 +102,6 @@ dependencies {
 
     // Swagger
     implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.8.13'
-    implementation("com.slack.api:slack-api-client:1.45.3")
 
     // Spring Cloud AWS SQS Starter
     implementation "io.awspring.cloud:spring-cloud-aws-starter-sqs:${awspringVersion}"

--- a/src/main/java/org/sopt/confeti/api/dummy/controller/AppleMusicAPITestController.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/controller/AppleMusicAPITestController.java
@@ -6,6 +6,7 @@ import org.sopt.confeti.api.dummy.facade.AppleMusicAPITestFacade;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,6 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequiredArgsConstructor
 @RequestMapping("${api.endpoints.dummy.base}${api.endpoints.dummy.apple-music-api-page}")
+@Profile(value = {"prod"})
 public class AppleMusicAPITestController {
 
     private final AppleMusicAPITestFacade appleMusicAPITestFacade;

--- a/src/main/java/org/sopt/confeti/api/dummy/controller/DummyPageController.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/controller/DummyPageController.java
@@ -19,6 +19,7 @@ import org.sopt.confeti.api.dummy.facade.dto.festival.request.UploadFestivalFile
 import org.sopt.confeti.api.dummy.facade.dto.festival.response.DummyFestivalPreviewDTO;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
 import org.springframework.validation.annotation.Validated;
@@ -36,6 +37,7 @@ import org.springframework.web.util.UriComponentsBuilder;
 @Validated
 @RequiredArgsConstructor
 @RequestMapping("${api.endpoints.dummy.base}")
+@Profile(value = {"prod"})
 public class DummyPageController {
 
     private final DummyFacade dummyFacade;
@@ -68,14 +70,14 @@ public class DummyPageController {
 
     @PostMapping("${api.endpoints.dummy.festival-page}")
     public String createFestival(
-            @Valid @ModelAttribute("festival") CreateFestivalRequest request,
-            @RequestParam("posterFile") MultipartFile poster,
-            @RequestParam("logoFile") MultipartFile logo,
-            @RequestParam(value = "reservationLogoFile", required = false) List<MultipartFile> reservationLogos,
-            RedirectAttributes redirectAttributes
+        @Valid @ModelAttribute("festival") CreateFestivalRequest request,
+        @RequestParam("posterFile") MultipartFile poster,
+        @RequestParam("logoFile") MultipartFile logo,
+        @RequestParam(value = "reservationLogoFile", required = false) List<MultipartFile> reservationLogos,
+        RedirectAttributes redirectAttributes
     ) {
         FestivalFilePathsDTO filePaths = dummyFacade.uploadFestivalFiles(
-                UploadFestivalFilesDTO.of(poster, logo, reservationLogos)
+            UploadFestivalFilesDTO.of(poster, logo, reservationLogos)
         );
 
         dummyFacade.createFestival(CreateFestivalDTO.of(request, filePaths));
@@ -87,12 +89,12 @@ public class DummyPageController {
 
     @GetMapping("${api.endpoints.dummy.festival-fix-page}")
     public String getFixFestivalPage(
-            @PathVariable Long festivalId,
-            Model model
+        @PathVariable Long festivalId,
+        Model model
     ) {
         String fixPageUrl = UriComponentsBuilder.fromUriString(dummyPageBase + fixFestivalPage)
-                .buildAndExpand(festivalId)
-                .toUriString();
+            .buildAndExpand(festivalId)
+            .toUriString();
         FixDummyFestivalDTO fixDummyFestivalDTO = dummyFacade.getFestivalInfoToFix(festivalId);
         model.addAttribute("festivalTitle", fixDummyFestivalDTO.title());
         model.addAttribute("stages", fixDummyFestivalDTO.stages());
@@ -103,14 +105,14 @@ public class DummyPageController {
 
     @PostMapping("${api.endpoints.dummy.festival-fix-page}")
     public String fixFestivalDatesAndMusics(
-            @PathVariable Long festivalId,
-            @Valid @ModelAttribute FixFestivalRequest request
+        @PathVariable Long festivalId,
+        @Valid @ModelAttribute FixFestivalRequest request
     ) {
         dummyFacade.fixFestival(
-                festivalId,
-                request.getDates().stream()
-                        .map(CreateFestivalDateDTO::from)
-                        .toList()
+            festivalId,
+            request.getDates().stream()
+                .map(CreateFestivalDateDTO::from)
+                .toList()
         );
 
         return "redirect:" + dummyPageBase + festivalListPage;
@@ -125,13 +127,13 @@ public class DummyPageController {
 
     @PostMapping("${api.endpoints.dummy.concert-page}")
     public String createConcert(
-            @Valid @ModelAttribute("concert") CreateConcertRequest request,
-            @RequestParam("posterFile") MultipartFile poster,
-            @RequestParam(value = "reservationLogoFile", required = false) List<MultipartFile> reservationLogos,
-            RedirectAttributes redirectAttributes
+        @Valid @ModelAttribute("concert") CreateConcertRequest request,
+        @RequestParam("posterFile") MultipartFile poster,
+        @RequestParam(value = "reservationLogoFile", required = false) List<MultipartFile> reservationLogos,
+        RedirectAttributes redirectAttributes
     ) {
         ConcertFilePathsDTO filePaths = dummyFacade.uploadConcertFiles(
-                UploadConcertFilesDTO.of(poster, reservationLogos)
+            UploadConcertFilesDTO.of(poster, reservationLogos)
         );
 
         dummyFacade.createConcert(CreateConcertDTO.of(request, filePaths));
@@ -149,18 +151,19 @@ public class DummyPageController {
 
     @GetMapping("${api.endpoints.dummy.festival-list-page}")
     public String getFestivalListPage(
-            Model model
+        Model model
     ) {
         List<DummyFestivalPreviewDTO> festivalPreviews = dummyFacade.getFestivalsPreview();
         List<DummyFestivalPreviewResponse> festivalPreviewResponses = festivalPreviews.stream()
-                .map(festivalPreview -> {
-                    String fixPageUrl = UriComponentsBuilder.fromUriString(dummyPageBase + fixFestivalPage)
-                            .buildAndExpand(festivalPreview.festivalId())
-                            .toUriString();
+            .map(festivalPreview -> {
+                String fixPageUrl = UriComponentsBuilder.fromUriString(
+                        dummyPageBase + fixFestivalPage)
+                    .buildAndExpand(festivalPreview.festivalId())
+                    .toUriString();
 
-                    return DummyFestivalPreviewResponse.of(festivalPreview, fixPageUrl, s3FileHandler);
-                })
-                .toList();
+                return DummyFestivalPreviewResponse.of(festivalPreview, fixPageUrl, s3FileHandler);
+            })
+            .toList();
 
         model.addAttribute("addFestivalUrl", dummyPageBase + festivalDummyPage);
         model.addAttribute("festivals", festivalPreviewResponses);

--- a/src/main/java/org/sopt/confeti/api/dummy/controller/PerformanceSearchController.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/controller/PerformanceSearchController.java
@@ -8,6 +8,7 @@ import org.sopt.confeti.global.annotation.UserId;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PatchMapping;
@@ -16,6 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 @Controller
 @RequiredArgsConstructor
 @RequestMapping("${api.endpoints.es.base}")
+@Profile(value = {"prod"})
 public class PerformanceSearchController {
 
     private final PerformanceSearchFacade performanceSearchFacade;

--- a/src/main/java/org/sopt/confeti/api/dummy/facade/AppleMusicAPITestFacade.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/facade/AppleMusicAPITestFacade.java
@@ -10,11 +10,13 @@ import org.sopt.confeti.global.annotation.RetryOnTokenExpire;
 import org.sopt.confeti.global.module.rest_client.builder.ApiRestClientBuilder;
 import org.sopt.confeti.global.util.music.AppleMusicAPITokenGenerator;
 import org.sopt.confeti.global.util.music.AppleMusicAPIURL;
+import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpHeaders;
 import org.springframework.util.MultiValueMap;
 
 @Facade
 @RequiredArgsConstructor
+@Profile(value = {"prod"})
 public class AppleMusicAPITestFacade {
 
     private final AppleMusicAPIURL appleMusicAPIURL;
@@ -63,13 +65,13 @@ public class AppleMusicAPITestFacade {
         putIfNotEmpty(params, "include", include);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getSingleAlbumPath(id))
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getSingleAlbumPath(id))
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
@@ -79,47 +81,49 @@ public class AppleMusicAPITestFacade {
         putIfNotEmpty(params, "include", include);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getMultipleAlbumsPath())
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getMultipleAlbumsPath())
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
-    public Object requestCatalogAlbumRelationship(String id, String relationship, List<String> include, Integer limit) {
+    public Object requestCatalogAlbumRelationship(String id, String relationship,
+        List<String> include, Integer limit) {
         Map<String, String> params = new HashMap<>();
         putIfNotEmpty(params, "include", include);
         putIfNotEmpty(params, "limit", limit);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getAlbumRelationshipByNamePath(id, relationship))
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getAlbumRelationshipByNamePath(id, relationship))
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
-    public Object requestCatalogAlbumRelationshipView(String id, String view, List<String> include, Integer limit,
-                                                      String with) {
+    public Object requestCatalogAlbumRelationshipView(String id, String view, List<String> include,
+        Integer limit,
+        String with) {
         Map<String, String> params = new HashMap<>();
         putIfNotEmpty(params, "include", include);
         putIfNotEmpty(params, "limit", limit);
         putIfNotEmpty(params, "with", with);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getAlbumRelationshipViewByNamePath(id, view))
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getAlbumRelationshipViewByNamePath(id, view))
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
@@ -129,13 +133,13 @@ public class AppleMusicAPITestFacade {
         putIfNotEmpty(params, "include", include);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getSingleArtistPath(id))
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getSingleArtistPath(id))
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
@@ -145,48 +149,50 @@ public class AppleMusicAPITestFacade {
         putIfNotEmpty(params, "include", include);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getMultipleArtistsPath())
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getMultipleArtistsPath())
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
-    public Object requestCatalogArtistRelationship(String id, String relationship, List<String> include,
-                                                   Integer limit) {
+    public Object requestCatalogArtistRelationship(String id, String relationship,
+        List<String> include,
+        Integer limit) {
         Map<String, String> params = new HashMap<>();
         putIfNotEmpty(params, "include", include);
         putIfNotEmpty(params, "limit", limit);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getArtistRelationshipByNamePath(id, relationship))
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getArtistRelationshipByNamePath(id, relationship))
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
-    public Object requestCatalogArtistRelationshipView(String id, String view, List<String> include, Integer limit,
-                                                       String with) {
+    public Object requestCatalogArtistRelationshipView(String id, String view, List<String> include,
+        Integer limit,
+        String with) {
         Map<String, String> params = new HashMap<>();
         putIfNotEmpty(params, "include", include);
         putIfNotEmpty(params, "limit", limit);
         putIfNotEmpty(params, "with", with);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getArtistRelationshipViewByNamePath(id, view))
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getArtistRelationshipViewByNamePath(id, view))
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
@@ -195,13 +201,13 @@ public class AppleMusicAPITestFacade {
         putIfNotEmpty(params, "include", include);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getSingleSongPath(id))
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getSingleSongPath(id))
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
@@ -211,29 +217,30 @@ public class AppleMusicAPITestFacade {
         putIfNotEmpty(params, "include", include);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getMultipleSongsPath())
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getMultipleSongsPath())
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
-    public Object requestCatalogSongRelationship(String id, String relationship, List<String> include, Integer limit) {
+    public Object requestCatalogSongRelationship(String id, String relationship,
+        List<String> include, Integer limit) {
         Map<String, String> params = new HashMap<>();
         putIfNotEmpty(params, "include", include);
         putIfNotEmpty(params, "limit", limit);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getSongRelationshipByNamePath(id, relationship))
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getSongRelationshipByNamePath(id, relationship))
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
@@ -245,13 +252,13 @@ public class AppleMusicAPITestFacade {
         putIfNotEmpty(params, "offset", offset);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getSingleSearchPath())
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getSingleSearchPath())
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
@@ -261,21 +268,21 @@ public class AppleMusicAPITestFacade {
         putIfNotEmpty(params, "limit", limit);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getSearchHintsPath())
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getSearchHintsPath())
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 
     @RetryOnTokenExpire
     public Object requestSearchSuggestions(
-            List<String> kinds,
-            Integer limit,
-            String term,
-            List<String> types
+        List<String> kinds,
+        Integer limit,
+        String term,
+        List<String> types
     ) {
         Map<String, String> params = new HashMap<>();
         putIfNotEmpty(params, "kinds", kinds);
@@ -284,12 +291,12 @@ public class AppleMusicAPITestFacade {
         putIfNotEmpty(params, "types", types);
 
         return restClient.request()
-                .get()
-                .baseUrl(appleMusicAPIURL.getBaseUrl())
-                .path(appleMusicAPIURL.getSearchSuggestionsPath())
-                .params(MultiValueMap.fromSingleValue(params))
-                .build()
-                .connect(headers)
-                .retrieve(Object.class);
+            .get()
+            .baseUrl(appleMusicAPIURL.getBaseUrl())
+            .path(appleMusicAPIURL.getSearchSuggestionsPath())
+            .params(MultiValueMap.fromSingleValue(params))
+            .build()
+            .connect(headers)
+            .retrieve(Object.class);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/dummy/facade/DummyFacade.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/facade/DummyFacade.java
@@ -24,10 +24,12 @@ import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.util.S3FileHandler;
+import org.springframework.context.annotation.Profile;
 import org.springframework.transaction.annotation.Transactional;
 
 @Facade
 @RequiredArgsConstructor
+@Profile(value = {"prod"})
 public class DummyFacade {
 
     private final S3FileHandler s3FileHandler;
@@ -37,13 +39,13 @@ public class DummyFacade {
 
     public FestivalFilePathsDTO uploadFestivalFiles(UploadFestivalFilesDTO files) {
         String posterPath = s3FileHandler.uploadFile(files.poster(),
-                FolderPath.combine(FolderPath.FESTIVAL, FolderPath.POSTER));
+            FolderPath.combine(FolderPath.FESTIVAL, FolderPath.POSTER));
         String logoPath = s3FileHandler.uploadFile(files.logo(),
-                FolderPath.combine(FolderPath.FESTIVAL, FolderPath.LOGO));
+            FolderPath.combine(FolderPath.FESTIVAL, FolderPath.LOGO));
         List<String> reservationLogoPaths = files.reservationLogos().stream()
-                .map(reservationLogo -> s3FileHandler.uploadFile(reservationLogo,
-                        FolderPath.combine(FolderPath.FESTIVAL, FolderPath.RESERVATION, FolderPath.LOGO)))
-                .toList();
+            .map(reservationLogo -> s3FileHandler.uploadFile(reservationLogo,
+                FolderPath.combine(FolderPath.FESTIVAL, FolderPath.RESERVATION, FolderPath.LOGO)))
+            .toList();
 
         return FestivalFilePathsDTO.of(posterPath, logoPath, reservationLogoPaths);
     }
@@ -56,11 +58,11 @@ public class DummyFacade {
 
     public ConcertFilePathsDTO uploadConcertFiles(UploadConcertFilesDTO files) {
         String posterPath = s3FileHandler.uploadFile(files.poster(),
-                FolderPath.combine(FolderPath.CONCERT, FolderPath.POSTER));
+            FolderPath.combine(FolderPath.CONCERT, FolderPath.POSTER));
         List<String> reservationLogoPaths = files.reservationLogos().stream()
-                .map(reservationLogo -> s3FileHandler.uploadFile(reservationLogo,
-                        FolderPath.combine(FolderPath.CONCERT, FolderPath.RESERVATION, FolderPath.LOGO)))
-                .toList();
+            .map(reservationLogo -> s3FileHandler.uploadFile(reservationLogo,
+                FolderPath.combine(FolderPath.CONCERT, FolderPath.RESERVATION, FolderPath.LOGO)))
+            .toList();
 
         return ConcertFilePathsDTO.of(posterPath, reservationLogoPaths);
     }
@@ -77,10 +79,10 @@ public class DummyFacade {
 
         validateFestivalFirstDateExist(festival);
         return FixDummyFestivalDTO.of(
-                festival.getTitle(),
-                festival.getDates()
-                        .getFirst()
-                        .getStages()
+            festival.getTitle(),
+            festival.getDates()
+                .getFirst()
+                .getStages()
         );
     }
 
@@ -94,22 +96,23 @@ public class DummyFacade {
     @Transactional
     public void fixFestival(long festivalId, List<CreateFestivalDateDTO> dates) {
         festivalService.addDates(festivalId, dates);
-        performanceService.addPerformanceArtists(PerformanceType.FESTIVAL, festivalId, getPerformanceArtists(dates));
+        performanceService.addPerformanceArtists(PerformanceType.FESTIVAL, festivalId,
+            getPerformanceArtists(dates));
     }
 
     private List<PerformanceArtist> getPerformanceArtists(List<CreateFestivalDateDTO> dates) {
         return dates.stream()
-                .flatMap(date -> date.stages().stream())
-                .flatMap(stage -> stage.times().stream())
-                .flatMap(time -> time.artists().stream())
-                .map(PerformanceArtist::create)
-                .toList();
+            .flatMap(date -> date.stages().stream())
+            .flatMap(stage -> stage.times().stream())
+            .flatMap(time -> time.artists().stream())
+            .map(PerformanceArtist::create)
+            .toList();
     }
 
     @Transactional(readOnly = true)
     public List<DummyFestivalPreviewDTO> getFestivalsPreview() {
         return festivalService.getAll().stream()
-                .map(DummyFestivalPreviewDTO::from)
-                .toList();
+            .map(DummyFestivalPreviewDTO::from)
+            .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/api/dummy/facade/PerformanceSearchFacade.java
+++ b/src/main/java/org/sopt/confeti/api/dummy/facade/PerformanceSearchFacade.java
@@ -7,10 +7,12 @@ import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchServi
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.annotation.Facade;
+import org.springframework.context.annotation.Profile;
 import org.springframework.transaction.annotation.Transactional;
 
 @Facade
 @RequiredArgsConstructor
+@Profile(value = {"prod"})
 public class PerformanceSearchFacade {
 
     private final PerformanceSearchService performanceSearchService;
@@ -21,8 +23,8 @@ public class PerformanceSearchFacade {
         performanceSearchService.deleteAll();
         List<PerformanceDTO> performances = performanceService.getAllPerformances();
         List<PerformanceDocument> performanceDocuments = performances.stream()
-                .map(PerformanceDocument::create)
-                .toList();
+            .map(PerformanceDocument::create)
+            .toList();
 
         performanceSearchService.save(performanceDocuments);
     }

--- a/src/main/java/org/sopt/confeti/auth/WebhookService.java
+++ b/src/main/java/org/sopt/confeti/auth/WebhookService.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.auth;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import lombok.RequiredArgsConstructor;
@@ -22,13 +23,14 @@ public class WebhookService {
 
     public void sendDiscordNotification() {
 
-        for (String profile : environment.getActiveProfiles()) {
-            if (profile.equalsIgnoreCase("dev")) {
-                return;
-            }
+        boolean isProd = Arrays.stream(environment.getActiveProfiles())
+                .anyMatch(profile -> profile.equalsIgnoreCase("prod"));
+
+        if (!isProd) {
+            return;
         }
 
-        String discordWebhookUrl = environment.getProperty("discord.webhook.url");
+        String discordWebhookUrl = environment.getProperty("notification.discord.webhook.url");
         if (discordWebhookUrl == null || discordWebhookUrl.isBlank()) {
             return;
         }
@@ -42,11 +44,11 @@ public class WebhookService {
         body.put("content", message);
 
         restClient.request()
-                .post()
-                .baseUrl(discordWebhookUrl)
-                .body(body)
-                .build()
-                .connect()
-                .retrieve();
+            .post()
+            .baseUrl(discordWebhookUrl)
+            .body(body)
+            .build()
+            .connect()
+            .retrieve();
     }
 }

--- a/src/main/java/org/sopt/confeti/global/notification/LocalNotificationAgent.java
+++ b/src/main/java/org/sopt/confeti/global/notification/LocalNotificationAgent.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Slf4j
 @Component
 @Profile(
-    value = {"dev"}
+    value = {"local"}
 )
 public class LocalNotificationAgent implements NotificationAgent {
 

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPITokenGenerator.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPITokenGenerator.java
@@ -14,10 +14,12 @@ import org.sopt.confeti.global.annotation.Generator;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 
 @Slf4j
 @Generator
 @RequiredArgsConstructor
+@Profile(value = {"prod"})
 public class AppleMusicAPITokenGenerator {
 
     private final String PRIVATE_KEY_ALGORITHM = "EC";
@@ -43,10 +45,10 @@ public class AppleMusicAPITokenGenerator {
         claims.put("exp", new Date(now.getTime() + expiration));
 
         return Jwts.builder()
-                .header().keyId(keyId).add("alg", "ES256").and()
-                .claims(claims)
-                .signWith(getPrivateKey())
-                .compact();
+            .header().keyId(keyId).add("alg", "ES256").and()
+            .claims(claims)
+            .signWith(getPrivateKey())
+            .compact();
     }
 
     private PrivateKey getPrivateKey() {

--- a/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIURL.java
+++ b/src/main/java/org/sopt/confeti/global/util/music/AppleMusicAPIURL.java
@@ -4,11 +4,13 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
 
 @Component
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Profile(value = {"prod"})
 public class AppleMusicAPIURL {
 
     @Getter
@@ -101,8 +103,8 @@ public class AppleMusicAPIURL {
 
     public String getSingleArtistPath(String id) {
         return UriComponentsBuilder.fromUriString(getArtistsBasePath() + artistsPathSingle)
-                .buildAndExpand(id)
-                .toUriString();
+            .buildAndExpand(id)
+            .toUriString();
     }
 
     public String getMultipleArtistsPath() {
@@ -110,27 +112,29 @@ public class AppleMusicAPIURL {
     }
 
     public String getArtistRelationshipByNamePath(String id, String relationship) {
-        return UriComponentsBuilder.fromUriString(getArtistsBasePath() + artistsPathRelationshipByName)
-                .buildAndExpand(id, relationship)
-                .toUriString();
+        return UriComponentsBuilder.fromUriString(
+                getArtistsBasePath() + artistsPathRelationshipByName)
+            .buildAndExpand(id, relationship)
+            .toUriString();
     }
 
     public String getArtistRelationshipViewByNamePath(String id, String view) {
-        return UriComponentsBuilder.fromUriString(getArtistsBasePath() + artistsPathRelationshipViewByName)
-                .buildAndExpand(id, view)
-                .toUriString();
+        return UriComponentsBuilder.fromUriString(
+                getArtistsBasePath() + artistsPathRelationshipViewByName)
+            .buildAndExpand(id, view)
+            .toUriString();
     }
 
     public String getArtistSongsPath(String id) {
         return UriComponentsBuilder.fromUriString(getArtistsBasePath() + artistsPathSongs)
-                .buildAndExpand(id)
-                .toUriString();
+            .buildAndExpand(id)
+            .toUriString();
     }
 
     public String getSingleAlbumPath(String id) {
         return UriComponentsBuilder.fromUriString(getAlbumsBasePath() + albumsPathSingle)
-                .buildAndExpand(id)
-                .toUriString();
+            .buildAndExpand(id)
+            .toUriString();
     }
 
     public String getMultipleAlbumsPath() {
@@ -138,21 +142,23 @@ public class AppleMusicAPIURL {
     }
 
     public String getAlbumRelationshipByNamePath(String id, String relationship) {
-        return UriComponentsBuilder.fromUriString(getAlbumsBasePath() + albumsPathRelationshipByName)
-                .buildAndExpand(id, relationship)
-                .toUriString();
+        return UriComponentsBuilder.fromUriString(
+                getAlbumsBasePath() + albumsPathRelationshipByName)
+            .buildAndExpand(id, relationship)
+            .toUriString();
     }
 
     public String getAlbumRelationshipViewByNamePath(String id, String view) {
-        return UriComponentsBuilder.fromUriString(getAlbumsBasePath() + albumsPathRelationshipViewByName)
-                .buildAndExpand(id, view)
-                .toUriString();
+        return UriComponentsBuilder.fromUriString(
+                getAlbumsBasePath() + albumsPathRelationshipViewByName)
+            .buildAndExpand(id, view)
+            .toUriString();
     }
 
     public String getSingleSongPath(String id) {
         return UriComponentsBuilder.fromUriString(getSongsBasePath() + songsPathSingle)
-                .buildAndExpand(id)
-                .toUriString();
+            .buildAndExpand(id)
+            .toUriString();
     }
 
     public String getMultipleSongsPath() {
@@ -161,8 +167,8 @@ public class AppleMusicAPIURL {
 
     public String getSongRelationshipByNamePath(String id, String relationship) {
         return UriComponentsBuilder.fromUriString(getSongsBasePath() + songsPathRelationshipByName)
-                .buildAndExpand(id, relationship)
-                .toUriString();
+            .buildAndExpand(id, relationship)
+            .toUriString();
     }
 
     public String getSingleSearchPath() {

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -4,6 +4,11 @@ spring:
       - classpath:common/application-common.yml
       - aws-secretsmanager:/confeti-api/prod/database?prefix=db-secrets.
       - aws-secretsmanager:/confeti-api/auth?prefix=auth-secrets.
+      - aws-secretsmanager:/confeti-api/prod/cloud?prefix=cloud-secrets.
+      - aws-secretsmanager:/confeti-api/prod/elastic-search?prefix=es-secrets.
+      - aws-secretsmanager:/confeti-api/prod/notification?prefix=notification-secrets.
+      - aws-secretsmanager:/confeti-api/prod/dummy?prefix=dummy-secrets.
+      - aws-secretsmanager:/confeti-api/prod/apple-music?prefix=apple-music-secrets.
 
   application:
     name: confeti-api-prod

--- a/src/main/resources/application-prod.yml
+++ b/src/main/resources/application-prod.yml
@@ -1,0 +1,98 @@
+spring:
+  config:
+    import:
+      - classpath:common/application-common.yml
+      - aws-secretsmanager:/confeti-api/prod/database?prefix=db-secrets.
+      - aws-secretsmanager:/confeti-api/auth?prefix=auth-secrets.
+
+  application:
+    name: confeti-api-prod
+
+  datasource:
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://${db-secrets.host}:${db-secrets.port}/${db-secrets.dbname}?useSSL=false&allowPublicKeyRetrieval=true&useUnicode=true&serverTimezone=Asia/Seoul
+    username: ${db-secrets.username}
+    password: ${db-secrets.password}
+
+  jpa:
+    hibernate:
+      ddl-auto: update
+    open-in-view: false
+    properties:
+      hibernate:
+        default_batch_fetch_size: 100
+
+  servlet:
+    multipart:
+      enabled: true
+      max-file-size: 30MB
+      max-request-size: 30MB
+
+  redis:
+    command-timeout: 3
+    connect-timeout: 5
+    shutdown-timeout: 200
+    sentinel:
+      master: mymaster
+      nodes:
+        - host: redis-sentinel-1
+          port: 26379
+        - host: redis-sentinel-2
+          port: 26379
+        - host: redis-sentinel-3
+          port: 26379
+
+springdoc:
+  packages-to-scan: org.sopt.confeti.api
+  default-consumes-media-type: application/json;charset=UTF-8
+  default-produces-media-type: application/json;charset=UTF-8
+  cache:
+    disabled: true
+  api-docs:
+    path: /openapi
+    groups:
+      enabled: true
+  swagger-ui:
+    enabled: true
+    path: /swagger-ui.html
+    tags-sorter: alpha
+    operations-sorter: alpha
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, metrics, prometheus
+
+logging:
+  level:
+    org.sopt.confeti: info
+    org.springframework.data.elasticsearch: info
+    org.springframework.web: info
+
+---
+server:
+  port: 8081
+  tomcat:
+    threads:
+      max: 50         # 최대 스레드 개수
+      min-spare: 5    # 최소 스페어(항상 유지) 스레드 개수
+    max-connections: 200  # 최대 커넥션 수
+    accept-count: 50
+spring:
+  config:
+    activate:
+      on-profile: blue
+---
+server:
+  port: 8082
+  tomcat:
+    threads:
+      max: 50         # 최대 스레드 개수
+      min-spare: 5    # 최소 스페어(항상 유지) 스레드 개수
+    max-connections: 200  # 최대 커넥션 수
+    accept-count: 50
+spring:
+  config:
+    activate:
+      on-profile: green

--- a/src/main/resources/common/application-apple-music.yml
+++ b/src/main/resources/common/application-apple-music.yml
@@ -1,10 +1,11 @@
 spring:
   config:
-    import:
-      - aws-secretsmanager:/confeti-api/prod/apple-music?prefix=apple-music-secrets.
-
+    activate:
+      on-profile: prod
 apple-music:
   api:
+    host: https://external.confeti.xyz
+    path: /apple-music-api
     endpoints:
       base-url: https://api.music.apple.com
       path-prefix: /v1/catalog/kr
@@ -39,15 +40,6 @@ apple-music:
     team-id: ${apple-music-secrets.team-id}
     private-key: ${apple-music-secrets.private-key}
     expiration: 172800000
----
-spring:
-  config:
-    activate:
-      on-profile: prod
-apple-music:
-  api:
-    host: https://external.confeti.xyz
-    path: /apple-music-api
 
 ---
 spring:

--- a/src/main/resources/common/application-apple-music.yml
+++ b/src/main/resources/common/application-apple-music.yml
@@ -1,0 +1,60 @@
+spring:
+  config:
+    import:
+      - aws-secretsmanager:/confeti-api/prod/apple-music?prefix=apple-music-secrets.
+
+apple-music:
+  api:
+    endpoints:
+      base-url: https://api.music.apple.com
+      path-prefix: /v1/catalog/kr
+      artists-path:
+        base: /artists
+        single: /{id}
+        multiple: ""
+        relationship-by-name: /{id}/{relationship}
+        relationship-view-by-name: /{id}/view/{view}
+        songs: /{id}/songs
+      albums-path:
+        base: /albums
+        single: /{id}
+        multiple: ""
+        relationship-by-name: /{id}/{relationship}
+        relationship-view-by-name: /{id}/view/{view}
+      songs-path:
+        base: /songs
+        single: /{id}
+        multiple: ""
+        relationship-by-name: /{id}/{relationship}
+      search-path:
+        base: /search
+        single: ""
+        hints: /hints
+        suggestions: /suggestions
+      charts-path:
+        base: /charts
+
+  credentials:
+    key-id: ${apple-music-secrets.key-id}
+    team-id: ${apple-music-secrets.team-id}
+    private-key: ${apple-music-secrets.private-key}
+    expiration: 172800000
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+apple-music:
+  api:
+    host: https://external.confeti.xyz
+    path: /apple-music-api
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+apple-music:
+  api:
+    host: http://localhost:4290
+    path: /apple-music-api

--- a/src/main/resources/common/application-cloud.yml
+++ b/src/main/resources/common/application-cloud.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    import:
+      - aws-secretsmanager:/confeti-api/prod/cloud?prefix=cloud-secrets.
+
+  cloud:
+    aws:
+      s3:
+        host: https://confeti-s3-prod.s3.ap-northeast-2.amazonaws.com/
+        bucket-name: confeti-s3-prod
+      credentials:
+        access-key: ${cloud-secrets.aws.credentials.access-key}
+        secret-key: ${cloud-secrets.aws.credentials.secret-key}
+      region:
+        static: ap-northeast-2
+
+event:
+  queues:
+    confeti-server: https://sqs.ap-northeast-2.amazonaws.com/078129922291/confeti-server-event-sqs

--- a/src/main/resources/common/application-cloud.yml
+++ b/src/main/resources/common/application-cloud.yml
@@ -1,8 +1,4 @@
 spring:
-  config:
-    import:
-      - aws-secretsmanager:/confeti-api/prod/cloud?prefix=cloud-secrets.
-
   cloud:
     aws:
       s3:

--- a/src/main/resources/common/application-common.yml
+++ b/src/main/resources/common/application-common.yml
@@ -1,0 +1,16 @@
+spring:
+  config:
+    import:
+      - classpath:common/application-dummy.yml
+      - classpath:common/application-cloud.yml
+      - classpath:common/application-elastic-search.yml
+      - classpath:common/application-apple-music.yml
+      - classpath:common/application-oauth.yml
+      - classpath:common/application-notification.yml
+      - classpath:common/application-message-broker.yml
+
+  jackson:
+    serialization:
+      write-dates-as-timestamps: false
+    time-zone: Asia/Seoul
+    default-property-inclusion: non_null

--- a/src/main/resources/common/application-dummy.yml
+++ b/src/main/resources/common/application-dummy.yml
@@ -1,0 +1,31 @@
+spring:
+  config:
+    import:
+      - aws-secretsmanager:/confeti-api/prod/dummy?prefix=dummy-secrets.
+
+api:
+  endpoints:
+    dummy:
+      base: ${dummy-secrets.dummy.base}
+      festival-page: /festivals
+      festival-fix-page: /festivals/{festivalId}
+      festival-list-page: /festival-list
+      concert-page: /concerts
+      apple-music-api-page: /apple-music-api
+      catalog-album: /albums/catalog-album
+      multiple-catalog-albums: /albums/multiple-catalog-albums
+      catalog-album-relationship: /albums/catalog-album-relationship
+      catalog-album-relationship-view: /albums/catalog-album-relationship-view
+      catalog-artist: /artists/catalog-artist
+      multiple-catalog-artists: /artists/multiple-catalog-artists
+      catalog-artist-relationship: /artists/catalog-artist-relationship
+      catalog-artist-relationship-view: /artists/catalog-artist-relationship-view
+      catalog-song: /songs/catalog-song
+      multiple-catalog-songs: /songs/multiple-catalog-songs
+      catalog-song-relationship: /songs/catalog-song-relationship
+      search-catalog-resources: /search/search-catalog-resources
+      catalog-search-hints: /search/catalog-search-hints
+      catalog-search-suggestions: /search/catalog-search-suggestions
+    es:
+      base: ${dummy-secrets.es.base}
+      batch: /batch

--- a/src/main/resources/common/application-dummy.yml
+++ b/src/main/resources/common/application-dummy.yml
@@ -1,7 +1,7 @@
 spring:
   config:
-    import:
-      - aws-secretsmanager:/confeti-api/prod/dummy?prefix=dummy-secrets.
+    activate:
+      on-profile: prod
 
 api:
   endpoints:

--- a/src/main/resources/common/application-elastic-search.yml
+++ b/src/main/resources/common/application-elastic-search.yml
@@ -1,8 +1,4 @@
 spring:
-  config:
-    import:
-      - aws-secretsmanager:/confeti-api/prod/elastic-search?prefix=es-secrets.
-
   data:
     elasticsearch:
       uris: ${es-secrets.host}:${es-secrets.port}

--- a/src/main/resources/common/application-elastic-search.yml
+++ b/src/main/resources/common/application-elastic-search.yml
@@ -1,0 +1,10 @@
+spring:
+  config:
+    import:
+      - aws-secretsmanager:/confeti-api/prod/elastic-search?prefix=es-secrets.
+
+  data:
+    elasticsearch:
+      uris: ${es-secrets.host}:${es-secrets.port}
+      username: ${es-secrets.username}
+      password: ${es-secrets.password}

--- a/src/main/resources/common/application-message-broker.yml
+++ b/src/main/resources/common/application-message-broker.yml
@@ -1,0 +1,17 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+message-broker:
+  sqs:
+    create-event: https://sqs.ap-northeast-2.amazonaws.com/078129922291/confeti-server-create-prod
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: local
+message-broker:
+  sqs:
+    create-event: https://sqs.ap-northeast-2.amazonaws.com/078129922291/confeti-server-create-dev

--- a/src/main/resources/common/application-notification.yml
+++ b/src/main/resources/common/application-notification.yml
@@ -1,0 +1,36 @@
+spring:
+  config:
+    activate:
+      on-profile: prod
+    import:
+      - aws-secretsmanager:/confeti-api/prod/notification?prefix=notification-secrets.
+
+notification:
+  slack:
+    error:
+      critical:
+        url: ${notification-secrets.slack.error.critical.url}
+      high:
+        url: ${notification-secrets.slack.error.high.url}
+
+  discord:
+    webhook:
+      url: ${notification-secrets.discord.webhook.url}
+
+---
+spring:
+  config:
+    activate:
+      on-profile: local
+
+notification:
+  slack:
+    error:
+      critical:
+        url: ''
+      high:
+        url: ''
+
+  discord:
+    webhook:
+      url: ''

--- a/src/main/resources/common/application-notification.yml
+++ b/src/main/resources/common/application-notification.yml
@@ -2,8 +2,6 @@ spring:
   config:
     activate:
       on-profile: prod
-    import:
-      - aws-secretsmanager:/confeti-api/prod/notification?prefix=notification-secrets.
 
 notification:
   slack:

--- a/src/main/resources/common/application-oauth.yml
+++ b/src/main/resources/common/application-oauth.yml
@@ -1,8 +1,3 @@
-spring:
-  config:
-    import:
-      - aws-secretsmanager:/confeti-api/auth?prefix=auth-secrets.
-
 jwt:
   secret-key: ${auth-secrets.jwt.secret-key}
   access-token-valid-time: 86400000

--- a/src/main/resources/common/application-oauth.yml
+++ b/src/main/resources/common/application-oauth.yml
@@ -1,0 +1,19 @@
+spring:
+  config:
+    import:
+      - aws-secretsmanager:/confeti-api/auth?prefix=auth-secrets.
+
+jwt:
+  secret-key: ${auth-secrets.jwt.secret-key}
+  access-token-valid-time: 86400000
+  refresh-token-valid-time: 172800000
+
+apple:
+  client-id: ${auth-secrets.apple.client-id}
+  key-id: ${auth-secrets.apple.key-id}
+  team-id: ${auth-secrets.apple.team-id}
+  private-key: ${auth-secrets.apple.private-key}
+
+kakao:
+  client-id: ${auth-secrets.kakao.client-id}
+  admin-key: ${auth-secrets.kakao.admin-key}


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
크게 세 가지 작업을 했습니다.
1. Github에서 application yml 관리를 위한 수정 및 구조 변경, 민감한 정보를 안전하게 사용하기 위해 Security Manager 도입
2. 로컬에서 `Dummy 공연 등록`, `Apple Music API에 직접 의존` 하는 로직을 없애기 위해 각 빈에 프로필 설정
3. 애플리케이션 힙 메모리 설정 수정

### (1)
application yml 파일이 불필요한 프로필 세분화 및 비효율적인 관리가 되고 있는 것 같아 리펙토링 했습니다.
그리고 설정이 점차 많아지면서 노션에서 공유하던 yml 설정 관리가 더 이상 어렵다고 판단했습니다.

모든 암호와 숨겨야하는 정보는 Security Manager로 이관했으며 AWS Starter에 로그인해서 확인하실 수 있습니다.
또한, 노션에 `application-local.yml` 파일을 올려두었으니 로컬 실행 시 꼭 복붙해주세요

### (2)
불필요한 빈 설정을 최소화했습니다.

### (3)
홈 서버로 서버를 이전할 계획입니다.
지금은 서버가 간신히 동작하고 있고, 매우 느리며 배포 시에 30분 이상 걸립니다.
이제는 스펙을 늘려야할 때가 온 것 같아 홈 서버 이전을 결정했습니다.
현재 홈 서버의 스펙은 4코어 8GB이며 2GB의 스왑 메모리가 잡혀있습니다. 그리고 물리 메모리 2GB가 남습니다.
이전 후 서버의 메모리는 최대 2GB까지 사용할 수 있도록 구성할 예정입니다.

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
