### PR TITLE
CSERVER-19 PerformanceDraft  도메인 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.admin.controller.docs.AdminControllerDocs;
+import org.sopt.confeti.api.admin.dto.request.CreatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.response.AdminArtistSearchResponses;
@@ -13,6 +14,7 @@ import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertListResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalListResponse;
+import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponses;
 import org.sopt.confeti.api.admin.facade.AdminFacade;
@@ -20,6 +22,7 @@ import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalListInfo;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
 import org.sopt.confeti.global.annotation.Admin;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.common.constant.RequestConstraint;
@@ -85,6 +88,18 @@ public class AdminController implements AdminControllerDocs {
             SuccessMessage.SUCCESS,
             TicketVendorResponses.from(adminFacade.getTicketVendors(), s3FileHandler)
         );
+    }
+
+    @Override
+    @PostMapping("/performances/drafts")
+    public ResponseEntity<BaseResponse<PerformanceDraftResponse>> createPerformanceDraft(
+        @ModelAttribute CreatePerformanceDraftRequest request
+    ) {
+        PerformanceDraftDto performanceDraftDto = adminFacade.createPerformanceDraft(request.toCreateManualDto());
+        return ApiResponseUtil.success(
+            SuccessMessage.CREATED,
+            PerformanceDraftResponse.from(performanceDraftDto, s3FileHandler)
+        );  
     }
 
     @Override

--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -141,6 +141,15 @@ public class AdminController implements AdminControllerDocs {
     }
 
     @Override
