### PR TITLE
CONSERVER-21: 연관인기음악 조회 api 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/search/dto/response/SearchResultResponse.java
+++ b/src/main/java/org/sopt/confeti/api/search/dto/response/SearchResultResponse.java
@@ -7,6 +7,7 @@ import org.sopt.confeti.global.util.S3FileHandler;
 
 public record SearchResultResponse(
         SearchResultArtistResponse artist,
+        List<SearchResultSongResponse> songs,
         int performanceCount,
         List<SearchResultPerformanceResponse> performances
 ) {
@@ -18,6 +19,9 @@ public record SearchResultResponse(
 
         return new SearchResultResponse(
                 artist,
+                searchResult.songs().stream()
+                        .map(SearchResultSongResponse::from)
+                        .toList(),
                 searchResult.performances().size(),
                 searchResult.performances().stream()
                         .map(performance -> SearchResultPerformanceResponse.of(performance, s3FileHandler))

--- a/src/main/java/org/sopt/confeti/api/search/dto/response/SearchResultSongResponse.java
+++ b/src/main/java/org/sopt/confeti/api/search/dto/response/SearchResultSongResponse.java
@@ -1,0 +1,22 @@
+package org.sopt.confeti.api.search.dto.response;
+
+import org.sopt.confeti.api.search.facade.dto.response.SearchResultSongDTO;
+
+public record SearchResultSongResponse(
+    String songId,
+    String songName,
+    String artistName,
+    String artworkUrl,
+    String previewUrl
+) {
+
+    public static SearchResultSongResponse from(SearchResultSongDTO song) {
+        return new SearchResultSongResponse(
+            song.songId(),
+            song.songName(),
+            song.artistName(),
+            song.artworkUrl(),
+            song.previewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/search/facade/SearchFacade.java
+++ b/src/main/java/org/sopt/confeti/api/search/facade/SearchFacade.java
@@ -16,6 +16,7 @@ import org.sopt.confeti.domain.elastic_search.application.SearchTermService;
 import org.sopt.confeti.domain.festival_favorite.application.FestivalFavoriteService;
 import org.sopt.confeti.domain.music.song.application.SongMusicAPIService;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceArtistDTO;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.annotation.ReadOnlyTransactional;
@@ -34,7 +35,6 @@ import org.sopt.confeti.global.util.music.MusicAPIHandler;
 public class SearchFacade {
 
     private static final String TYPE_ALL = "ALL";
-    private static final int ARTIST_SEARCH_COUNT = 1;
     private static final int RELATED_POPULAR_SONG_LIMIT = 3;
 
     private final SearchTermService searchTermService;
@@ -95,7 +95,9 @@ public class SearchFacade {
             }
         }
 
-        return SearchResultDTO.of(performance, performanceFavorite);
+        List<ConfetiSong> songs = getPopularSongsByPerformanceArtists(performance);
+
+        return SearchResultDTO.of(performance, performanceFavorite, songs);
     }
 
     @ReadOnlyTransactional
@@ -171,5 +173,20 @@ public class SearchFacade {
         favoritePerformances.forEach(performance -> {
             performanceFavorites.replace(performance.id(), true);
         });
+    }
+
+    private List<ConfetiSong> getPopularSongsByPerformanceArtists(PerformanceDTO performance) {
+        List<PerformanceArtistDTO> artists = performance.artists();
+        if (artists == null || artists.isEmpty()) {
+            return List.of();
+        }
+
+        return artists.stream()
+            .map(PerformanceArtistDTO::artistId)
+            .map(artistId -> songMusicAPIService.getPopularSongsByArtist(artistId,
+                RELATED_POPULAR_SONG_LIMIT))
+            .filter(songs -> !songs.isEmpty())
+            .findFirst()
+            .orElse(List.of());
     }
 }

--- a/src/main/java/org/sopt/confeti/api/search/facade/SearchFacade.java
+++ b/src/main/java/org/sopt/confeti/api/search/facade/SearchFacade.java
@@ -1,6 +1,9 @@
 package org.sopt.confeti.api.search.facade;
 
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -36,6 +39,7 @@ public class SearchFacade {
 
     private static final String TYPE_ALL = "ALL";
     private static final int RELATED_POPULAR_SONG_LIMIT = 3;
+    private static final int RELATED_POPULAR_SONG_ARTIST_LIMIT = 3;
 
     private final SearchTermService searchTermService;
     private final MusicAPIHandler musicAPIHandler;
@@ -181,12 +185,33 @@ public class SearchFacade {
             return List.of();
         }
 
-        return artists.stream()
+        List<String> artistIds = artists.stream()
             .map(PerformanceArtistDTO::artistId)
+            .distinct()
+            .limit(RELATED_POPULAR_SONG_ARTIST_LIMIT)
+            .toList();
+
+        List<ConfetiSong> mergedSongs = artistIds.stream()
             .map(artistId -> songMusicAPIService.getPopularSongsByArtist(artistId,
                 RELATED_POPULAR_SONG_LIMIT))
-            .filter(songs -> !songs.isEmpty())
-            .findFirst()
-            .orElse(List.of());
+            .flatMap(List::stream)
+            .collect(Collectors.collectingAndThen(
+                Collectors.toMap(
+                    ConfetiSong::getId,
+                    song -> song,
+                    (left, right) -> left,
+                    LinkedHashMap::new
+                ),
+                map -> new ArrayList<>(map.values())
+            ));
+
+        if (mergedSongs.isEmpty()) {
+            return List.of();
+        }
+
+        Collections.shuffle(mergedSongs);
+        return mergedSongs.stream()
+            .limit(RELATED_POPULAR_SONG_LIMIT)
+            .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/api/search/facade/SearchFacade.java
+++ b/src/main/java/org/sopt/confeti/api/search/facade/SearchFacade.java
@@ -14,6 +14,7 @@ import org.sopt.confeti.domain.concert_favorite.application.ConcertFavoriteServi
 import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
 import org.sopt.confeti.domain.elastic_search.application.SearchTermService;
 import org.sopt.confeti.domain.festival_favorite.application.FestivalFavoriteService;
+import org.sopt.confeti.domain.music.song.application.SongMusicAPIService;
 import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.annotation.Facade;
@@ -23,6 +24,7 @@ import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.interceptor.auth.UserContext;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+import org.sopt.confeti.global.resolver.music_api.song.vo.ConfetiSong;
 import org.sopt.confeti.global.util.analyzer.SearchTermAnalyzer;
 import org.sopt.confeti.global.util.analyzer.dto.PerformanceSearchTermAnalyzeResult;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
@@ -33,6 +35,7 @@ public class SearchFacade {
 
     private static final String TYPE_ALL = "ALL";
     private static final int ARTIST_SEARCH_COUNT = 1;
+    private static final int RELATED_POPULAR_SONG_LIMIT = 3;
 
     private final SearchTermService searchTermService;
     private final MusicAPIHandler musicAPIHandler;
@@ -41,6 +44,7 @@ public class SearchFacade {
     private final FestivalFavoriteService festivalFavoriteService;
     private final ConcertFavoriteService concertFavoriteService;
     private final PerformanceSearchService performanceSearchService;
+    private final SongMusicAPIService songMusicAPIService;
 
     @ReadOnlyTransactional
     public SearchResultDTO getHomeSearchResultWithAid(String aid) {
@@ -54,6 +58,8 @@ public class SearchFacade {
 
         List<PerformanceDTO> performances = performanceService.getPerformancesByArtistIdAndType(aid,
             PerformanceType.PERFORMANCE);
+        List<ConfetiSong> songs = songMusicAPIService.getPopularSongsByArtist(artist.getId(),
+            RELATED_POPULAR_SONG_LIMIT);
 
         Map<Long, Boolean> performanceFavorites = performances.stream()
             .collect(Collectors.toMap(
@@ -67,7 +73,8 @@ public class SearchFacade {
             getPerformanceFavorites(performanceFavorites, favoritePerformances);
         }
 
-        return SearchResultDTO.of(artist, artistFavorite, performances, performanceFavorites);
+        return SearchResultDTO.of(artist, artistFavorite, performances, performanceFavorites,
+            songs);
     }
 
     @ReadOnlyTransactional
@@ -137,9 +144,15 @@ public class SearchFacade {
             getPerformanceFavorites(performanceFavorites, favoritePerformances);
         }
 
+        List<ConfetiSong> songs = artist.map(confetiArtist ->
+                songMusicAPIService.getPopularSongsByArtist(confetiArtist.getId(),
+                    RELATED_POPULAR_SONG_LIMIT))
+            .orElse(List.of());
+
         return SearchResultDTO.of(artist.orElse(null), artistFavorite,
             performances.stream().toList(),
-            performanceFavorites);
+            performanceFavorites,
+            songs);
     }
 
     public PopularTermsDTO getPopularSearchTerms(int limit) {

--- a/src/main/java/org/sopt/confeti/api/search/facade/dto/response/SearchResultDTO.java
+++ b/src/main/java/org/sopt/confeti/api/search/facade/dto/response/SearchResultDTO.java
@@ -32,9 +32,16 @@ public record SearchResultDTO(
     }
 
     public static SearchResultDTO of(PerformanceDTO performance, boolean performanceFavorite) {
+        return of(performance, performanceFavorite, List.of());
+    }
+
+    public static SearchResultDTO of(PerformanceDTO performance, boolean performanceFavorite,
+        List<ConfetiSong> songs) {
         return new SearchResultDTO(
                 null,
-                List.of(),
+                songs.stream()
+                        .map(SearchResultSongDTO::from)
+                        .toList(),
                 List.of(SearchResultPerformanceDTO.of(performance, performanceFavorite))
         );
     }

--- a/src/main/java/org/sopt/confeti/api/search/facade/dto/response/SearchResultDTO.java
+++ b/src/main/java/org/sopt/confeti/api/search/facade/dto/response/SearchResultDTO.java
@@ -5,13 +5,15 @@ import java.util.Map;
 import java.util.Objects;
 import org.sopt.confeti.domain.view.performance.application.dto.response.PerformanceDTO;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+import org.sopt.confeti.global.resolver.music_api.song.vo.ConfetiSong;
 
 public record SearchResultDTO(
         SearchResultArtistDTO artist,
+        List<SearchResultSongDTO> songs,
         List<SearchResultPerformanceDTO> performances
 ) {
     public static SearchResultDTO of(ConfetiArtist artist, boolean artistFavorite, List<PerformanceDTO> performances,
-                                     Map<Long, Boolean> performanceFavorites) {
+                                     Map<Long, Boolean> performanceFavorites, List<ConfetiSong> songs) {
         SearchResultArtistDTO artistDTO = null;
         if (Objects.nonNull(artist)) {
             artistDTO = SearchResultArtistDTO.of(artist, artistFavorite);
@@ -19,6 +21,9 @@ public record SearchResultDTO(
 
         return new SearchResultDTO(
                 artistDTO,
+                songs.stream()
+                        .map(SearchResultSongDTO::from)
+                        .toList(),
                 performances.stream()
                         .map(performance -> SearchResultPerformanceDTO.of(performance,
                                 performanceFavorites.get(performance.id())))
@@ -29,6 +34,7 @@ public record SearchResultDTO(
     public static SearchResultDTO of(PerformanceDTO performance, boolean performanceFavorite) {
         return new SearchResultDTO(
                 null,
+                List.of(),
                 List.of(SearchResultPerformanceDTO.of(performance, performanceFavorite))
         );
     }

--- a/src/main/java/org/sopt/confeti/api/search/facade/dto/response/SearchResultSongDTO.java
+++ b/src/main/java/org/sopt/confeti/api/search/facade/dto/response/SearchResultSongDTO.java
@@ -1,0 +1,22 @@
+package org.sopt.confeti.api.search.facade.dto.response;
+
+import org.sopt.confeti.global.resolver.music_api.song.vo.ConfetiSong;
+
+public record SearchResultSongDTO(
+    String songId,
+    String songName,
+    String artistName,
+    String artworkUrl,
+    String previewUrl
+) {
+
+    public static SearchResultSongDTO from(ConfetiSong song) {
+        return new SearchResultSongDTO(
+            song.getId(),
+            song.getTrackName(),
+            song.getArtistName(),
+            song.getArtworkUrl(),
+            song.getPreviewUrl()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/music/song/application/SongMusicAPIService.java
+++ b/src/main/java/org/sopt/confeti/domain/music/song/application/SongMusicAPIService.java
@@ -4,6 +4,7 @@ import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.domain.music.application.MusicAPIService;
 import org.sopt.confeti.domain.music.application.dto.CacheResult;
 import org.sopt.confeti.domain.music.application.dto.FetchResult;
@@ -19,6 +20,7 @@ import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.stereotype.Service;
 
 @Service
+@Slf4j
 @RequiredArgsConstructor
 public class SongMusicAPIService extends MusicAPIService<ConfetiSong> {
 
@@ -80,29 +82,43 @@ public class SongMusicAPIService extends MusicAPIService<ConfetiSong> {
     }
 
     public List<ConfetiSong> getPopularSongsByArtist(String artistId, int limit) {
-        List<ConfetiSong> songs = musicAPIHandler.getArtistTopSongs(artistId, limit);
-        if (songs.isEmpty()) {
+        List<ConfetiSong> songs;
+        try {
+            songs = musicAPIHandler.getArtistTopSongs(artistId, limit);
+        } catch (Exception ex) {
+            log.warn("SongMusicAPIService.getPopularSongsByArtist failed. artistId: {}, message: {}",
+                artistId, ex.getMessage());
             return List.of();
         }
 
-        Set<String> songIds = songs.stream()
-            .map(ConfetiSong::getId)
-            .collect(Collectors.toSet());
-        CacheResult<ConfetiSong> cacheResult = getCached(MusicAPICondition.from(songIds));
-        Set<String> cachedSongIds = cacheResult.cachedIds();
-        if (cachedSongIds.size() == songIds.size()) {
-            return songs;
+        if (songs == null || songs.isEmpty()) {
+            return List.of();
         }
 
-        List<ConfetiSong> missingSongs = songs.stream()
-            .filter(song -> !cachedSongIds.contains(song.getId()))
-            .toList();
-        if (missingSongs.isEmpty()) {
+        try {
+            Set<String> songIds = songs.stream()
+                .map(ConfetiSong::getId)
+                .collect(Collectors.toSet());
+            CacheResult<ConfetiSong> cacheResult = getCached(MusicAPICondition.from(songIds));
+            Set<String> cachedSongIds = cacheResult.cachedIds();
+            if (cachedSongIds.size() == songIds.size()) {
+                return songs;
+            }
+
+            List<ConfetiSong> missingSongs = songs.stream()
+                .filter(song -> !cachedSongIds.contains(song.getId()))
+                .toList();
+            if (missingSongs.isEmpty()) {
+                return songs;
+            }
+
+            persist(missingSongs);
+            cache(missingSongs);
+        } catch (Exception ex) {
+            log.warn("SongMusicAPIService.getPopularSongsByArtist cache/persist failed. artistId: {}, message: {}",
+                artistId, ex.getMessage());
             return songs;
         }
-
-        persist(missingSongs);
-        cache(missingSongs);
 
         return songs;
     }

--- a/src/main/java/org/sopt/confeti/domain/music/song/application/SongMusicAPIService.java
+++ b/src/main/java/org/sopt/confeti/domain/music/song/application/SongMusicAPIService.java
@@ -82,19 +82,30 @@ public class SongMusicAPIService extends MusicAPIService<ConfetiSong> {
     }
 
     public List<ConfetiSong> getPopularSongsByArtist(String artistId, int limit) {
-        List<ConfetiSong> songs;
+        List<ConfetiSong> songs = safeGetArtistTopSongs(artistId, limit);
+        if (songs.isEmpty()) {
+            return List.of();
+        }
+
+        safePersistAndCacheMissingSongs(artistId, songs);
+        return songs;
+    }
+
+    private List<ConfetiSong> safeGetArtistTopSongs(String artistId, int limit) {
         try {
-            songs = musicAPIHandler.getArtistTopSongs(artistId, limit);
+            List<ConfetiSong> songs = musicAPIHandler.getArtistTopSongs(artistId, limit);
+            if (songs == null || songs.isEmpty()) {
+                return List.of();
+            }
+            return songs;
         } catch (Exception ex) {
             log.warn("SongMusicAPIService.getPopularSongsByArtist failed. artistId: {}, message: {}",
                 artistId, ex.getMessage());
             return List.of();
         }
+    }
 
-        if (songs == null || songs.isEmpty()) {
-            return List.of();
-        }
-
+    private void safePersistAndCacheMissingSongs(String artistId, List<ConfetiSong> songs) {
         try {
             Set<String> songIds = songs.stream()
                 .map(ConfetiSong::getId)
@@ -102,14 +113,14 @@ public class SongMusicAPIService extends MusicAPIService<ConfetiSong> {
             CacheResult<ConfetiSong> cacheResult = getCached(MusicAPICondition.from(songIds));
             Set<String> cachedSongIds = cacheResult.cachedIds();
             if (cachedSongIds.size() == songIds.size()) {
-                return songs;
+                return;
             }
 
             List<ConfetiSong> missingSongs = songs.stream()
                 .filter(song -> !cachedSongIds.contains(song.getId()))
                 .toList();
             if (missingSongs.isEmpty()) {
-                return songs;
+                return;
             }
 
             persist(missingSongs);
@@ -117,9 +128,6 @@ public class SongMusicAPIService extends MusicAPIService<ConfetiSong> {
         } catch (Exception ex) {
             log.warn("SongMusicAPIService.getPopularSongsByArtist cache/persist failed. artistId: {}, message: {}",
                 artistId, ex.getMessage());
-            return songs;
         }
-
-        return songs;
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/music/song/application/SongMusicAPIService.java
+++ b/src/main/java/org/sopt/confeti/domain/music/song/application/SongMusicAPIService.java
@@ -78,4 +78,32 @@ public class SongMusicAPIService extends MusicAPIService<ConfetiSong> {
 
         return new FetchResult<>(fetchedSongs);
     }
+
+    public List<ConfetiSong> getPopularSongsByArtist(String artistId, int limit) {
+        List<ConfetiSong> songs = musicAPIHandler.getArtistTopSongs(artistId, limit);
+        if (songs.isEmpty()) {
+            return List.of();
+        }
+
+        Set<String> songIds = songs.stream()
+            .map(ConfetiSong::getId)
+            .collect(Collectors.toSet());
+        CacheResult<ConfetiSong> cacheResult = getCached(MusicAPICondition.from(songIds));
+        Set<String> cachedSongIds = cacheResult.cachedIds();
+        if (cachedSongIds.size() == songIds.size()) {
+            return songs;
+        }
+
+        List<ConfetiSong> missingSongs = songs.stream()
+            .filter(song -> !cachedSongIds.contains(song.getId()))
+            .toList();
+        if (missingSongs.isEmpty()) {
+            return songs;
+        }
+
+        persist(missingSongs);
+        cache(missingSongs);
+
+        return songs;
+    }
 }


### PR DESCRIPTION
## 🔊 Summaries

- 기존 /search 응답에 아티스트가 포함될 때 songs 리스트가 같이 내려오도록 확장했요. 새 엔드포인트 추가는 없고, 응답 구조에만 songs 필드가 하나 더 붙는 형태로 이해했어요

- SearchFacade에서 아티스트가 있을 때 SongMusicAPIService로 인기 song 3개 조회해서 DTO로 매핑해주도록 연결했어요. (aid/term 흐름 둘 다)

- 노래 응답을 위해 SearchResultSongDTO랑 SearchResultSongResponse 새로 만들고 기존 SearchResultDTO/Response에 songs 필드 추가했어요

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
