### PR TITLE
CSERVER-16 예매처 도메인 파일 사용 방식 변경

### DIFF
--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -12,7 +12,6 @@ import org.sopt.confeti.api.admin.dto.response.TicketVendorResponses;
 import org.sopt.confeti.api.admin.facade.AdminFacade;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalDetailInfo;
-import org.sopt.confeti.global.annotation.Admin;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.common.constant.RequestConstraint;
 import org.sopt.confeti.global.message.SuccessMessage;
@@ -21,10 +20,10 @@ import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PatchMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -40,7 +39,7 @@ public class AdminController implements AdminControllerDocs {
     @Override
     @PostMapping("/ticket-vendors")
     public ResponseEntity<BaseResponse<TicketVendorResponse>> createTicketVendor(
-        @RequestBody CreateTicketVendorRequest request
+        @ModelAttribute CreateTicketVendorRequest request
     ) {
         return ApiResponseUtil.success(
             SuccessMessage.CREATED, 
@@ -49,10 +48,10 @@ public class AdminController implements AdminControllerDocs {
     }
 
     @Override
-    @PutMapping("/ticket-vendors/{ticketVendorId}")
+    @PatchMapping("/ticket-vendors/{ticketVendorId}")
     public ResponseEntity<BaseResponse<TicketVendorResponse>> updateTicketVendor(
         @PathVariable Long ticketVendorId,
-        @RequestBody UpdateTicketVendorRequest request
+        @ModelAttribute UpdateTicketVendorRequest request
     ) {
         return ApiResponseUtil.success(
             SuccessMessage.UPDATED, 
@@ -74,7 +73,7 @@ public class AdminController implements AdminControllerDocs {
     public ResponseEntity<BaseResponse<TicketVendorResponses>> getTicketVendors() {
         return ApiResponseUtil.success(
             SuccessMessage.SUCCESS,
-            TicketVendorResponses.from(adminFacade.getTicketVendors())
+            TicketVendorResponses.from(adminFacade.getTicketVendors(), s3FileHandler)
         );
     }
 

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -17,8 +17,11 @@ import org.sopt.confeti.global.common.constant.RequestConstraint;
 import org.sopt.confeti.global.common.swagger.AuthErrorResponses;
 import org.sopt.confeti.global.common.swagger.CommonErrorResponses;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
 
 @Tag(name = "어드민 API", description = "어드민 전용 API")
 public interface AdminControllerDocs {
@@ -34,11 +37,14 @@ public interface AdminControllerDocs {
     )
     @AuthErrorResponses
     @CommonErrorResponses
+    @PostMapping(value = "/ticket-vendors", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<BaseResponse<TicketVendorResponse>> createTicketVendor(
-        @Valid @RequestBody CreateTicketVendorRequest request
+        @ModelAttribute @Valid CreateTicketVendorRequest request
     );
 
-    @Operation(summary = "예매처 수정")
+    @Operation(summary = "예매처 수정 (Patch)",
+        description = "수정을 원하는 필드만 전달하면 해당 부분만 수정을 진행함"
+    )
     @ApiResponses(
         value = {
             @ApiResponse(
@@ -49,9 +55,10 @@ public interface AdminControllerDocs {
     )
     @AuthErrorResponses
     @CommonErrorResponses
+    @PatchMapping(value = "/ticket-vendors/{ticketVendorId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     ResponseEntity<BaseResponse<TicketVendorResponse>> updateTicketVendor(
         @PathVariable Long ticketVendorId,
-        @Valid @RequestBody UpdateTicketVendorRequest request
+        @ModelAttribute @Valid UpdateTicketVendorRequest request
     );
 
     @Operation(summary = "예매처 삭제")

--- a/src/main/java/org/sopt/confeti/api/admin/dto/request/CreateTicketVendorRequest.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/request/CreateTicketVendorRequest.java
@@ -1,9 +1,11 @@
 package org.sopt.confeti.api.admin.dto.request;
 
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.web.multipart.MultipartFile;
 
 public record CreateTicketVendorRequest(
     @NotBlank String name,
-    @NotBlank String logoPath
+    @NotNull MultipartFile logoImage
 ) {
 }

--- a/src/main/java/org/sopt/confeti/api/admin/dto/request/UpdateTicketVendorRequest.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/request/UpdateTicketVendorRequest.java
@@ -1,9 +1,9 @@
 package org.sopt.confeti.api.admin.dto.request;
 
-import jakarta.validation.constraints.NotBlank;
+import org.springframework.web.multipart.MultipartFile;
 
 public record UpdateTicketVendorRequest(
-    @NotBlank String name,
-    @NotBlank String logoPath
+    String name,
+    MultipartFile logoImage
 ) {
 }

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/TicketVendorResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/TicketVendorResponse.java
@@ -1,34 +1,45 @@
 package org.sopt.confeti.api.admin.dto.response;
 
+import org.sopt.confeti.domain.ticketvendor.TicketVendor;
 import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorCreateResponseDto;
 import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorDto;
 import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorUpdateResponseDto;
-import org.sopt.confeti.domain.ticketvendor.TicketVendor;
-import org.sopt.confeti.global.util.S3FileHandler;
 import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.util.S3FileHandler;
 
 public record TicketVendorResponse(
     Long id,
     String name,
     String logoPath
 ) {
+
     public static TicketVendorResponse of(TicketVendor ticketVendor, S3FileHandler s3FileHandler) {
         return new TicketVendorResponse(
             ticketVendor.getId(),
             ticketVendor.getName(),
-            s3FileHandler.getFileSignedUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), ticketVendor.getLogoPath()).toString()
+            s3FileHandler.getFileSignedUrl(
+                FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO),
+                ticketVendor.getLogoPath()).toString()
         );
     }
 
     public static TicketVendorResponse of(TicketVendorDto dto, S3FileHandler s3FileHandler) {
-        return new TicketVendorResponse(dto.id(), dto.name(), s3FileHandler.getFileSignedUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), dto.logoPath()).toString());
+        return new TicketVendorResponse(dto.id(), dto.name(),
+            s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO),
+                dto.logoPath()).toString());
     }
 
-    public static TicketVendorResponse from(TicketVendorCreateResponseDto dto, S3FileHandler s3FileHandler) {
-        return new TicketVendorResponse(dto.id(), dto.name(), s3FileHandler.getFileSignedUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), dto.logoPath()).toString());
+    public static TicketVendorResponse from(TicketVendorCreateResponseDto dto,
+        S3FileHandler s3FileHandler) {
+        return new TicketVendorResponse(dto.id(), dto.name(),
+            s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO),
+                dto.logoPath()).toString());
     }
 
-    public static TicketVendorResponse from(TicketVendorUpdateResponseDto dto, S3FileHandler s3FileHandler) {
-        return new TicketVendorResponse(dto.id(), dto.name(), s3FileHandler.getFileSignedUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), dto.logoPath()).toString());
+    public static TicketVendorResponse from(TicketVendorUpdateResponseDto dto,
+        S3FileHandler s3FileHandler) {
+        return new TicketVendorResponse(dto.id(), dto.name(),
+            s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO),
+                dto.logoPath()).toString());
     }
 }

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/TicketVendorResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/TicketVendorResponse.java
@@ -1,30 +1,34 @@
 package org.sopt.confeti.api.admin.dto.response;
 