+    @DeleteMapping("/performances/drafts/{draftId}")
+    public ResponseEntity<BaseResponse<Void>> deletePerformanceDraft(
+        @PathVariable Long draftId
+    ) {
+        adminFacade.deletePerformanceDraft(draftId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+    }
+
+    @Override
     @GetMapping("/performances/concerts")
     public ResponseEntity<BaseResponse<AdminConcertListResponse>> getAdminConcerts() {
         AdminConcertListInfo concertList = adminFacade.getAdminConcerts();

--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -16,6 +16,7 @@ import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertListResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalListResponse;
+import org.sopt.confeti.api.admin.dto.response.PerformanceDraftDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftListResponses;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
@@ -113,6 +114,17 @@ public class AdminController implements AdminControllerDocs {
             SuccessMessage.CREATED,
             PerformanceDraftResponse.from(performanceDraftDto, s3FileHandler)
         );  
+    }
+
+    @Override
+    @GetMapping("/performances/drafts/{draftId}")
+    public ResponseEntity<BaseResponse<PerformanceDraftDetailResponse>> getPerformanceDraftDetail(
+        @PathVariable Long draftId
+    ) {
+        return ApiResponseUtil.success(
+            SuccessMessage.SUCCESS,
+            PerformanceDraftDetailResponse.from(adminFacade.getPerformanceDraftDetail(draftId), s3FileHandler)
+        );
     }
 
     @Override

--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.api.admin.controller;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
@@ -15,6 +16,7 @@ import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertListResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalListResponse;
+import org.sopt.confeti.api.admin.dto.response.PerformanceDraftListResponses;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponses;
@@ -49,6 +51,7 @@ public class AdminController implements AdminControllerDocs {
 
     private final AdminFacade adminFacade;
     private final S3FileHandler s3FileHandler;
+    private final ObjectMapper objectMapper;
 
     @Override
     @PostMapping("/ticket-vendors")
@@ -88,6 +91,15 @@ public class AdminController implements AdminControllerDocs {
         return ApiResponseUtil.success(
             SuccessMessage.SUCCESS,
             TicketVendorResponses.from(adminFacade.getTicketVendors(), s3FileHandler)
+        );
+    }
+
+    @Override
+    @GetMapping("/performances/drafts")
+    public ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts() {
+        return ApiResponseUtil.success(
+            SuccessMessage.SUCCESS,
+            PerformanceDraftListResponses.from(adminFacade.getPerformanceDrafts(), objectMapper)
         );
     }
 

--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.admin.controller.docs.AdminControllerDocs;
 import org.sopt.confeti.api.admin.dto.request.CreatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
+import org.sopt.confeti.api.admin.dto.request.UpdatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.response.AdminArtistSearchResponses;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
@@ -100,6 +101,19 @@ public class AdminController implements AdminControllerDocs {
             SuccessMessage.CREATED,
             PerformanceDraftResponse.from(performanceDraftDto, s3FileHandler)
         );  
+    }
+
+    @Override
+    @PatchMapping("/performances/drafts/{draftId}")
+    public ResponseEntity<BaseResponse<PerformanceDraftResponse>> updatePerformanceDraft(
+        @PathVariable Long draftId,
+        @ModelAttribute UpdatePerformanceDraftRequest request
+    ) {
+        PerformanceDraftDto performanceDraftDto = adminFacade.updatePerformanceDraft(request.toUpdateDto(draftId));
+        return ApiResponseUtil.success(
+            SuccessMessage.UPDATED,
+            PerformanceDraftResponse.from(performanceDraftDto, s3FileHandler)
+        );
     }
 
     @Override

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -105,7 +105,11 @@ public interface AdminControllerDocs {
     ResponseEntity<BaseResponse<TicketVendorResponses>> getTicketVendors();
 
 
-    @Operation(summary = "대기 공연 목록 조회")
+    @Operation(summary = "대기 공연 목록 조회", description = 
+    """
+    크롤링한 데이터의 경우 status가 "검토 필요" 반환되고,  
+    수동 등록한 데이터의 경우 status가 "보류"로 반환됩니다. (현재 수동 등록의 경우 콘서트, 페스티벌 수정/저장 API를 사용하므로 해당 케이스는 존재하지 않습니다.)
+            """;)
     @ApiResponses(
         value = {
             @ApiResponse(
@@ -118,7 +122,9 @@ public interface AdminControllerDocs {
     @CommonErrorResponses
     ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts();
 
-    @Operation(summary = "대기 공연 등록")
+    @Deprecated
+    @Operation(summary = "대기 공연 등록",
+        description = "현재 해당 API를 사용하지 않습니다. 공연 수동 등록 시 페스티벌, 콘서트 각각의 수정/저장 API를 사용해야합니다. ")
     @ApiResponses(
         value = {
             @ApiResponse(
@@ -133,7 +139,113 @@ public interface AdminControllerDocs {
         @ModelAttribute @Valid CreatePerformanceDraftRequest request
     );
 
-    @Operation(summary = "대기 공연 상세 조회")
+    @Operation(summary = "대기 공연 상세 조회",
+        description = """
+        performanceData 는 아래와 같습니다. 
+        festival인 경우
+{
+  "title": "2026 서울재즈페스티벌",
+  "subtitle": "Seoul Jazz Festival",
+  "startAt": "2026-05-22T00:00:00",
+  "endAt": "2026-05-24T23:59:59",
+  "area": "SEOUL",
+  "reserveAt": "2026-03-20T12:00:00",
+  "ageRating": "전체 관람가",
+  "time": "12:00 ~ 22:00",
+  "price": "200000",
+  "address": "올림픽 공원",
+  "timetableSupportStatus": "SUPPORTED",
+  "reservationUrls": [
+    {
+      "name": "멜론 티켓",
+      "url": "https://ticket.melon.com/performance/12345"
+    },
+    {
+      "name": "인터파크 티켓",
+      "url": "https://tickets.interpark.com/goods/12345"
+    }
+  ],
+  "dates": [
+    {
+      "festivalAt": "2026-05-22",
+      "openAt": "11:00:00",
+      "dailyArtists": [
+        {
+          "artistId": "1163087245"
+        },
+        {
+          "artistId": "1188975595"
+        }
+      ],
+      "stages": [
+        {
+          "name": "May Forest Stage",
+          "order": 1,
+          "times": [
+            {
+              "startAt": "13:00:00",
+              "endAt": "14:00:00",
+              "artistId": "1163087245"
+            },
+            {
+              "startAt": "14:30:00",
+              "endAt": "15:30:00",
+              "artistId": "1188975595"
+            }
+          ]
+        },
+        {
+          "name": "Sparkling Dome",
+          "order": 2,
+          "times": []
+        }
+      ]
+    },
+    {
+      "festivalAt": "2026-05-23",
+      "openAt": "11:00:00",
+      "dailyArtists": [
+        {
+          "artistId": "1203816887"
+        },
+        {
+          "artistId": "1214153999"
+        }
+      ],
+      "stages": [] 
+    }
+  ]
+}
+
+콘서트인 경우
+
+{
+  "title": "2026 카더가든 콘서트",
+  "subtitle": "The Golden Hour",
+  "startAt": "2026-04-01T18:00:00",
+  "endAt": "2026-04-01T20:30:00",
+  "area": "서울",
+  "reserveAt": "2026-03-15T20:00:00",
+  "ageRating": "만 7세 이상",
+  "time": "150분",
+  "price": "150000",
+  "address": "올림픽 주경기장",
+  "artists": [
+    {
+      "artistId": "1020577647"
+    }
+  ],
+  "reservationUrls": [
+    {
+      "name": "인터파크 티켓",
+      "reservationUrl": "https://ticket.interpark.com"
+    }
+  ]
+}
+
+
+"""
+    )
     @ApiResponses(
         value = {
             @ApiResponse(
@@ -148,8 +260,12 @@ public interface AdminControllerDocs {
         @PathVariable Long draftId
     );
 
+    @Deprecated
     @Operation(summary = "대기 공연 수정",
-        description = "수정을 원하는 필드만 전달하면 해당 부분만 수정됩니다. 이미지는 선택적으로 교체할 수 있습니다."
+        description = """
+        현재 해당 API를 사용하지 않습니다. 대기 공연 수정은 현재 요구사항에서 지원되지 않습니다.
+        수정을 원하는 필드만 전달하면 해당 부분만 수정됩니다. 이미지는 선택적으로 교체할 수 있습니다.
+        """
     )
     @ApiResponses(
         value = {

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -167,6 +167,21 @@ public interface AdminControllerDocs {
         @ModelAttribute UpdatePerformanceDraftRequest request
     );
 
+    @Operation(summary = "대기 공연 삭제")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<Void>> deletePerformanceDraft(
+        @PathVariable Long draftId
+    );
+
     @Operation(
         summary = "등록된 콘서트 목록 조회",
         description = "어드민 권한으로 등록된 모든 콘서트 목록을 조회합니다. "

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -19,6 +19,7 @@ import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertListResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalListResponse;
+import org.sopt.confeti.api.admin.dto.response.PerformanceDraftDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftListResponses;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
@@ -130,6 +131,21 @@ public interface AdminControllerDocs {
     @CommonErrorResponses
     public ResponseEntity<BaseResponse<PerformanceDraftResponse>> createPerformanceDraft(
         @ModelAttribute @Valid CreatePerformanceDraftRequest request
+    );
+
+    @Operation(summary = "대기 공연 상세 조회")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<PerformanceDraftDetailResponse>> getPerformanceDraftDetail(
+        @PathVariable Long draftId
     );
 
     @Operation(summary = "대기 공연 수정",

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -9,6 +9,8 @@ import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.Size;
+
+import org.sopt.confeti.api.admin.dto.request.CreatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.response.AdminArtistSearchResponses;
@@ -16,8 +18,10 @@ import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertListResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalListResponse;
+import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponses;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
 import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.common.constant.RequestConstraint;
 import org.sopt.confeti.global.common.swagger.AuthErrorResponses;
@@ -96,6 +100,22 @@ public interface AdminControllerDocs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<TicketVendorResponses>> getTicketVendors();
+
+
+    @Operation(summary = "대기 공연 등록")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "201",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    public ResponseEntity<BaseResponse<PerformanceDraftResponse>> createPerformanceDraft(
+        @ModelAttribute @Valid CreatePerformanceDraftRequest request
+    );
 
     @Operation(
         summary = "등록된 콘서트 목록 조회",

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -19,6 +19,7 @@ import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertListResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.AdminFestivalListResponse;
+import org.sopt.confeti.api.admin.dto.response.PerformanceDraftListResponses;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponses;
@@ -102,6 +103,19 @@ public interface AdminControllerDocs {
     @CommonErrorResponses
     ResponseEntity<BaseResponse<TicketVendorResponses>> getTicketVendors();
 
+
+    @Operation(summary = "대기 공연 목록 조회")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts();
 
     @Operation(summary = "대기 공연 등록")
     @ApiResponses(

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -12,6 +12,7 @@ import jakarta.validation.constraints.Size;
 
 import org.sopt.confeti.api.admin.dto.request.CreatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
+import org.sopt.confeti.api.admin.dto.request.UpdatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.response.AdminArtistSearchResponses;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
@@ -115,6 +116,25 @@ public interface AdminControllerDocs {
     @CommonErrorResponses
     public ResponseEntity<BaseResponse<PerformanceDraftResponse>> createPerformanceDraft(
         @ModelAttribute @Valid CreatePerformanceDraftRequest request
+    );
+
+    @Operation(summary = "대기 공연 수정",
+        description = "수정을 원하는 필드만 전달하면 해당 부분만 수정됩니다. 이미지는 선택적으로 교체할 수 있습니다."
+    )
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    @PatchMapping(value = "/performances/drafts/{draftId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    ResponseEntity<BaseResponse<PerformanceDraftResponse>> updatePerformanceDraft(
+        @PathVariable Long draftId,
+        @ModelAttribute UpdatePerformanceDraftRequest request
     );
 
     @Operation(

--- a/src/main/java/org/sopt/confeti/api/admin/dto/request/CreatePerformanceDraftRequest.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/request/CreatePerformanceDraftRequest.java
@@ -1,0 +1,33 @@
+package org.sopt.confeti.api.admin.dto.request;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.util.Optional;
+
+import org.sopt.confeti.domain.performancedraft.DraftStatus;
+import org.sopt.confeti.domain.performancedraft.PerformanceType;
+import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
+import org.sopt.confeti.global.common.upload.MultipartFileAdapter;
+import org.springframework.web.multipart.MultipartFile;
+
+public record CreatePerformanceDraftRequest(
+    @NotNull
+    PerformanceType performanceType,
+    @NotBlank
+    String performanceData,
+    @NotNull
+    MultipartFile posterImage,
+    MultipartFile logoImage
+) {
+
+    public PerformanceDraftCreateDto toCreateManualDto() {
+        MultipartFileAdapter posterAdapter = new MultipartFileAdapter(posterImage);
+        MultipartFileAdapter logoAdapter = Optional.ofNullable(logoImage)
+            .map(MultipartFileAdapter::new)
+            .orElse(null);
+        return PerformanceDraftCreateDto.of(
+                performanceType, performanceData, DraftStatus.HOLD, posterAdapter, logoAdapter);
+    }
+
+}

--- a/src/main/java/org/sopt/confeti/api/admin/dto/request/UpdatePerformanceDraftRequest.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/request/UpdatePerformanceDraftRequest.java
@@ -1,0 +1,28 @@
+package org.sopt.confeti.api.admin.dto.request;
+
+import java.util.Optional;
+import org.sopt.confeti.domain.performancedraft.DraftStatus;
+import org.sopt.confeti.domain.performancedraft.PerformanceType;
+import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
+import org.sopt.confeti.global.common.upload.MultipartFileAdapter;
+import org.springframework.web.multipart.MultipartFile;
+
+public record UpdatePerformanceDraftRequest(
+    PerformanceType performanceType,
+    DraftStatus status,
+    String performanceData,
+    MultipartFile posterImage,
+    MultipartFile logoImage
+) {
+    public PerformanceDraftUpdateDto toUpdateDto(Long id) {
+        MultipartFileAdapter posterAdapter = Optional.ofNullable(posterImage)
+            .filter(f -> !f.isEmpty())
+            .map(MultipartFileAdapter::new)
+            .orElse(null);
+        MultipartFileAdapter logoAdapter = Optional.ofNullable(logoImage)
+            .filter(f -> !f.isEmpty())
+            .map(MultipartFileAdapter::new)
+            .orElse(null);
+        return PerformanceDraftUpdateDto.of(id, performanceType, status, performanceData, posterAdapter, logoAdapter);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftDetailResponse.java
@@ -1,0 +1,54 @@
+package org.sopt.confeti.api.admin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import java.util.List;
+import java.util.Optional;
+import org.sopt.confeti.api.admin.facade.dto.response.PerformanceDraftDetailInfo;
+import org.sopt.confeti.domain.performancedraft.DraftStatus;
+import org.sopt.confeti.domain.performancedraft.PerformanceType;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+public record PerformanceDraftDetailResponse(
+        Long id,
+        PerformanceType performanceType,
+        DraftStatus status,
+        @JsonRawValue
+        String performanceData,
+        String posterUrl,
+        String logoUrl,
+        List<ArtistResponse> artists
+) {
+    public record ArtistResponse(
+            String artistId,
+            String name,
+            String profileUrl
+    ) {
+        public static ArtistResponse from(ConfetiArtist artist) {
+            return new ArtistResponse(
+                    artist.getId(),
+                    artist.getName(),
+                    artist.getProfileUrl()
+            );
+        }
+    }
+
+    public static PerformanceDraftDetailResponse from(PerformanceDraftDetailInfo info, S3FileHandler s3FileHandler) {
+        return new PerformanceDraftDetailResponse(
+                info.draft().id(),
+                info.draft().performanceType(),
+                info.draft().status(),
+                info.draft().performanceData(),
+                Optional.ofNullable(info.draft().posterPath())
+                        .map(path -> s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path).toString())
+                        .orElse(null),
+                Optional.ofNullable(info.draft().logoPath())
+                        .map(path -> s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path).toString())
+                        .orElse(null),
+                info.artists().stream()
+                        .map(ArtistResponse::from)
+                        .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftDetailResponse.java
@@ -40,10 +40,10 @@ public record PerformanceDraftDetailResponse(
                 info.draft().performanceType(),
                 info.draft().status(),
                 info.draft().performanceData(),
-                Optional.ofNullable(info.draft().posterPath())
+                Optional.ofNullable(info.draft().posterUrl())
                         .map(path -> s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path).toString())
                         .orElse(null),
-                Optional.ofNullable(info.draft().logoPath())
+                Optional.ofNullable(info.draft().logoUrl())
                         .map(path -> s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path).toString())
                         .orElse(null),
                 info.artists().stream()

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftDetailResponse.java
@@ -37,7 +37,7 @@ public record PerformanceDraftDetailResponse(
     public static PerformanceDraftDetailResponse from(PerformanceDraftDetailInfo info, S3FileHandler s3FileHandler) {
         return new PerformanceDraftDetailResponse(
                 info.draft().id(),
-                info.draft().performanceType(),
+                info.draft().performanceDraftType(),
                 info.draft().status(),
                 info.draft().performanceData(),
                 Optional.ofNullable(info.draft().posterUrl())

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponse.java
@@ -31,7 +31,7 @@ public record PerformanceDraftListResponse(
 
         return new PerformanceDraftListResponse(
                 dto.id(),
-                dto.performanceType(),
+                dto.performanceDraftType(),
                 dto.status(),
                 title,
                 area,

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponse.java
@@ -1,0 +1,42 @@
+package org.sopt.confeti.api.admin.dto.response;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.sopt.confeti.domain.performancedraft.DraftStatus;
+import org.sopt.confeti.domain.performancedraft.PerformanceType;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
+
+public record PerformanceDraftListResponse(
+        Long id,
+        PerformanceType performanceType,
+        DraftStatus status,
+        String title,
+        String area,
+        String startAt
+) {
+    public static PerformanceDraftListResponse from(PerformanceDraftDto dto, ObjectMapper objectMapper) {
+        String title = null;
+        String area = null;
+        String startAt = null;
+
+        try {
+            JsonNode rootNode = objectMapper.readTree(dto.performanceData());
+            title = rootNode.hasNonNull("title") ? rootNode.get("title").asText() : null;
+            area = rootNode.hasNonNull("area") ? rootNode.get("area").asText() : null;
+            startAt = rootNode.hasNonNull("startAt") ? rootNode.get("startAt").asText() : null;
+        } catch (JsonProcessingException e) {
+            // 파싱 실패 시 기본값 null
+        }
+
+        return new PerformanceDraftListResponse(
+                dto.id(),
+                dto.performanceType(),
+                dto.status(),
+                title,
+                area,
+                startAt
+        );
+    }
+}
+

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponses.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponses.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.admin.dto.response;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDtos;
+
+import java.util.List;
+
+public record PerformanceDraftListResponses(
+        List<PerformanceDraftListResponse> drafts
+) {
+    public static PerformanceDraftListResponses from(PerformanceDraftDtos dtos, ObjectMapper objectMapper) {
+        List<PerformanceDraftListResponse> responses = dtos.drafts().stream()
+                .map(dto -> PerformanceDraftListResponse.from(dto, objectMapper))
+                .toList();
+        return new PerformanceDraftListResponses(responses);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftResponse.java
@@ -1,0 +1,40 @@
+package org.sopt.confeti.api.admin.dto.response;
+
+import com.fasterxml.jackson.annotation.JsonRawValue;
+import org.sopt.confeti.domain.performancedraft.DraftStatus;
+import org.sopt.confeti.domain.performancedraft.PerformanceType;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.util.S3FileHandler;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+public record PerformanceDraftResponse(
+        Long id,
+        PerformanceType performanceType,
+        DraftStatus status,
+        @JsonRawValue
+        String performanceData,
+        String posterPath,
+        String logoPath,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PerformanceDraftResponse from(PerformanceDraftDto dto, S3FileHandler s3FileHandler) {
+        return new PerformanceDraftResponse(
+                dto.id(),
+                dto.performanceType(),
+                dto.status(),
+                dto.performanceData(),
+                Optional.ofNullable(dto.posterPath())
+                    .map(path -> s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path).toString())
+                    .orElse(null),
+                Optional.ofNullable(dto.logoPath())
+                    .map(path -> s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path).toString())
+                    .orElse(null),
+                dto.createdAt(),
+                dto.updatedAt()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftResponse.java
@@ -16,8 +16,8 @@ public record PerformanceDraftResponse(
         DraftStatus status,
         @JsonRawValue
         String performanceData,
-        String posterPath,
-        String logoPath,
+        String posterUrl,
+        String logoUrl,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {
@@ -27,10 +27,10 @@ public record PerformanceDraftResponse(
                 dto.performanceType(),
                 dto.status(),
                 dto.performanceData(),
-                Optional.ofNullable(dto.posterPath())
+                Optional.ofNullable(dto.posterUrl())
                     .map(path -> s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path).toString())
                     .orElse(null),
-                Optional.ofNullable(dto.logoPath())
+                Optional.ofNullable(dto.logoUrl())
                     .map(path -> s3FileHandler.getFileUrl(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path).toString())
                     .orElse(null),
                 dto.createdAt(),

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftResponse.java
@@ -24,7 +24,7 @@ public record PerformanceDraftResponse(
     public static PerformanceDraftResponse from(PerformanceDraftDto dto, S3FileHandler s3FileHandler) {
         return new PerformanceDraftResponse(
                 dto.id(),
-                dto.performanceType(),
+                dto.performanceDraftType(),
                 dto.status(),
                 dto.performanceData(),
                 Optional.ofNullable(dto.posterUrl())

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -9,7 +9,6 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.response.AdminArtistSearchResponses;
-import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo;
@@ -25,6 +24,7 @@ import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftServ
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDtos;
 import org.sopt.confeti.domain.ticketvendor.TicketVendor;
 import org.sopt.confeti.domain.ticketvendor.application.TicketVendorService;
 import org.sopt.confeti.domain.ticketvendor.application.dto.request.TicketVendorCreateDto;
@@ -159,6 +159,10 @@ public class AdminFacade {
             .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
             .orElse(null);
         return performanceDraftService.createDraft(dto, posterPath, logoPath);
+    }
+
+    public PerformanceDraftDtos getPerformanceDrafts() {
+        return Tx.readOnlyTx(performanceDraftService::findAllDrafts);
     }
 
     public PerformanceDraftDto updatePerformanceDraft(PerformanceDraftUpdateDto dto) {

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -189,7 +189,7 @@ public class AdminFacade {
     }
 
     public PerformanceDraftDtos getPerformanceDrafts() {
-        return Tx.readOnlyTx(performanceDraftService::findAllDrafts);
+        return Tx.readOnlyTx(performanceDraftService::getAllDrafts);
     }
 
     public void deletePerformanceDraft(Long draftId) {

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -23,6 +23,7 @@ import org.sopt.confeti.domain.festival.application.FestivalService;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
 import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftService;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
+import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
 import org.sopt.confeti.domain.ticketvendor.TicketVendor;
 import org.sopt.confeti.domain.ticketvendor.application.TicketVendorService;
@@ -158,6 +159,30 @@ public class AdminFacade {
             .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
             .orElse(null);
         return performanceDraftService.createDraft(dto, posterPath, logoPath);
+    }
+
+    public PerformanceDraftDto updatePerformanceDraft(PerformanceDraftUpdateDto dto) {
+        PerformanceDraft existing = Tx.readOnlyTx(() -> performanceDraftService.getById(dto.id()));
+
+        String posterPath = dto.getOptionalPosterImage()
+            .map(image -> {
+                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), existing.getPosterPath());
+                return s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER));
+            })
+            .orElseGet(existing::getPosterPath);
+
+        String logoPath = dto.getOptionalLogoImage()
+            .map(image -> {
+                if (existing.getLogoPath() != null) {
+                    s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), existing.getLogoPath());
+                }
+                return s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO));
+            })
+            .orElseGet(existing::getLogoPath);
+
+        final String finalPosterPath = posterPath;
+        final String finalLogoPath = logoPath;
+        return Tx.masterTx(() -> performanceDraftService.updateDraft(dto, finalPosterPath, finalLogoPath));
     }
 
 }

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -243,17 +243,19 @@ public class AdminFacade {
 
         String posterPath = dto.getOptionalPosterImage()
             .map(image -> {
+                String newPath = s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER));
                 s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), existing.getPosterPath());
-                return s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER));
+                return newPath;
             })
             .orElseGet(existing::getPosterPath);
 
         String logoPath = dto.getOptionalLogoImage()
             .map(image -> {
+                String newPath = s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO));
                 if (existing.getLogoPath() != null) {
                     s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), existing.getLogoPath());
                 }
-                return s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO));
+                return newPath;
             })
             .orElseGet(existing::getLogoPath);
 

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -1,9 +1,15 @@
 package org.sopt.confeti.api.admin.facade;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
@@ -14,12 +20,16 @@ import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo.ConcertInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalDetailInfo;
-import org.sopt.confeti.domain.concert.application.dto.ConcertPreviewInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalPreviewInfo;
+import org.sopt.confeti.api.admin.facade.dto.response.PerformanceDraftDetailInfo;
 import org.sopt.confeti.domain.concert.application.ConcertService;
+import org.sopt.confeti.domain.concert.application.dto.ConcertPreviewInfo;
 import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.music.artist.Artist;
+import org.sopt.confeti.domain.music.artist.application.ArtistService;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
+import org.sopt.confeti.domain.performancedraft.PerformanceType;
 import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftService;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
@@ -50,6 +60,8 @@ public class AdminFacade {
     private final MusicAPIHandler musicAPIHandler;
     private final S3FileHandler s3FileHandler;
     private final PerformanceDraftService performanceDraftService;
+    private final ArtistService artistService;
+    private final ObjectMapper objectMapper;
 
     public TicketVendorResponse createTicketVendor(CreateTicketVendorRequest request) {
         String logoPath = s3FileHandler.uploadFile(request.logoImage(),
@@ -164,6 +176,43 @@ public class AdminFacade {
     public PerformanceDraftDtos getPerformanceDrafts() {
         return Tx.readOnlyTx(performanceDraftService::findAllDrafts);
     }
+
+    public PerformanceDraftDetailInfo getPerformanceDraftDetail(Long draftId) {
+        PerformanceDraft draft = Tx.readOnlyTx(() -> performanceDraftService.getById(draftId));
+        PerformanceDraftDto dto = PerformanceDraftDto.from(draft);
+
+        Set<String> artistIds = extractArtistIds(dto);
+        List<ConfetiArtist> artists = Tx.readOnlyTx(() -> artistService.getArtists(artistIds))
+                .stream()
+                .map(Artist::toDomain)
+                .toList();
+
+        return new PerformanceDraftDetailInfo(dto, artists);
+    }
+
+    private Set<String> extractArtistIds(PerformanceDraftDto dto) {
+        Set<String> artistIds = new HashSet<>();
+        try {
+            JsonNode root = objectMapper.readTree(dto.performanceData());
+            if (dto.performanceType() == PerformanceType.CONCERT) {
+                Optional.ofNullable(root.get("artists")).ifPresent(arr ->
+                    arr.forEach(item -> Optional.ofNullable(item.get("artistId"))
+                        .ifPresent(node -> artistIds.add(node.asText())))
+                );
+            } else {
+                Optional.ofNullable(root.get("dates")).ifPresent(dates ->
+                    dates.forEach(date -> Optional.ofNullable(date.get("dailyArtists")).ifPresent(daily ->
+                        daily.forEach(item -> Optional.ofNullable(item.get("artistId"))
+                            .ifPresent(node -> artistIds.add(node.asText())))
+                    ))
+                );
+            }
+        } catch (JsonProcessingException e) {
+            // 파싱 실패 시 빈 Set 반환
+        }
+        return artistIds;
+    }
+
 
     public PerformanceDraftDto updatePerformanceDraft(PerformanceDraftUpdateDto dto) {
         PerformanceDraft existing = Tx.readOnlyTx(() -> performanceDraftService.getById(dto.id()));

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -1,6 +1,6 @@
 package org.sopt.confeti.api.admin.facade;
 
-
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -59,9 +59,9 @@ import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.transaction.Tx;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.sopt.confeti.global.event.S3FileDeleteEvent;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.multipart.MultipartFile;
-
-import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Slf4j
 @Facade
@@ -76,6 +76,7 @@ public class AdminFacade {
     private final PerformanceDraftService performanceDraftService;
     private final ArtistService artistService;
     private final PerformanceService performanceService;
+    private final ApplicationEventPublisher eventPublisher;
     private final ObjectMapper objectMapper;
 
     public TicketVendorResponse createTicketVendor(CreateTicketVendorRequest request) {
@@ -230,9 +231,6 @@ public class AdminFacade {
         return new PerformanceDraftDetailInfo(dto, artists);
     }
 
-
-
-
     public PerformanceDraftDto updatePerformanceDraft(PerformanceDraftUpdateDto dto) {
         PerformanceDraft existing = Tx.readOnlyTx(() -> performanceDraftService.getById(dto.id()));
 
@@ -247,31 +245,41 @@ public class AdminFacade {
                 .orElse(null);
         } catch (Exception e) {
             log.warn("AdminFacade.updatePerformanceDraft : logo 업로드에 실패해 업로드했던 poster 파일을 롤백합니다. newPosterPath : {}", newPosterPath);
-            Optional.ofNullable(newPosterPath)
-                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path));
+            if (newPosterPath != null) {
+                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), newPosterPath);
+            }
             throw e;
         }
 
         final String finalPosterPath = newPosterPath != null ? newPosterPath : existing.getPosterPath();
         final String finalLogoPath = newLogoPath != null ? newLogoPath : existing.getLogoPath();
-        final String capturedNewPosterPath = newPosterPath;
-        final String capturedNewLogoPath = newLogoPath;
 
+        PerformanceDraftDto result;
         try {
-            PerformanceDraftDto result = Tx.masterTx(() -> performanceDraftService.updateDraft(dto, finalPosterPath, finalLogoPath));
-            Optional.ofNullable(capturedNewPosterPath)
-                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), existing.getPosterPath()));
-            Optional.ofNullable(capturedNewLogoPath)
-                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), existing.getLogoPath()));
-            return result;
+            result = Tx.masterTx(() -> performanceDraftService.updateDraft(dto, finalPosterPath, finalLogoPath));
         } catch (Exception e) {
-            log.warn("AdminFacade.updatePerformanceDraft : 공연 초안 수정에 실패해 업로드했던 이미지 파일을 롤백합니다. newPosterPath : {}, newLogoPath : {}", capturedNewPosterPath, capturedNewLogoPath);
-            Optional.ofNullable(capturedNewPosterPath)
-                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path));
-            Optional.ofNullable(capturedNewLogoPath)
-                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path));
+            log.warn("AdminFacade.updatePerformanceDraft : 공연 초안 수정(DB)에 실패해 업로드했던 새 이미지 파일을 롤백합니다.");
+            if (newPosterPath != null) {
+                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), newPosterPath);
+            }
+            if (newLogoPath != null) {
+                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), newLogoPath);
+            }
             throw e;
         }
+
+        Optional.ofNullable(newPosterPath)
+            .filter(path -> existing.getPosterPath() != null)
+            .ifPresent(path -> eventPublisher.publishEvent(
+                new S3FileDeleteEvent(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), existing.getPosterPath())
+            ));
+        Optional.ofNullable(newLogoPath)
+            .filter(path -> existing.getLogoPath() != null)
+            .ifPresent(path -> eventPublisher.publishEvent(
+                new S3FileDeleteEvent(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), existing.getLogoPath())
+            ));
+
+        return result;
     }
 
     public PutAdminConcertResponse upsertConcert(MultipartFile poster,

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -32,6 +32,7 @@ import org.sopt.confeti.domain.music.artist.Artist;
 import org.sopt.confeti.domain.music.artist.application.ArtistService;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraftType;
+import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftParser;
 import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftService;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
@@ -77,7 +78,7 @@ public class AdminFacade {
     private final ArtistService artistService;
     private final PerformanceService performanceService;
     private final ApplicationEventPublisher eventPublisher;
-    private final ObjectMapper objectMapper;
+    private final PerformanceDraftParser performanceDraftParser;
 
     public TicketVendorResponse createTicketVendor(CreateTicketVendorRequest request) {
         String logoPath = s3FileHandler.uploadFile(request.logoImage(),
@@ -222,7 +223,7 @@ public class AdminFacade {
         PerformanceDraft draft = Tx.readOnlyTx(() -> performanceDraftService.getById(draftId));
         PerformanceDraftDto dto = PerformanceDraftDto.from(draft);
 
-        Set<String> artistIds = dto.getArtistIds(objectMapper);
+        Set<String> artistIds = performanceDraftParser.parseArtistIds(dto.performanceDraftType(), dto.performanceData());
         List<ConfetiArtist> artists = Tx.readOnlyTx(() -> artistService.getArtists(artistIds))
                 .stream()
                 .map(Artist::toDomain)

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -185,7 +185,16 @@ public class AdminFacade {
         String logoPath = dto.getOptionalLogoImage()
             .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
             .orElse(null);
-        return performanceDraftService.createDraft(dto, posterPath, logoPath);
+
+        try {
+            return performanceDraftService.createDraft(dto, posterPath, logoPath);
+        } catch (Exception e) {
+            log.warn("AdminFacade.createPerformanceDraft : 공연 초안 생성에 실패해 업로드했던 이미지 파일을 롤백합니다. posterPath : {}, logoPath : {}", posterPath, logoPath);
+            s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), posterPath);
+            Optional.ofNullable(logoPath)
+                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path));
+            throw e;
+        }
     }
 
     public PerformanceDraftDtos getPerformanceDrafts() {
@@ -241,27 +250,42 @@ public class AdminFacade {
     public PerformanceDraftDto updatePerformanceDraft(PerformanceDraftUpdateDto dto) {
         PerformanceDraft existing = Tx.readOnlyTx(() -> performanceDraftService.getById(dto.id()));
 
-        String posterPath = dto.getOptionalPosterImage()
-            .map(image -> {
-                String newPath = s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER));
-                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), existing.getPosterPath());
-                return newPath;
-            })
-            .orElseGet(existing::getPosterPath);
+        String newPosterPath = dto.getOptionalPosterImage()
+            .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER)))
+            .orElse(null);
 
-        String logoPath = dto.getOptionalLogoImage()
-            .map(image -> {
-                String newPath = s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO));
-                if (existing.getLogoPath() != null) {
-                    s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), existing.getLogoPath());
-                }
-                return newPath;
-            })
-            .orElseGet(existing::getLogoPath);
+        String newLogoPath = null;
+        try {
+            newLogoPath = dto.getOptionalLogoImage()
+                .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
+                .orElse(null);
+        } catch (Exception e) {
+            log.warn("AdminFacade.updatePerformanceDraft : logo 업로드에 실패해 업로드했던 poster 파일을 롤백합니다. newPosterPath : {}", newPosterPath);
+            Optional.ofNullable(newPosterPath)
+                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path));
+            throw e;
+        }
 
