### PR TITLE
CSERVER-8 @Valid 어노테이션을 인터페이스의 파라미터에 설정하도록 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserOnboardController.java
@@ -1,6 +1,5 @@
 package org.sopt.confeti.api.user.controller;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import java.util.Optional;
@@ -123,7 +122,7 @@ public class UserOnboardController implements UserOnboardControllerDocs {
     @Onboarding
     @PatchMapping("/artists/favorite")
     public ResponseEntity<BaseResponse<Void>> patchFavoriteArtists(
-        @Valid @RequestBody PatchOnboardFavoriteArtistsRequest request
+        @RequestBody PatchOnboardFavoriteArtistsRequest request
     ) {
         userOnboardFacade.patchFavoriteArtist(request.toDto());
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
@@ -132,7 +131,7 @@ public class UserOnboardController implements UserOnboardControllerDocs {
     @Onboarding
     @PostMapping("/artists/favorite")
     public ResponseEntity<BaseResponse<UserOnboardFavoriteArtistsResponse>> addFavoriteArtists(
-        @Valid @RequestBody AddOnboardFavoriteArtistRequest request
+        @RequestBody AddOnboardFavoriteArtistRequest request
     ) {
         UserOnboardFavoriteArtistsDTO favoriteArtists = userOnboardFacade.addFavoriteArtists(
             request.toDTO());

--- a/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
@@ -1,6 +1,5 @@
 package org.sopt.confeti.api.user.controller;
 
-import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.controller.docs.UserTimetableControllerDocs;
@@ -80,7 +79,7 @@ public class UserTimetableController implements UserTimetableControllerDocs {
     @Permission(role = {Role.GENERAL})
     @PostMapping
     public ResponseEntity<BaseResponse<Void>> addTimetableFestival(
-        @Valid @RequestBody AddTimetablesRequest addTimetablesRequest
+        @RequestBody AddTimetablesRequest addTimetablesRequest
     ) {
         userTimetableFacade.addTimetables(
             AddTimetablesDTO.from(addTimetablesRequest));
@@ -103,7 +102,7 @@ public class UserTimetableController implements UserTimetableControllerDocs {
     @PatchMapping("/{timetableId}/time-blocks")
     public ResponseEntity<BaseResponse<Void>> updateTimetableFestival(
         @PathVariable(name = "timetableId") @Min(RequestConstraint.ID) long timetableId,
-        @Valid @RequestBody PatchTimeBlocksRequest patchTimeBlocksRequest
+        @RequestBody PatchTimeBlocksRequest patchTimeBlocksRequest
     ) {
         userTimetableFacade.patchTimeBlocks(timetableId,
             PatchTimeBlocksDTO.from(patchTimeBlocksRequest));
@@ -160,7 +159,7 @@ public class UserTimetableController implements UserTimetableControllerDocs {
     @Permission(role = {Role.GENERAL})
     @PatchMapping
     public ResponseEntity<BaseResponse<Void>> updateTimetableFestival(
-        @Valid @RequestBody PatchTimetablesRequest patchTimetablesRequest
+        @RequestBody PatchTimetablesRequest patchTimetablesRequest
     ) {
         userTimetableFacade.updateTimetables(patchTimetablesRequest.toCommand());
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserTimetableControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserTimetableControllerDocs.java
@@ -4,6 +4,7 @@ import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.responses.ApiResponses;
 import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
 import jakarta.validation.constraints.Min;
 import org.sopt.confeti.api.user.dto.request.timetable.AddTimetablesRequest;
 import org.sopt.confeti.api.user.dto.request.timetable.PatchTimeBlocksRequest;
@@ -70,7 +71,7 @@ public interface UserTimetableControllerDocs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<Void>> addTimetableFestival(
-        @RequestBody AddTimetablesRequest addTimetablesRequest
+        @Valid @RequestBody AddTimetablesRequest addTimetablesRequest
     );
 
     @Operation(summary = "등록된 시간표 조회")
@@ -102,7 +103,7 @@ public interface UserTimetableControllerDocs {
     @CommonErrorResponses
     ResponseEntity<BaseResponse<Void>> updateTimetableFestival(
         @PathVariable(name = "timetableId") @Min(RequestConstraint.ID) long timetableId,
-        @RequestBody PatchTimeBlocksRequest patchTimeBlocksRequest
+        @Valid @RequestBody PatchTimeBlocksRequest patchTimeBlocksRequest
     );
 
     @Operation(
@@ -192,7 +193,7 @@ public interface UserTimetableControllerDocs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<Void>> updateTimetableFestival(
-        @RequestBody PatchTimetablesRequest patchTimetablesRequest
+        @Valid @RequestBody PatchTimetablesRequest patchTimetablesRequest
     );
 
     @Operation(summary = "타임테이블 날짜 목록 조회")


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->

- `@Valid` 어노테이션을 인터페이스의 파라미터에 설정하도록 수정
- 기존 `@Valid`가 구현체에만 적용되어 있었던 경우 오류가 발생함. Spring의 유효성 검사가 AOP로 수행되는데, 이때 AOP 프록시는 인터페이스를 기준으로 생성됨. 인터페이스에는 `@Valid`가 없었으므로 유효성 검사 없이 데이터를 구현체인 컨트롤러에게 전달하는데, 막상 컨트롤러를 보니 인터페이스와 구현체 간 제약 선언이 불일치하여  ConstraintDeclarationException이 발생.
-> 리스코프 치환 원칙 위배네요 ㅋㅋㅋ..

1. `@Valid`가 구현체에만 있는 경우 -> 오류 발생
2. `@Valid`가 인터페이스에만 있는 경우 -> 정상 처리
3. `@Valid`가 인터페이스와 구현체 둘 다 있는 경우 -> 정상적으로 처리되고 있었으나 불필요. (이번 PR에서 제거)
->   서브 타입에서 오버라이딩되거나 구현된 메서드의 파라미터에는 어떠한 제약 조건도 추가로 선언하면 안된다고 함.



## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