+import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorCreateResponseDto;
 import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorDto;
+import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorUpdateResponseDto;
 import org.sopt.confeti.domain.ticketvendor.TicketVendor;
+import org.sopt.confeti.global.util.S3FileHandler;
+import org.sopt.confeti.global.common.constant.FolderPath;
 
 public record TicketVendorResponse(
     Long id,
     String name,
     String logoPath
 ) {
-    public static TicketVendorResponse of(TicketVendor ticketVendor) {
+    public static TicketVendorResponse of(TicketVendor ticketVendor, S3FileHandler s3FileHandler) {
         return new TicketVendorResponse(
             ticketVendor.getId(),
             ticketVendor.getName(),
-            ticketVendor.getLogoPath()
+            s3FileHandler.getFileSignedUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), ticketVendor.getLogoPath()).toString()
         );
     }
 
-    public static TicketVendorResponse of(TicketVendorDto dto) {
-        return new TicketVendorResponse(dto.id(), dto.name(), dto.logoPath());
+    public static TicketVendorResponse of(TicketVendorDto dto, S3FileHandler s3FileHandler) {
+        return new TicketVendorResponse(dto.id(), dto.name(), s3FileHandler.getFileSignedUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), dto.logoPath()).toString());
     }
 
-    public static TicketVendorResponse from(org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorCreateResponseDto dto) {
-        return new TicketVendorResponse(dto.id(), dto.name(), dto.logoPath());
+    public static TicketVendorResponse from(TicketVendorCreateResponseDto dto, S3FileHandler s3FileHandler) {
+        return new TicketVendorResponse(dto.id(), dto.name(), s3FileHandler.getFileSignedUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), dto.logoPath()).toString());
     }
 