-        final String finalPosterPath = posterPath;
-        final String finalLogoPath = logoPath;
-        return Tx.masterTx(() -> performanceDraftService.updateDraft(dto, finalPosterPath, finalLogoPath));
+        final String finalPosterPath = newPosterPath != null ? newPosterPath : existing.getPosterPath();
+        final String finalLogoPath = newLogoPath != null ? newLogoPath : existing.getLogoPath();
+        final String capturedNewPosterPath = newPosterPath;
+        final String capturedNewLogoPath = newLogoPath;
+
+        try {
+            PerformanceDraftDto result = Tx.masterTx(() -> performanceDraftService.updateDraft(dto, finalPosterPath, finalLogoPath));
+            Optional.ofNullable(capturedNewPosterPath)
+                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), existing.getPosterPath()));
+            Optional.ofNullable(capturedNewLogoPath)
+                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), existing.getLogoPath()));
+            return result;
+        } catch (Exception e) {
+            log.warn("AdminFacade.updatePerformanceDraft : 공연 초안 수정에 실패해 업로드했던 이미지 파일을 롤백합니다. newPosterPath : {}, newLogoPath : {}", capturedNewPosterPath, capturedNewLogoPath);
+            Optional.ofNullable(capturedNewPosterPath)
+                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path));
+            Optional.ofNullable(capturedNewLogoPath)
+                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path));
+            throw e;
+        }
     }
 
     public PutAdminConcertResponse upsertConcert(MultipartFile poster,

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -1,8 +1,6 @@
 package org.sopt.confeti.api.admin.facade;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+
 import java.time.LocalDate;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -63,6 +61,8 @@ import org.sopt.confeti.global.util.S3FileHandler;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.web.multipart.MultipartFile;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+
 @Slf4j
 @Facade
 @RequiredArgsConstructor
@@ -75,8 +75,8 @@ public class AdminFacade {
     private final S3FileHandler s3FileHandler;
     private final PerformanceDraftService performanceDraftService;
     private final ArtistService artistService;
-    private final ObjectMapper objectMapper;
     private final PerformanceService performanceService;
+    private final ObjectMapper objectMapper;
 
     public TicketVendorResponse createTicketVendor(CreateTicketVendorRequest request) {
         String logoPath = s3FileHandler.uploadFile(request.logoImage(),
@@ -221,7 +221,7 @@ public class AdminFacade {
         PerformanceDraft draft = Tx.readOnlyTx(() -> performanceDraftService.getById(draftId));
         PerformanceDraftDto dto = PerformanceDraftDto.from(draft);
 
-        Set<String> artistIds = extractArtistIds(dto);
+        Set<String> artistIds = dto.getArtistIds(objectMapper);
         List<ConfetiArtist> artists = Tx.readOnlyTx(() -> artistService.getArtists(artistIds))
                 .stream()
                 .map(Artist::toDomain)
@@ -230,28 +230,7 @@ public class AdminFacade {
         return new PerformanceDraftDetailInfo(dto, artists);
     }
 
-    private Set<String> extractArtistIds(PerformanceDraftDto dto) {
-        Set<String> artistIds = new HashSet<>();
-        try {
-            JsonNode root = objectMapper.readTree(dto.performanceData());
-            if (dto.performanceType() == PerformanceDraftType.CONCERT) {
-                Optional.ofNullable(root.get("artists")).ifPresent(arr ->
-                    arr.forEach(item -> Optional.ofNullable(item.get("artistId"))
-                        .ifPresent(node -> artistIds.add(node.asText())))
-                );
-            } else {
-                Optional.ofNullable(root.get("dates")).ifPresent(dates ->
-                    dates.forEach(date -> Optional.ofNullable(date.get("dailyArtists")).ifPresent(daily ->
-                        daily.forEach(item -> Optional.ofNullable(item.get("artistId"))
-                            .ifPresent(node -> artistIds.add(node.asText())))
-                    ))
-                );
-            }
-        } catch (JsonProcessingException e) {
-            // 파싱 실패 시 빈 Set 반환
-        }
-        return artistIds;
-    }
+
 
 
     public PerformanceDraftDto updatePerformanceDraft(PerformanceDraftUpdateDto dto) {

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -177,6 +177,15 @@ public class AdminFacade {
         return Tx.readOnlyTx(performanceDraftService::findAllDrafts);
     }
 
+    public void deletePerformanceDraft(Long draftId) {
+        PerformanceDraft draft = Tx.readOnlyTx(() -> performanceDraftService.getById(draftId));
+        Optional.ofNullable(draft.getPosterPath())
+                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path));
+        Optional.ofNullable(draft.getLogoPath())
+                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path));
+        Tx.masterTx(() -> performanceDraftService.deleteDraft(draftId));
+    }
+
     public PerformanceDraftDetailInfo getPerformanceDraftDetail(Long draftId) {
         PerformanceDraft draft = Tx.readOnlyTx(() -> performanceDraftService.getById(draftId));
         PerformanceDraftDto dto = PerformanceDraftDto.from(draft);

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -181,18 +181,25 @@ public class AdminFacade {
     }
 
     public PerformanceDraftDto createPerformanceDraft(PerformanceDraftCreateDto dto) {
-        String posterPath = s3FileHandler.uploadFile(dto.posterImage(), FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER));
-        String logoPath = dto.getOptionalLogoImage()
-            .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
-            .orElse(null);
+        String posterPath = null;
+        String logoPath = null;
 
         try {
+            posterPath = s3FileHandler.uploadFile(dto.posterImage(), FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER));
+            logoPath = dto.getOptionalLogoImage()
+                .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
+                .orElse(null);
+
             return performanceDraftService.createDraft(dto, posterPath, logoPath);
         } catch (Exception e) {
             log.warn("AdminFacade.createPerformanceDraft : 공연 초안 생성에 실패해 업로드했던 이미지 파일을 롤백합니다. posterPath : {}, logoPath : {}", posterPath, logoPath);
-            s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), posterPath);
-            Optional.ofNullable(logoPath)
-                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path));
+            
+            if (posterPath != null) {
+                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), posterPath);
+            }
+            if (logoPath != null) {
+                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), logoPath);
+            }
             throw e;
         }
     }

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -9,6 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.response.AdminArtistSearchResponses;
+import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo;
@@ -19,6 +20,10 @@ import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalPreviewInfo;
 import org.sopt.confeti.domain.concert.application.ConcertService;
 import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