-    public static TicketVendorResponse from(org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorUpdateResponseDto dto) {
-        return new TicketVendorResponse(dto.id(), dto.name(), dto.logoPath());
+    public static TicketVendorResponse from(TicketVendorUpdateResponseDto dto, S3FileHandler s3FileHandler) {
+        return new TicketVendorResponse(dto.id(), dto.name(), s3FileHandler.getFileSignedUrl(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), dto.logoPath()).toString());
     }
 }

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/TicketVendorResponses.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/TicketVendorResponses.java
@@ -6,10 +6,10 @@ import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendo
 public record TicketVendorResponses(
     List<TicketVendorResponse> ticketVendors
 ) {
-    public static TicketVendorResponses from(final TicketVendorDtos dtos) {
+    public static TicketVendorResponses from(final TicketVendorDtos dtos, org.sopt.confeti.global.util.S3FileHandler s3FileHandler) {
         return new TicketVendorResponses(
             dtos.ticketVendors().stream()
-                .map(TicketVendorResponse::of)
+                .map(dto -> TicketVendorResponse.of(dto, s3FileHandler))
                 .toList()
         );
     }

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -15,8 +15,10 @@ import org.sopt.confeti.domain.ticketvendor.application.dto.request.TicketVendor
 import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorDtos;
 import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorUpdateResponseDto;
 import org.sopt.confeti.global.annotation.Facade;
+import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.transaction.Tx;
-import org.springframework.transaction.annotation.Transactional;
+import org.sopt.confeti.global.util.S3FileHandler;
+import org.springframework.web.multipart.MultipartFile;
 
 @Facade
 @RequiredArgsConstructor
@@ -25,31 +27,45 @@ public class AdminFacade {
     private final TicketVendorService ticketVendorService;
     private final ConcertService concertService;
     private final FestivalService festivalService;
+    private final S3FileHandler s3FileHandler;
 
-    @Transactional
     public TicketVendorResponse createTicketVendor(CreateTicketVendorRequest request) {
-        TicketVendorCreateDto dto = TicketVendorCreateDto.from(request);
-        TicketVendorCreateResponseDto responseDto = ticketVendorService.create(dto);
+        String logoPath = s3FileHandler.uploadFile(request.logoImage(), FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO));
+        TicketVendorCreateDto dto = TicketVendorCreateDto.from(request, logoPath);
         
-        return TicketVendorResponse.from(responseDto);
+        TicketVendorCreateResponseDto responseDto = Tx.masterTx(() -> ticketVendorService.create(dto));
+        
+        return TicketVendorResponse.from(responseDto, s3FileHandler);
     }
 
-    @Transactional
     public TicketVendorResponse updateTicketVendor(Long ticketVendorId, UpdateTicketVendorRequest request) {
-        TicketVendorUpdateDto dto = TicketVendorUpdateDto.of(ticketVendorId, request);
-        TicketVendorUpdateResponseDto responseDto = ticketVendorService.update(dto);
+        org.sopt.confeti.domain.ticketvendor.TicketVendor existing = Tx.readOnlyTx(() -> ticketVendorService.getById(ticketVendorId));
+        String logoPath = existing.getLogoPath();
+
+        MultipartFile logoImage = request != null ? request.logoImage() : null;
+
+        if (logoImage != null && !logoImage.isEmpty()) {
+            s3FileHandler.deleteFile(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), logoPath);
+            logoPath = s3FileHandler.uploadFile(logoImage, FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO));
+        }
+
+        final String finalLogoPath = logoPath;
+        TicketVendorUpdateResponseDto responseDto = Tx.masterTx(() -> {
+            TicketVendorUpdateDto dto = TicketVendorUpdateDto.of(ticketVendorId, request, finalLogoPath);
+            return ticketVendorService.update(dto);
+        });
         
-        return TicketVendorResponse.from(responseDto);
+        return TicketVendorResponse.from(responseDto, s3FileHandler);
     }
 
-    @Transactional
     public void deleteTicketVendor(Long ticketVendorId) {
-        ticketVendorService.delete(ticketVendorId);
+        org.sopt.confeti.domain.ticketvendor.TicketVendor existing = Tx.readOnlyTx(() -> ticketVendorService.getById(ticketVendorId));
+        s3FileHandler.deleteFile(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), existing.getLogoPath());
+        Tx.masterTx(() -> ticketVendorService.delete(ticketVendorId));
     }
 
-    @Transactional(readOnly = true)
     public TicketVendorDtos getTicketVendors() {
-        return ticketVendorService.findAll();
+        return Tx.readOnlyTx(() -> ticketVendorService.findAll());
     }
 
     public AdminConcertDetailInfo getAdminConcertDetail(long concertId) {

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -10,10 +10,11 @@ import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalDetailInfo;
 import org.sopt.confeti.domain.concert.application.ConcertService;
 import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.ticketvendor.TicketVendor;
 import org.sopt.confeti.domain.ticketvendor.application.TicketVendorService;
 import org.sopt.confeti.domain.ticketvendor.application.dto.request.TicketVendorCreateDto;
-import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorCreateResponseDto;
 import org.sopt.confeti.domain.ticketvendor.application.dto.request.TicketVendorUpdateDto;
+import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorCreateResponseDto;
 import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorDtos;
 import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorUpdateResponseDto;
 import org.sopt.confeti.global.annotation.Facade;
@@ -21,9 +22,8 @@ import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.transaction.Tx;
 import org.sopt.confeti.global.util.S3FileHandler;
-import org.springframework.web.multipart.MultipartFile;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 @Facade
 @RequiredArgsConstructor
@@ -36,28 +36,34 @@ public class AdminFacade {
     private final S3FileHandler s3FileHandler;
 
     public TicketVendorResponse createTicketVendor(CreateTicketVendorRequest request) {
-        String logoPath = s3FileHandler.uploadFile(request.logoImage(), FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO));
+        String logoPath = s3FileHandler.uploadFile(request.logoImage(),
+            FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO));
         TicketVendorCreateDto dto = TicketVendorCreateDto.from(request, logoPath);
 
-        TicketVendorCreateResponseDto responseDto = Tx.masterTx(() -> ticketVendorService.create(dto));
+        TicketVendorCreateResponseDto responseDto = Tx.masterTx(
+            () -> ticketVendorService.create(dto));
 
         return TicketVendorResponse.from(responseDto, s3FileHandler);
     }
 
-    public TicketVendorResponse updateTicketVendor(Long ticketVendorId, UpdateTicketVendorRequest request) {
-        org.sopt.confeti.domain.ticketvendor.TicketVendor existing = Tx.readOnlyTx(() -> ticketVendorService.getById(ticketVendorId));
+    public TicketVendorResponse updateTicketVendor(Long ticketVendorId,
+        UpdateTicketVendorRequest request) {
+        TicketVendor existing = Tx.readOnlyTx(() -> ticketVendorService.getById(ticketVendorId));
         String logoPath = existing.getLogoPath();
 
         MultipartFile logoImage = request != null ? request.logoImage() : null;
 
         if (logoImage != null && !logoImage.isEmpty()) {
-            s3FileHandler.deleteFile(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), logoPath);
-            logoPath = s3FileHandler.uploadFile(logoImage, FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO));
+            s3FileHandler.deleteFile(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO),
+                logoPath);
+            logoPath = s3FileHandler.uploadFile(logoImage,
+                FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO));
         }
 
         final String finalLogoPath = logoPath;
         TicketVendorUpdateResponseDto responseDto = Tx.masterTx(() -> {
-            TicketVendorUpdateDto dto = TicketVendorUpdateDto.of(ticketVendorId, request, finalLogoPath);
+            TicketVendorUpdateDto dto = TicketVendorUpdateDto.of(ticketVendorId, request,
+                finalLogoPath);
             return ticketVendorService.update(dto);
         });
 