+import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftService;
+import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
 import org.sopt.confeti.domain.ticketvendor.TicketVendor;
 import org.sopt.confeti.domain.ticketvendor.application.TicketVendorService;
 import org.sopt.confeti.domain.ticketvendor.application.dto.request.TicketVendorCreateDto;
@@ -43,6 +48,7 @@ public class AdminFacade {
     private final FestivalService festivalService;
     private final MusicAPIHandler musicAPIHandler;
     private final S3FileHandler s3FileHandler;
+    private final PerformanceDraftService performanceDraftService;
 
     public TicketVendorResponse createTicketVendor(CreateTicketVendorRequest request) {
         String logoPath = s3FileHandler.uploadFile(request.logoImage(),
@@ -145,4 +151,13 @@ public class AdminFacade {
         List<ConfetiArtist> artists = musicAPIHandler.findArtistsByKeyword(term, limit);
         return AdminArtistSearchResponses.from(artists);
     }
+
+    public PerformanceDraftDto createPerformanceDraft(PerformanceDraftCreateDto dto) {
+        String posterPath = s3FileHandler.uploadFile(dto.posterImage(), FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER));
+        String logoPath = dto.getOptionalLogoImage()
+            .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
+            .orElse(null);
+        return performanceDraftService.createDraft(dto, posterPath, logoPath);
+    }
+
 }

--- a/src/main/java/org/sopt/confeti/api/admin/facade/dto/response/PerformanceDraftDetailInfo.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/dto/response/PerformanceDraftDetailInfo.java
@@ -1,0 +1,11 @@
+package org.sopt.confeti.api.admin.facade.dto.response;
+
+import java.util.List;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record PerformanceDraftDetailInfo(
+        PerformanceDraftDto draft,
+        List<ConfetiArtist> artists
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/DraftStatus.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/DraftStatus.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.domain.performancedraft;
 
+import com.fasterxml.jackson.annotation.JsonValue;
 import lombok.AllArgsConstructor;
 
 @AllArgsConstructor
@@ -8,6 +9,7 @@ public enum DraftStatus {
     HOLD("보류"),
     ;
 
+    @JsonValue
     private final String description;
 
 }

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/DraftStatus.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/DraftStatus.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.domain.performancedraft;
+
+import lombok.AllArgsConstructor;
+
+@AllArgsConstructor
+public enum DraftStatus {
+    UNREVIEWED("검토 필요"),
+    HOLD("보류"),
+    ;
+
+    private final String description;
+
+}

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/PerformanceDraft.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/PerformanceDraft.java
@@ -1,0 +1,113 @@
+package org.sopt.confeti.domain.performancedraft;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+@Table(name = "performance_drafts")
+public class PerformanceDraft {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private PerformanceType performanceType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    private DraftStatus status;
+
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(columnDefinition = "json", nullable = false)
+    private String performanceData;
+
+    @Column(nullable = false)
+    private String posterPath;
+
+    @Column(nullable = true)
+    private String logoPath;
+
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    private LocalDateTime updatedAt;
+
+    @Builder
+    private PerformanceDraft(
+        PerformanceType performanceType, 
+        DraftStatus status, 
+        String performanceData, 
+        String posterPath, 
+        String logoPath
+    ) {
+        this.performanceType = performanceType;
+        this.status = status;
+        this.performanceData = performanceData;
+        this.posterPath = posterPath;
+        this.logoPath = logoPath;
+    }
+
+    public static PerformanceDraft create(
+        PerformanceType performanceType, 
+        String performanceData, 
+        DraftStatus status,
+        String posterPath,
+        String logoPath
+    ) {
+        return PerformanceDraft.builder()
+                .performanceType(performanceType)
+                .status(status)
+                .performanceData(performanceData)
+                .posterPath(posterPath)
+                .logoPath(logoPath)
+                .build();
+    }
+
+    public void update(
+        PerformanceType performanceType, 
+        DraftStatus status, 
+        String performanceData,
+        String posterPath,
+        String logoPath
+    ) {
+        if (performanceType != null) {
+            this.performanceType = performanceType;
+        }
+        if (status != null) {
+            this.status = status;
+        }
+        if (performanceData != null && !performanceData.isBlank()) {
+            this.performanceData = performanceData;
+        }
+        if (posterPath != null && !posterPath.isBlank()) {
+            this.posterPath = posterPath;
+        }
+        if (logoPath != null && !logoPath.isBlank()) {
+            this.logoPath = logoPath;
+        }
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/PerformanceDraft.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/PerformanceDraft.java
@@ -33,7 +33,7 @@ public class PerformanceDraft {
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
-    private PerformanceDraftType performanceType;
+    private PerformanceDraftType performanceDraftType;
 
     @Enumerated(EnumType.STRING)
     @Column(nullable = false, length = 20)
@@ -64,7 +64,7 @@ public class PerformanceDraft {
         String posterPath, 
         String logoPath
     ) {
-        this.performanceType = performanceType;
+        this.performanceDraftType = performanceType;
         this.status = status;
         this.performanceData = performanceData;
         this.posterPath = posterPath;
@@ -72,14 +72,14 @@ public class PerformanceDraft {
     }
 
     public static PerformanceDraft create(
-        PerformanceDraftType performanceType, 
+        PerformanceDraftType performanceDraftType, 
         String performanceData, 
         DraftStatus status,
         String posterPath,
         String logoPath
     ) {
         return PerformanceDraft.builder()
-                .performanceType(performanceType)
+                .performanceType(performanceDraftType)
                 .status(status)
                 .performanceData(performanceData)
                 .posterPath(posterPath)
@@ -88,14 +88,14 @@ public class PerformanceDraft {
     }
 
     public void update(
-        PerformanceDraftType performanceType, 
+        PerformanceDraftType performanceDraftType, 
         DraftStatus status, 
         String performanceData,
         String posterPath,
         String logoPath
     ) {
-        if (performanceType != null) {
-            this.performanceType = performanceType;
+        if (performanceDraftType != null) {
+            this.performanceDraftType = performanceDraftType;
         }
         if (status != null) {
             this.status = status;

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/PerformanceDraft.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/PerformanceDraft.java
@@ -43,7 +43,7 @@ public class PerformanceDraft {
     @Column(columnDefinition = "json", nullable = false)
     private String performanceData;
 
-    @Column(nullable = false)
+    @Column(nullable = true)
     private String posterPath;
 
     @Column(nullable = true)

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/PerformanceType.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/PerformanceType.java
@@ -1,0 +1,6 @@
+package org.sopt.confeti.domain.performancedraft;
+
+public enum PerformanceType {
+    FESTIVAL,
+    CONCERT
+}

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftParser.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftParser.java
@@ -1,0 +1,44 @@
+package org.sopt.confeti.domain.performancedraft.application;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
+
+import org.sopt.confeti.domain.performancedraft.PerformanceDraftType;
+import org.springframework.stereotype.Component;
+
+import lombok.RequiredArgsConstructor;
+
+@Component
+@RequiredArgsConstructor
+public class PerformanceDraftParser {
+
+    private final ObjectMapper objectMapper;
+
+    public Set<String> parseArtistIds(PerformanceDraftType performanceDraftType, String performanceData) {
+        Set<String> artistIds = new HashSet<>();
+        try {
+            JsonNode root = objectMapper.readTree(performanceData);
+            if (performanceDraftType == PerformanceDraftType.CONCERT) {
+                Optional.ofNullable(root.get("artists")).ifPresent(arr ->
+                    arr.forEach(item -> Optional.ofNullable(item.get("artistId"))
+                        .ifPresent(node -> artistIds.add(node.asText())))
+                );
+            } else {
+                Optional.ofNullable(root.get("dates")).ifPresent(dates ->
+                    dates.forEach(date -> Optional.ofNullable(date.get("dailyArtists"))
+                        .ifPresent(daily -> daily.forEach(item -> Optional.ofNullable(item.get("artistId"))
+                            .ifPresent(node -> artistIds.add(node.asText())))))
+                );
+            }
+        } catch (Exception e) {
+            // 파싱 실패 시 빈 Set 반환
+        }
+        return artistIds;
+    }
+
+
+}

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
@@ -34,7 +34,7 @@ public class PerformanceDraftService {
     }
 
     @Transactional(readOnly = true)
-    public PerformanceDraftDtos findAllDrafts() {
+    public PerformanceDraftDtos getAllDrafts() {
         return PerformanceDraftDtos.from(
                 draftRepository.findAll().stream()
                         .map(PerformanceDraftDto::from)

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
@@ -1,0 +1,33 @@
+package org.sopt.confeti.domain.performancedraft.application;
+
+import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
+import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
+import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
+import org.sopt.confeti.domain.performancedraft.infra.PerformanceDraftRepository;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.exception.NotFoundException;
+import org.sopt.confeti.global.message.ErrorMessage;
+import org.sopt.confeti.global.util.S3FileHandler;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class PerformanceDraftService {
+
+    private final PerformanceDraftRepository draftRepository;
+    private final S3FileHandler s3FileHandler;
+
+    @Transactional
+    public PerformanceDraftDto createDraft(PerformanceDraftCreateDto dto, String posterPath, String logoPath) {
+        PerformanceDraft draft = dto.toEntity(posterPath, logoPath);
+        PerformanceDraft savedDraft = draftRepository.save(draft);
+        return PerformanceDraftDto.from(savedDraft);
+    }
+
+
+}

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
@@ -6,10 +6,8 @@ import org.sopt.confeti.domain.performancedraft.application.dto.request.Performa
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
 import org.sopt.confeti.domain.performancedraft.infra.PerformanceDraftRepository;
-import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
-import org.sopt.confeti.global.util.S3FileHandler;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -20,7 +18,6 @@ import java.util.List;
 public class PerformanceDraftService {
 
     private final PerformanceDraftRepository draftRepository;
-    private final S3FileHandler s3FileHandler;
 
     @Transactional
     public PerformanceDraftDto createDraft(PerformanceDraftCreateDto dto, String posterPath, String logoPath) {
@@ -29,5 +26,28 @@ public class PerformanceDraftService {
         return PerformanceDraftDto.from(savedDraft);
     }
 
+    @Transactional
+    public PerformanceDraftDto updateDraft(PerformanceDraftUpdateDto dto, String posterPath, String logoPath) {
+        PerformanceDraft draft = getById(dto.id());
+        draft.update(dto.performanceType(), dto.status(), dto.performanceData(), posterPath, logoPath);
+        return PerformanceDraftDto.from(draft);
+    }
 
+    @Transactional(readOnly = true)
+    public List<PerformanceDraftDto> findAllDrafts() {
+        return draftRepository.findAll().stream()
+                .map(PerformanceDraftDto::from)
+                .toList();
+    }
+
+    @Transactional
+    public void deleteDraft(Long draftId) {
+        PerformanceDraft draft = getById(draftId);
+        draftRepository.delete(draft);
+    }
+
+    public PerformanceDraft getById(Long id) {
+        return draftRepository.findById(id)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
@@ -48,6 +48,7 @@ public class PerformanceDraftService {
         draftRepository.delete(draft);
     }
 
+    @Transactional(readOnly = true)
     public PerformanceDraft getById(Long id) {
         return draftRepository.findById(id)
                 .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
@@ -5,13 +5,13 @@ import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
+import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDtos;
 import org.sopt.confeti.domain.performancedraft.infra.PerformanceDraftRepository;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -34,10 +34,12 @@ public class PerformanceDraftService {
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceDraftDto> findAllDrafts() {
-        return draftRepository.findAll().stream()
-                .map(PerformanceDraftDto::from)
-                .toList();
+    public PerformanceDraftDtos findAllDrafts() {
+        return PerformanceDraftDtos.from(
+                draftRepository.findAll().stream()
+                        .map(PerformanceDraftDto::from)
+                        .toList()
+        );
     }
 
     @Transactional

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/request/PerformanceDraftCreateDto.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/request/PerformanceDraftCreateDto.java
@@ -1,0 +1,31 @@
+package org.sopt.confeti.domain.performancedraft.application.dto.request;
+
+import java.util.Optional;
+
+import org.sopt.confeti.domain.performancedraft.DraftStatus;
+import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
+import org.sopt.confeti.domain.performancedraft.PerformanceType;
+import org.sopt.confeti.global.common.upload.UploadableFile;
+
+public record PerformanceDraftCreateDto(
+        PerformanceType performanceType,
+        String performanceData,
+        DraftStatus status,
+        UploadableFile posterImage,
+        UploadableFile logoImage
+) {
+    public static PerformanceDraftCreateDto of(
+        PerformanceType performanceType, String performanceData, DraftStatus status, 
+        UploadableFile posterImage, UploadableFile logoImage
+    ) {
+        return new PerformanceDraftCreateDto(performanceType, performanceData, status, posterImage, logoImage);
+    }
+
+    public PerformanceDraft toEntity(String posterPath, String logoPath) {
+        return PerformanceDraft.create(this.performanceType, this.performanceData, this.status, posterPath, logoPath);
+    }
+
+    public Optional<UploadableFile> getOptionalLogoImage(){
+        return Optional.ofNullable(this.logoImage);
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/request/PerformanceDraftUpdateDto.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/request/PerformanceDraftUpdateDto.java
@@ -1,0 +1,30 @@
+package org.sopt.confeti.domain.performancedraft.application.dto.request;
+
+import java.util.Optional;
+import org.sopt.confeti.domain.performancedraft.DraftStatus;
+import org.sopt.confeti.domain.performancedraft.PerformanceType;
+import org.sopt.confeti.global.common.upload.UploadableFile;
+
+public record PerformanceDraftUpdateDto(
+    Long id,
+    PerformanceType performanceType,
+    DraftStatus status,
+    String performanceData,
+    UploadableFile posterImage,
+    UploadableFile logoImage
+) {
+    public static PerformanceDraftUpdateDto of(
+        Long id, PerformanceType performanceType, DraftStatus status, String performanceData,
+        UploadableFile posterImage, UploadableFile logoImage
+    ) {
+        return new PerformanceDraftUpdateDto(id, performanceType, status, performanceData, posterImage, logoImage);
+    }
+
+    public Optional<UploadableFile> getOptionalPosterImage() {
+        return Optional.ofNullable(this.posterImage);
+    }
+
+    public Optional<UploadableFile> getOptionalLogoImage() {
+        return Optional.ofNullable(this.logoImage);
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/response/PerformanceDraftDto.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/response/PerformanceDraftDto.java
@@ -16,8 +16,8 @@ public record PerformanceDraftDto(
         PerformanceDraftType performanceType,
         DraftStatus status,
         String performanceData,
-        String posterPath,
-        String logoPath,
+        String posterUrl,
+        String logoUrl,
         LocalDateTime createdAt,
         LocalDateTime updatedAt
 ) {

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/response/PerformanceDraftDto.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/response/PerformanceDraftDto.java
@@ -1,0 +1,31 @@
+package org.sopt.confeti.domain.performancedraft.application.dto.response;
+
+import org.sopt.confeti.domain.performancedraft.DraftStatus;
+import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
+import org.sopt.confeti.domain.performancedraft.PerformanceType;
+
+import java.time.LocalDateTime;
+
+public record PerformanceDraftDto(
+        Long id,
+        PerformanceType performanceType,
+        DraftStatus status,
+        String performanceData,
+        String posterPath,
+        String logoPath,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static PerformanceDraftDto from(PerformanceDraft draft) {
+        return new PerformanceDraftDto(
+                draft.getId(),
+                draft.getPerformanceType(),
+                draft.getStatus(),
+                draft.getPerformanceData(),
+                draft.getPosterPath(),
+                draft.getLogoPath(),
+                draft.getCreatedAt(),
+                draft.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/response/PerformanceDraftDto.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/response/PerformanceDraftDto.java
@@ -1,5 +1,10 @@
 package org.sopt.confeti.domain.performancedraft.application.dto.response;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.HashSet;
+import java.util.Optional;
+import java.util.Set;
 import org.sopt.confeti.domain.performancedraft.DraftStatus;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraftType;
@@ -27,5 +32,28 @@ public record PerformanceDraftDto(
                 draft.getCreatedAt(),
                 draft.getUpdatedAt()
         );
+    }
+
+    public Set<String> getArtistIds(ObjectMapper objectMapper) {
+        Set<String> artistIds = new HashSet<>();
+        try {
+            JsonNode root = objectMapper.readTree(performanceData);
+            if (performanceType == PerformanceDraftType.CONCERT) {
+                Optional.ofNullable(root.get("artists")).ifPresent(arr ->
+                    arr.forEach(item -> Optional.ofNullable(item.get("artistId"))
+                        .ifPresent(node -> artistIds.add(node.asText())))
+                );
+            } else {
+                Optional.ofNullable(root.get("dates")).ifPresent(dates ->
+                    dates.forEach(date -> Optional.ofNullable(date.get("dailyArtists")).ifPresent(daily ->
+                        daily.forEach(item -> Optional.ofNullable(item.get("artistId"))
+                            .ifPresent(node -> artistIds.add(node.asText())))
+                    ))
+                );
+            }
+        } catch (Exception e) {
+            // 파싱 실패 시 빈 Set 반환
+        }
+        return artistIds;
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/response/PerformanceDraftDto.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/dto/response/PerformanceDraftDto.java
@@ -13,7 +13,7 @@ import java.time.LocalDateTime;
 
 public record PerformanceDraftDto(
         Long id,
-        PerformanceDraftType performanceType,
+        PerformanceDraftType performanceDraftType,
         DraftStatus status,
         String performanceData,
         String posterUrl,
@@ -24,7 +24,7 @@ public record PerformanceDraftDto(
     public static PerformanceDraftDto from(PerformanceDraft draft) {
         return new PerformanceDraftDto(
                 draft.getId(),
-                draft.getPerformanceType(),
+                draft.getPerformanceDraftType(),
                 draft.getStatus(),
                 draft.getPerformanceData(),
                 draft.getPosterPath(),
@@ -34,26 +34,4 @@ public record PerformanceDraftDto(
         );
     }
 
-    public Set<String> getArtistIds(ObjectMapper objectMapper) {
-        Set<String> artistIds = new HashSet<>();
-        try {
-            JsonNode root = objectMapper.readTree(performanceData);
-            if (performanceType == PerformanceDraftType.CONCERT) {
-                Optional.ofNullable(root.get("artists")).ifPresent(arr ->
-                    arr.forEach(item -> Optional.ofNullable(item.get("artistId"))
-                        .ifPresent(node -> artistIds.add(node.asText())))
-                );
-            } else {
-                Optional.ofNullable(root.get("dates")).ifPresent(dates ->
-                    dates.forEach(date -> Optional.ofNullable(date.get("dailyArtists")).ifPresent(daily ->
-                        daily.forEach(item -> Optional.ofNullable(item.get("artistId"))
-                            .ifPresent(node -> artistIds.add(node.asText())))
-                    ))
-                );
-            }
-        } catch (Exception e) {
-            // 파싱 실패 시 빈 Set 반환
-        }
-        return artistIds;
-    }
 }

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/infra/PerformanceDraftRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/infra/PerformanceDraftRepository.java
@@ -1,0 +1,8 @@
+package org.sopt.confeti.domain.performancedraft.infra;
+
+import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface PerformanceDraftRepository extends JpaRepository<PerformanceDraft, Long> {
+
+}

--- a/src/main/java/org/sopt/confeti/domain/ticketvendor/application/dto/request/TicketVendorCreateDto.java
+++ b/src/main/java/org/sopt/confeti/domain/ticketvendor/application/dto/request/TicketVendorCreateDto.java
@@ -1,5 +1,8 @@
 package org.sopt.confeti.domain.ticketvendor.application.dto.request;
 
+import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
+import org.sopt.confeti.domain.ticketvendor.TicketVendor;
+
 public record TicketVendorCreateDto(
     String name,
     String logoPath
@@ -8,11 +11,11 @@ public record TicketVendorCreateDto(
         return new TicketVendorCreateDto(name, logoPath);
     }
 
-    public static TicketVendorCreateDto from(org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest request, String logoPath) {
+    public static TicketVendorCreateDto from(CreateTicketVendorRequest request, String logoPath) {
         return new TicketVendorCreateDto(request.name(), logoPath);
     }
 
-    public org.sopt.confeti.domain.ticketvendor.TicketVendor toEntity() {
-        return org.sopt.confeti.domain.ticketvendor.TicketVendor.create(this.name, this.logoPath);
+    public TicketVendor toEntity() {
+        return TicketVendor.create(this.name, this.logoPath);
     }
 }

--- a/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
+++ b/src/main/java/org/sopt/confeti/global/common/constant/FolderPath.java
@@ -5,7 +5,7 @@ import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.message.ErrorMessage;
 
 public enum FolderPath {
-    FESTIVAL("festival"), CONCERT("concert"), USER("user"), TICKET_VENDOR("ticket-vendor"),
+    FESTIVAL("festival"), CONCERT("concert"), USER("user"), TICKET_VENDOR("ticket-vendor"), PERFORMANCE_DRAFT("performance-draft"),
     LOGO("logo"), POSTER_BG("poster-bg"), POSTER("poster"),
     RESERVATION("reservation"), PROFILE("profile"), DEFAULT("default");
 

--- a/src/main/java/org/sopt/confeti/global/common/upload/MultipartFileAdapter.java
+++ b/src/main/java/org/sopt/confeti/global/common/upload/MultipartFileAdapter.java
@@ -1,0 +1,33 @@
+package org.sopt.confeti.global.common.upload;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+public class MultipartFileAdapter implements UploadableFile {
+    private final MultipartFile file;
+
+    @Override
+    public InputStream getInputStream() throws IOException {
+        return file.getInputStream();
+    }
+
+    @Override
+    public String getOriginalFilename() {
+        return file.getOriginalFilename();
+    }
+
+    @Override
+    public long getSize() {
+        return file.getSize();
+    }
+
+    @Override
+    public String getContentType() {
+        return file.getContentType();
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/common/upload/UploadableFile.java
+++ b/src/main/java/org/sopt/confeti/global/common/upload/UploadableFile.java
@@ -1,0 +1,11 @@
+package org.sopt.confeti.global.common.upload;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+public interface UploadableFile {
+    InputStream getInputStream() throws IOException;
+    String getOriginalFilename();
+    long getSize();
+    String getContentType();
+}

--- a/src/main/java/org/sopt/confeti/global/event/S3EventListener.java
+++ b/src/main/java/org/sopt/confeti/global/event/S3EventListener.java
@@ -1,0 +1,27 @@
+package org.sopt.confeti.global.event;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.global.util.S3FileHandler;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class S3EventListener {
+
+    private final S3FileHandler s3FileHandler;
+
+    @Async
+    @EventListener
+    public void handleDeleteEvent(S3FileDeleteEvent event) {
+        try {
+            s3FileHandler.deleteFile(event.folderPath(), event.filePath());
+            log.info("S3EventListener.handleDeleteEvent : 기존 S3 파일 삭제 완료. path : {}", event.filePath());
+        } catch (Exception e) {
+            log.error("S3EventListener.handleDeleteEvent : 기존 파일 삭제 실패 (S3 고아 객체 발생). path : {}", event.filePath(), e);
+        }
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/event/S3FileDeleteEvent.java
+++ b/src/main/java/org/sopt/confeti/global/event/S3FileDeleteEvent.java
@@ -1,0 +1,7 @@
+package org.sopt.confeti.global.event;
+
+public record S3FileDeleteEvent(
+        String folderPath,
+        String filePath
+) {
+}

--- a/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
+++ b/src/main/java/org/sopt/confeti/global/util/S3FileHandler.java
@@ -18,6 +18,7 @@ import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.global.annotation.Handler;
+import org.sopt.confeti.global.common.upload.UploadableFile;
 import org.sopt.confeti.global.exception.ConfetiException;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
@@ -82,6 +83,28 @@ public class S3FileHandler {
         return fileName;
     }
 
+    /**
+     * 파일 업로드
+     */
+    public String uploadFile(UploadableFile file, String folderPath) {
+        final String fileName = fileNameGenerator.generate(
+            Objects.requireNonNull(file.getOriginalFilename()));
+        checkFileNotExist(folderPath, fileName);
+
+        final ObjectMetadata metadata = getMetadata(file);
+
+        try {
+            upload(
+                folderPath + fileName,
+                file.getInputStream(), metadata
+            );
+        } catch (IOException e) {
+            throw new ConfetiException(ErrorMessage.BAD_REQUEST);
+        }
+
+        return fileName;
+    }
+
     private ObjectMetadata getMetadata(MultipartFile file) {
         return new ObjectMetadata.Builder()
             .contentLength(file.getSize())
@@ -101,6 +124,13 @@ public class S3FileHandler {
         return new ObjectMetadata.Builder()
             .contentLength(file.length())
             .contentType(contentType)
+            .build();
+    }
+
+    private ObjectMetadata getMetadata(UploadableFile file) {
+        return new ObjectMetadata.Builder()
+            .contentLength(file.getSize())
+            .contentType(file.getContentType())
             .build();
     }
 


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->

- 공연 대기 목록 도메인 생성
- 공연 대기 목록 생성 시 이미지를 크롤링 해오는 경우와 수동으로 올리는 경우 이미지 타입이 다르더라도 둘 다 동일한 공연 대기 목록 생성이 가능하도록 UploadableFile 인터페이스와 MultipartFileAdapter를 구현해서 처리함 
- festival performanceDraft 조회 시 dailyArtist 필드를 따로 두어서 Artist만 우선 등록하는 경우를 처리함
- performanceDraft 상세 조회 시 아티스트 정보는 별도 필드로 담아서 반환함


## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
- 제가 수동 등록을 콘서트와 페스티벌로 따로 등록하는 플로우인걸 나중에 인지해서 현재 기능 명세상 사용하지 않는 공연 대기 수동 등록 + 수정 API가 존재하는 형태입니다. 이 API들을 삭제하지 않고 올린 이유는 아래와 같습니다.
  1. 추후 요구사항이 변경 시 사용할 수 있을 것 같아서
  2. 이미 해당 부분에 얽혀있는 작업들이 좀 많아서 이 부분을 사이드 이펙트 없이 깔끔하게 제거하는게 시간이 더 많이 걸릴 것 같아서
 - 대신 API에 @Deprecated 걸어두었고, swagger 내 description에도 클라이언트가 이해하기 편하도록 해당 API를 사용하지 않고 수동 등록 시 콘서트/페스티벌의 수정/삭제 API를 사용하도록 작성해두었습니다.