@@ -65,8 +71,10 @@ public class AdminFacade {
     }
 
     public void deleteTicketVendor(Long ticketVendorId) {
-        org.sopt.confeti.domain.ticketvendor.TicketVendor existing = Tx.readOnlyTx(() -> ticketVendorService.getById(ticketVendorId));
-        s3FileHandler.deleteFile(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO), existing.getLogoPath());
+        org.sopt.confeti.domain.ticketvendor.TicketVendor existing = Tx.readOnlyTx(
+            () -> ticketVendorService.getById(ticketVendorId));
+        s3FileHandler.deleteFile(FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO),
+            existing.getLogoPath());
         Tx.masterTx(() -> ticketVendorService.delete(ticketVendorId));
     }
 

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/ConcertReservationResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/ConcertReservationResponse.java
@@ -5,17 +5,19 @@ import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.util.S3FileHandler;
 
 public record ConcertReservationResponse(
-        String url,
-        String name,
-        String logoUrl
+    String url,
+    String name,
+    String logoUrl
 ) {
-    public static ConcertReservationResponse of(ConcertReservationDTO reservationDTO, S3FileHandler s3FileHandler) {
+
+    public static ConcertReservationResponse of(ConcertReservationDTO reservationDTO,
+        S3FileHandler s3FileHandler) {
         return new ConcertReservationResponse(
-                reservationDTO.url(),
-                reservationDTO.name(),
-                s3FileHandler.getFileUrl(
-                        FolderPath.combine(FolderPath.CONCERT, FolderPath.RESERVATION, FolderPath.LOGO),
-                        reservationDTO.logoPath()).toString()
+            reservationDTO.url(),
+            reservationDTO.name(),
+            s3FileHandler.getFileUrl(
+                FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO),
+                reservationDTO.logoPath()).toString()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalReservationResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalReservationResponse.java
@@ -5,17 +5,19 @@ import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.util.S3FileHandler;
 
 public record FestivalReservationResponse(
-        String url,
-        String name,
-        String logoUrl
+    String url,
+    String name,
+    String logoUrl
 ) {
-    public static FestivalReservationResponse of(FestivalReservationDTO reservationDTO, S3FileHandler s3FileHandler) {
+
+    public static FestivalReservationResponse of(FestivalReservationDTO reservationDTO,
+        S3FileHandler s3FileHandler) {
         return new FestivalReservationResponse(
-                reservationDTO.url(),
-                reservationDTO.name(),
-                s3FileHandler.getFileUrl(
-                        FolderPath.combine(FolderPath.FESTIVAL, FolderPath.RESERVATION, FolderPath.LOGO),
-                        reservationDTO.logoPath()).toString()
+            reservationDTO.url(),
+            reservationDTO.name(),
+            s3FileHandler.getFileUrl(
+                FolderPath.combine(FolderPath.TICKET_VENDOR, FolderPath.LOGO),
+                reservationDTO.logoPath()).toString()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/ticketvendor/TicketVendor.java
+++ b/src/main/java/org/sopt/confeti/domain/ticketvendor/TicketVendor.java
@@ -69,7 +69,11 @@ public class TicketVendor {
     }
 
     public void update(String name, String logoPath) {
-        this.name = name;
-        this.logoPath = logoPath;
+        if (name != null && !name.isBlank()) {
+            this.name = name;
+        }
+        if (logoPath != null && !logoPath.isBlank()) {
+            this.logoPath = logoPath;
+        }
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/ticketvendor/application/TicketVendorService.java
+++ b/src/main/java/org/sopt/confeti/domain/ticketvendor/application/TicketVendorService.java
@@ -8,6 +8,7 @@ import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendo
 import org.sopt.confeti.domain.ticketvendor.application.dto.request.TicketVendorUpdateDto;
 import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendorUpdateResponseDto;
 import org.sopt.confeti.domain.ticketvendor.infra.repository.TicketVendorRepository;
+import org.sopt.confeti.global.annotation.ReadOnlyTransactional;
 import org.sopt.confeti.global.exception.ConflictException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
@@ -21,6 +22,11 @@ import org.sopt.confeti.domain.ticketvendor.application.dto.response.TicketVendo
 public class TicketVendorService {
 
     private final TicketVendorRepository ticketVendorRepository;
+
+    @Transactional(readOnly = true)
+    public TicketVendor getById(Long id) {
+        return ticketVendorRepository.findById(id).orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+    }
 
     @Transactional
     public TicketVendor getOrCreate(String name, String logoPath) {
@@ -44,12 +50,14 @@ public class TicketVendorService {
         TicketVendor ticketVendor = ticketVendorRepository.findById(dto.ticketVendorId())
             .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
 
-        ticketVendorRepository.findByName(dto.name())
-            .ifPresent(existingVendor -> {
-                if (!existingVendor.getId().equals(dto.ticketVendorId())) {
-                    throw new ConflictException(ErrorMessage.CONFLICT);
-                }
-            });
+        if (dto.name() != null) {
+            ticketVendorRepository.findByName(dto.name())
+                .ifPresent(existingVendor -> {
+                    if (!existingVendor.getId().equals(dto.ticketVendorId())) {
+                        throw new ConflictException(ErrorMessage.CONFLICT);
+                    }
+                });
+        }
 
         ticketVendor.update(dto.name(), dto.logoPath());
         return TicketVendorUpdateResponseDto.of(ticketVendor);
@@ -63,7 +71,7 @@ public class TicketVendorService {
         ticketVendorRepository.delete(ticketVendor);
     }
 
-    @Transactional(readOnly = true)
+    @ReadOnlyTransactional
     public TicketVendorDtos findAll() {
         return TicketVendorDtos.from(
             ticketVendorRepository.findAll().stream()

--- a/src/main/java/org/sopt/confeti/domain/ticketvendor/application/dto/request/TicketVendorCreateDto.java
+++ b/src/main/java/org/sopt/confeti/domain/ticketvendor/application/dto/request/TicketVendorCreateDto.java
@@ -8,8 +8,8 @@ public record TicketVendorCreateDto(
         return new TicketVendorCreateDto(name, logoPath);
     }
 
-    public static TicketVendorCreateDto from(org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest request) {
-        return new TicketVendorCreateDto(request.name(), request.logoPath());
+    public static TicketVendorCreateDto from(org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest request, String logoPath) {
+        return new TicketVendorCreateDto(request.name(), logoPath);
     }
 
     public org.sopt.confeti.domain.ticketvendor.TicketVendor toEntity() {

--- a/src/main/java/org/sopt/confeti/domain/ticketvendor/application/dto/request/TicketVendorUpdateDto.java
+++ b/src/main/java/org/sopt/confeti/domain/ticketvendor/application/dto/request/TicketVendorUpdateDto.java
@@ -1,5 +1,7 @@
 package org.sopt.confeti.domain.ticketvendor.application.dto.request;
 
+import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
+
 public record TicketVendorUpdateDto(
     Long ticketVendorId,
     String name,
@@ -9,7 +11,7 @@ public record TicketVendorUpdateDto(
         return new TicketVendorUpdateDto(ticketVendorId, name, logoPath);
     }
 
-    public static TicketVendorUpdateDto of(Long ticketVendorId, org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest request) {
-        return new TicketVendorUpdateDto(ticketVendorId, request.name(), request.logoPath());
+    public static TicketVendorUpdateDto of(Long ticketVendorId, UpdateTicketVendorRequest request, String logoPath) {
+        return new TicketVendorUpdateDto(ticketVendorId, request != null ? request.name() : null, logoPath);
     }
 }

--- a/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
@@ -5,7 +5,7 @@ import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
 
 public enum FolderPath {
-    FESTIVAL("festival"), CONCERT("concert"), USER("user"),
+    FESTIVAL("festival"), CONCERT("concert"), USER("user"), TICKET_VENDOR("ticket-vendor"),
     LOGO("logo"), POSTER_BG("poster-bg"), POSTER("poster"),
     RESERVATION("reservation"), PROFILE("profile"), DEFAULT("default");
 


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 제가 이전 어드민 작업을 하면서 이미지를 presignedUrl로 미리 생성한 뒤 업로드하는 플로우로 착각했는데, 현재 저희 구조는 파일 자체를 서버로 업로드하는 구조였기 때문에 이 부분을 수정함.
- 파일 업로드 시에는 @RequestPart 를 사용하지 않고 @ModelAttribute 로 단일 DTO내에 파일을 추가하도록 함.
  - 기존에 유저 프로필 업로드 로직에서 @ModelAttribute 를 사용하고 있었기 때문에 클라 작업이 조금 더 용이할 것 같아서..
- S3 내에 ticket-vendor path를 추가했고, 해당 버킷의 이미지를 클라이언트에게 반환하는 구조임.
- 기존 예매처 수정 API를 PUT에서 PATCH로 변경함.
  - 이미지를 url 텍스트로 저장하는 줄 알고 매번 동일한 텍스트를 보내도록 하는게 편할 것 같다고 생각했는데, 매번 이미지 파일 자체를 서버로 전달하는 것이 너무 비효율적이라고 판단함. 
## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
