### PR TITLE
CSERVER-12 (어드민) 페스티벌 등록/수정 API 구현

### DIFF
--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -10,8 +10,9 @@ import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.admin.controller.docs.AdminControllerDocs;
 import org.sopt.confeti.api.admin.dto.request.CreatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
-import org.sopt.confeti.api.admin.dto.request.UpdatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.PutAdminConcertRequest;
+import org.sopt.confeti.api.admin.dto.request.PutAdminFestivalRequest;
+import org.sopt.confeti.api.admin.dto.request.UpdatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.response.AdminArtistSearchResponses;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
@@ -22,10 +23,12 @@ import org.sopt.confeti.api.admin.dto.response.PerformanceDraftDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftListResponses;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.PutAdminConcertResponse;
+import org.sopt.confeti.api.admin.dto.response.PutAdminFestivalResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponses;
 import org.sopt.confeti.api.admin.facade.AdminFacade;
 import org.sopt.confeti.api.admin.facade.dto.request.AdminConcertCommand;
+import org.sopt.confeti.api.admin.facade.dto.request.AdminFestivalCommand;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalDetailInfo;
@@ -117,11 +120,12 @@ public class AdminController implements AdminControllerDocs {
     public ResponseEntity<BaseResponse<PerformanceDraftResponse>> createPerformanceDraft(
         @ModelAttribute CreatePerformanceDraftRequest request
     ) {
-        PerformanceDraftDto performanceDraftDto = adminFacade.createPerformanceDraft(request.toCreateManualDto());
+        PerformanceDraftDto performanceDraftDto = adminFacade.createPerformanceDraft(
+            request.toCreateManualDto());
         return ApiResponseUtil.success(
             SuccessMessage.CREATED,
             PerformanceDraftResponse.from(performanceDraftDto, s3FileHandler)
-        );  
+        );
     }
 
     @Override
@@ -131,7 +135,8 @@ public class AdminController implements AdminControllerDocs {
     ) {
         return ApiResponseUtil.success(
             SuccessMessage.SUCCESS,
-            PerformanceDraftDetailResponse.from(adminFacade.getPerformanceDraftDetail(draftId), s3FileHandler)
+            PerformanceDraftDetailResponse.from(adminFacade.getPerformanceDraftDetail(draftId),
+                s3FileHandler)
         );
     }
 
@@ -141,7 +146,8 @@ public class AdminController implements AdminControllerDocs {
         @PathVariable Long draftId,
         @ModelAttribute UpdatePerformanceDraftRequest request
     ) {
-        PerformanceDraftDto performanceDraftDto = adminFacade.updatePerformanceDraft(request.toUpdateDto(draftId));
+        PerformanceDraftDto performanceDraftDto = adminFacade.updatePerformanceDraft(
+            request.toUpdateDto(draftId));
         return ApiResponseUtil.success(
             SuccessMessage.UPDATED,
             PerformanceDraftResponse.from(performanceDraftDto, s3FileHandler)
@@ -205,6 +211,22 @@ public class AdminController implements AdminControllerDocs {
         return ApiResponseUtil.success(
             command.concertId() == null ? SuccessMessage.CREATED : SuccessMessage.SUCCESS,
             adminFacade.upsertConcert(poster, command)
+        );
+    }
+
+    @Override
+    @PutMapping(value = "/performances/festivals", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ResponseEntity<BaseResponse<PutAdminFestivalResponse>> upsertFestival(
+        @RequestPart(required = false) MultipartFile poster,
+        @RequestPart(required = false) MultipartFile logo,
+        @Valid @RequestPart(value = "festival") PutAdminFestivalRequest request
+    ) {
+        request.validate();
+
+        AdminFestivalCommand command = request.toCommand();
+        return ApiResponseUtil.success(
+            command.festivalId() == null ? SuccessMessage.CREATED : SuccessMessage.SUCCESS,
+            adminFacade.upsertFestival(poster, logo, command)
         );
     }
 

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -14,6 +14,7 @@ import org.sopt.confeti.api.admin.dto.request.CreatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdatePerformanceDraftRequest;
 import org.sopt.confeti.api.admin.dto.request.PutAdminConcertRequest;
+import org.sopt.confeti.api.admin.dto.request.PutAdminFestivalRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.response.AdminArtistSearchResponses;
 import org.sopt.confeti.api.admin.dto.response.AdminConcertDetailResponse;
@@ -24,6 +25,7 @@ import org.sopt.confeti.api.admin.dto.response.PerformanceDraftDetailResponse;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftListResponses;
 import org.sopt.confeti.api.admin.dto.response.PerformanceDraftResponse;
 import org.sopt.confeti.api.admin.dto.response.PutAdminConcertResponse;
+import org.sopt.confeti.api.admin.dto.response.PutAdminFestivalResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponses;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
@@ -393,6 +395,29 @@ public interface AdminControllerDocs {
     ResponseEntity<BaseResponse<PutAdminConcertResponse>> upsertConcert(
         @RequestPart MultipartFile poster,
         @Valid @RequestPart(value = "concert") PutAdminConcertRequest request
+    );
+
+    @Operation(
+        summary = "페스티벌 등록/수정",
+        description = "페스티벌을 등록하거나 수정합니다. "
+            + "festivalId가 null이면 신규 등록, 값이 있으면 기존 페스티벌을 수정합니다. "
+            + "포스터 이미지는 'poster' 파트, 로고 이미지는 'logo' 파트로, "
+            + "나머지 데이터는 'festival' 파트(application/json)로 전송합니다."
+    )
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<PutAdminFestivalResponse>> upsertFestival(
+        @RequestPart(required = false) MultipartFile poster,
+        @RequestPart(required = false) MultipartFile logo,
+        @Valid @RequestPart(value = "festival") PutAdminFestivalRequest request
     );
 
     @Operation(summary = "아티스트 검색")

--- a/src/main/java/org/sopt/confeti/api/admin/dto/request/PutAdminFestivalRequest.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/request/PutAdminFestivalRequest.java
@@ -7,6 +7,7 @@ import jakarta.validation.constraints.NotNull;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -135,6 +136,7 @@ public record PutAdminFestivalRequest(
     }
 
     private void validateArtistTimetableMapping() {
+        Set<String> targetArtistIds = new HashSet<>(artistIds);
         Set<String> timetableArtistIds = dates.stream()
             .filter(date -> date.stages() != null)
             .flatMap(date -> date.stages().stream())
@@ -142,9 +144,15 @@ public record PutAdminFestivalRequest(
             .flatMap(time -> time.artistIds().stream())
             .collect(Collectors.toSet());
 
-        if (!timetableArtistIds.containsAll(artistIds)) {
+        if (!timetableArtistIds.containsAll(targetArtistIds)) {
             log.warn(
                 "PutAdminFestivalRequest.validateArtistTimetableMapping : 모든 아티스트가 타임테이블에 배정되어야 합니다.");
+            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+        }
+
+        if (!targetArtistIds.containsAll(timetableArtistIds)) {
+            log.warn(
+                "PutAdminFestivalRequest.validateArtistTimetableMapping : 타임테이블의 모든 아티스트가 선택되어야 합니다.");
             throw new BadRequestException(ErrorMessage.BAD_REQUEST);
         }
     }

--- a/src/main/java/org/sopt/confeti/api/admin/dto/request/PutAdminFestivalRequest.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/request/PutAdminFestivalRequest.java
@@ -1,0 +1,202 @@
+package org.sopt.confeti.api.admin.dto.request;
+
+import jakarta.validation.Valid;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.api.admin.facade.dto.request.AdminFestivalCommand;
+import org.sopt.confeti.domain.festival.infra.TimetableSupportStatus;
+import org.sopt.confeti.global.exception.BadRequestException;
+import org.sopt.confeti.global.exception.ParameterInvalidException;
+import org.sopt.confeti.global.message.ErrorMessage;
+
+@Slf4j
+public record PutAdminFestivalRequest(
+    Long festivalId,
+    @NotBlank String title,
+    @NotBlank String subtitle,
+    @NotNull LocalDate startAt,
+    @NotNull LocalDate endAt,
+    @NotBlank String area,
+    @NotNull LocalDateTime reserveAt,
+    @NotBlank String ageRating,
+    @NotBlank String time,
+    @NotBlank String price,
+    @NotBlank String address,
+    @NotNull @Valid List<ReservationUrlRequest> reservationUrls,
+    List<String> artistIds,
+    List<@Valid DateRequest> dates
+) {
+
+    public AdminFestivalCommand toCommand() {
+        TimetableSupportStatus status = hasTimetableInfo()
+            ? TimetableSupportStatus.SUPPORTED
+            : TimetableSupportStatus.NOT_SUPPORTED;
+
+        return AdminFestivalCommand.of(
+            festivalId, title, subtitle, startAt, endAt, area,
+            reserveAt, ageRating, time, price, address, status,
+            reservationUrls.stream()
+                .map(url -> AdminFestivalCommand.ReservationUrlCommand.of(
+                    url.ticketVendorId(), url.reservationUrl()))
+                .toList(),
+            artistIds,
+            dates != null
+                ? dates.stream().map(this::toDateCommand).toList()
+                : List.of()
+        );
+    }
+
+    private AdminFestivalCommand.DateCommand toDateCommand(DateRequest date) {
+        return AdminFestivalCommand.DateCommand.of(
+            date.festivalDateId(), date.festivalAt(), date.openAt(),
+            date.stages() != null
+                ? date.stages().stream().map(this::toStageCommand).toList()
+                : List.of()
+        );
+    }
+
+    private AdminFestivalCommand.StageCommand toStageCommand(StageRequest stage) {
+        return AdminFestivalCommand.StageCommand.of(
+            stage.festivalStageId(), stage.name(), stage.order(),
+            stage.times().stream().map(this::toTimeCommand).toList()
+        );
+    }
+
+    private AdminFestivalCommand.TimeCommand toTimeCommand(TimeRequest time) {
+        return AdminFestivalCommand.TimeCommand.of(
+            time.festivalTimeId(), time.startAt(), time.endAt(),
+            time.name(), time.artistIds()
+        );
+    }
+
+    public void validate() {
+        validateDuration();
+        validateReserveDate();
+
+        if (hasTimetableInfo()) {
+            validateTimetableDuration();
+            validateTimetableRequiresArtists();
+            validateArtistTimetableMapping();
+        }
+    }
+
+    private void validateDuration() {
+        if (startAt.isAfter(endAt)) {
+            log.warn("PutAdminFestivalRequest.validateDuration : 시작 날짜는 끝 날짜보다 작거나 같아야 합니다.");
+            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+        }
+    }
+
+    private void validateReserveDate() {
+        if (!reserveAt.isBefore(startAt.atStartOfDay())) {
+            log.warn("PutAdminFestivalRequest.validateReserveDate : 예약 일자는 시작 날짜보다 작아야 합니다.");
+            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+        }
+    }
+
+    private void validateTimetableDuration() {
+        if (dates.isEmpty()) {
+            log.warn(
+                "PutAdminFestivalRequest.validateTimetableDuration : 타임테이블을 등록하려면 날짜 정보가 있어야 합니다.");
+            throw new ParameterInvalidException(ErrorMessage.BAD_REQUEST);
+        }
+
+        LocalDate startDate = dates.stream().findFirst().get().festivalAt();
+        LocalDate endDate = dates.stream().findFirst().get().festivalAt();
+
+        for (DateRequest date : dates) {
+            startDate = date.festivalAt.isBefore(startDate) ? date.festivalAt : startDate;
+            endDate = date.festivalAt.isAfter(endDate) ? date.festivalAt : endDate;
+        }
+
+        if (startAt.isAfter(startDate)
+            || endAt.isBefore(endDate)) {
+            log.warn(
+                "PutAdminFestivalRequest.validateTimetableDuration : 타임테이블의 날짜는 페스티벌의 공연 기간 안으로 지정해야합니다. 공연 기간 : {} ~ {}, 타임테이블 지정 날짜 : {} ~ {}",
+                startAt, endAt, startDate, endDate);
+            throw new ParameterInvalidException(ErrorMessage.BAD_REQUEST);
+        }
+    }
+
+    private void validateTimetableRequiresArtists() {
+        if (artistIds == null || artistIds.isEmpty()) {
+            log.warn(
+                "PutAdminFestivalRequest.validateTimetableRequiresArtists : 타임테이블이 존재하면 아티스트 목록이 필요합니다.");
+            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+        }
+    }
+
+    private void validateArtistTimetableMapping() {
+        Set<String> timetableArtistIds = dates.stream()
+            .filter(date -> date.stages() != null)
+            .flatMap(date -> date.stages().stream())
+            .flatMap(stage -> stage.times().stream())
+            .flatMap(time -> time.artistIds().stream())
+            .collect(Collectors.toSet());
+
+        if (!timetableArtistIds.containsAll(artistIds)) {
+            log.warn(
+                "PutAdminFestivalRequest.validateArtistTimetableMapping : 모든 아티스트가 타임테이블에 배정되어야 합니다.");
+            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+        }
+    }
+
+    private boolean hasTimetableInfo() {
+        if (dates == null || dates.isEmpty()) {
+            return false;
+        }
+
+        boolean hasStageInfo = dates.stream()
+            .anyMatch(date -> date.stages() != null && !date.stages.isEmpty());
+
+        if (!hasStageInfo) {
+            log.warn("PutAdminFestivalRequest.hasTimetableInfo : 타임테이블 등록을 위해서 스테이지 정보까지 있어야 합니다.");
+            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+        }
+
+        return true;
+    }
+
+    public record ReservationUrlRequest(
+        @NotNull Long ticketVendorId,
+        @NotBlank String reservationUrl
+    ) {
+
+    }
+
+    public record DateRequest(
+        Long festivalDateId,
+        @NotNull LocalDate festivalAt,
+        @NotNull LocalTime openAt,
+        List<@Valid StageRequest> stages
+    ) {
+
+    }
+
+    public record StageRequest(
+        Long festivalStageId,
+        @NotBlank String name,
+        @NotNull Integer order,
+        @NotEmpty List<@Valid TimeRequest> times
+    ) {
+
+    }
+
+    public record TimeRequest(
+        Long festivalTimeId,
+        @NotNull LocalTime startAt,
+        @NotNull LocalTime endAt,
+        String name,
+        @NotEmpty List<@NotBlank String> artistIds
+    ) {
+
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PutAdminFestivalResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PutAdminFestivalResponse.java
@@ -1,0 +1,8 @@
+package org.sopt.confeti.api.admin.dto.response;
+
+public record PutAdminFestivalResponse(long festivalId) {
+
+    public static PutAdminFestivalResponse from(long festivalId) {
+        return new PutAdminFestivalResponse(festivalId);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -1,7 +1,6 @@
 package org.sopt.confeti.api.admin.facade;
 
 import java.time.LocalDate;
-import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
@@ -64,6 +63,7 @@ import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 import org.sopt.confeti.global.event.S3FileDeleteEvent;
 import org.sopt.confeti.global.exception.BadRequestException;
+import org.sopt.confeti.global.exception.ParameterInvalidException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.transaction.Tx;
@@ -487,12 +487,20 @@ public class AdminFacade {
         MultipartFile poster, MultipartFile logo, AdminFestivalCommand command,
         String posterFolderPath, String logoFolderPath
     ) {
+        if (poster == null || logo == null) {
+            log.warn("AdminFacade.createFestivalWithFileUpload : 포스터와 로고 파일은 필수 입니다.");
+            throw new ParameterInvalidException(ErrorMessage.BAD_REQUEST);
+        }
+
         String posterPath = s3FileHandler.uploadFile(poster, posterFolderPath);
 
         String logoPath;
         try {
             logoPath = s3FileHandler.uploadFile(logo, logoFolderPath);
         } catch (Exception e) {
+            log.warn(
+                "AdminFacade.createFestivalWithFileUpload : 로고 파일 업로드 도중 에러가 발생해 롤백합니다. Festival Create Command : {}",
+                command);
             s3FileHandler.deleteFile(posterFolderPath, posterPath);
             throw e;
         }
@@ -646,6 +654,13 @@ public class AdminFacade {
         for (AdminFestivalCommand.DateCommand dateCmd : dateCommands) {
             if (dateCmd.festivalDateId() != null) { // 수정
                 FestivalDate existingDate = existingDatesMap.get(dateCmd.festivalDateId());
+
+                if (existingDate == null) {
+                    log.warn("AdminFacade.updateFestivalDates : 존재하지 않는 날짜입니다. 입력된 아이디 : {}",
+                        dateCmd.festivalDateId());
+                    throw new ParameterInvalidException(ErrorMessage.BAD_REQUEST);
+                }
+
                 existingDate.update(dateCmd.festivalAt(), dateCmd.openAt());
                 updateFestivalStages(existingDate, dateCmd, artistNameMap);
 
@@ -679,6 +694,13 @@ public class AdminFacade {
         for (AdminFestivalCommand.StageCommand stageCmd : stageCommands) {
             if (stageCmd.festivalStageId() != null) { // 수정
                 FestivalStage existingStage = existingStagesMap.get(stageCmd.festivalStageId());
+
+                if (existingStage == null) {
+                    log.warn("AdminFacade.updateFestivalStages : 존재하지 않는 스테이지입니다. 입력된 아이디 : {}",
+                        stageCmd.festivalStageId());
+                    throw new ParameterInvalidException(ErrorMessage.BAD_REQUEST);
+                }
+
                 existingStage.update(stageCmd.name(), stageCmd.order());
                 updateFestivalTimes(existingStage, stageCmd, artistNameMap);
             } else { // 생성
@@ -710,6 +732,13 @@ public class AdminFacade {
 
             if (timeCmd.festivalTimeId() != null) { // 수정
                 FestivalTime existingTime = existingTimesMap.get(timeCmd.festivalTimeId());
+
+                if (existingTime == null) {
+                    log.warn("AdminFacade.updateFestivalTimes : 존재하지 않는 시간 블록입니다. 입력된 아이디 : {}",
+                        timeCmd.festivalTimeId());
+                    throw new ParameterInvalidException(ErrorMessage.BAD_REQUEST);
+                }
+
                 existingTime.update(timeName, timeCmd.startAt(), timeCmd.endAt(), newArtists);
             } else { // 생성
                 FestivalTime newTime = FestivalTime.create(
@@ -772,7 +801,7 @@ public class AdminFacade {
     private List<FestivalDate> buildFestivalDates(AdminFestivalCommand command,
         Map<String, String> artistNameMap) {
         if (command.dates().isEmpty()) {
-            return new ArrayList<>();
+            return List.of();
         }
 
         return command.dates().stream()
@@ -788,7 +817,7 @@ public class AdminFacade {
     private List<FestivalStage> buildFestivalStages(
         AdminFestivalCommand.DateCommand dateCmd, Map<String, String> artistNameMap) {
         if (dateCmd.stages().isEmpty()) {
-            return new ArrayList<>();
+            return List.of();
         }
 
         return dateCmd.stages().stream()
@@ -831,7 +860,7 @@ public class AdminFacade {
     private List<PerformanceArtist> buildFestivalPerformanceArtists(
         AdminFestivalCommand command) {
         if (command.artistIds() == null || command.artistIds().isEmpty()) {
-            return new ArrayList<>();
+            return List.of();
         }
 
         return command.artistIds().stream()

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -1,11 +1,12 @@
 package org.sopt.confeti.api.admin.facade;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.time.LocalDate;
+import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -15,9 +16,11 @@ import org.sopt.confeti.api.admin.dto.request.CreateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.request.UpdateTicketVendorRequest;
 import org.sopt.confeti.api.admin.dto.response.AdminArtistSearchResponses;
 import org.sopt.confeti.api.admin.dto.response.PutAdminConcertResponse;
+import org.sopt.confeti.api.admin.dto.response.PutAdminFestivalResponse;
 import org.sopt.confeti.api.admin.dto.response.TicketVendorResponse;
 import org.sopt.confeti.api.admin.facade.dto.request.AdminConcertCommand;
 import org.sopt.confeti.api.admin.facade.dto.request.AdminConcertCommand.ReservationUrl;
+import org.sopt.confeti.api.admin.facade.dto.request.AdminFestivalCommand;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo.ConcertInfo;
@@ -25,22 +28,27 @@ import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalPreviewInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.PerformanceDraftDetailInfo;
+import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.application.ConcertService;
 import org.sopt.confeti.domain.concert.application.dto.ConcertPreviewInfo;
+import org.sopt.confeti.domain.concert_artist.ConcertArtist;
+import org.sopt.confeti.domain.concert_reservation_url.ConcertReservationUrl;
+import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.festival_artist.FestivalArtist;
+import org.sopt.confeti.domain.festival_date.FestivalDate;
+import org.sopt.confeti.domain.festival_reservation_url.FestivalReservationUrl;
+import org.sopt.confeti.domain.festival_stage.FestivalStage;
+import org.sopt.confeti.domain.festival_time.FestivalTime;
 import org.sopt.confeti.domain.music.artist.Artist;
 import org.sopt.confeti.domain.music.artist.application.ArtistService;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
-import org.sopt.confeti.domain.performancedraft.PerformanceDraftType;
 import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftParser;
 import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftService;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDtos;
-import org.sopt.confeti.domain.concert.Concert;
-import org.sopt.confeti.domain.concert_artist.ConcertArtist;
-import org.sopt.confeti.domain.concert_reservation_url.ConcertReservationUrl;
 import org.sopt.confeti.domain.ticketvendor.TicketVendor;
 import org.sopt.confeti.domain.ticketvendor.application.TicketVendorService;
 import org.sopt.confeti.domain.ticketvendor.application.dto.request.TicketVendorCreateDto;
@@ -54,13 +62,13 @@ import org.sopt.confeti.domain.view.performance.application.PerformanceService;
 import org.sopt.confeti.global.annotation.Facade;
 import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.event.S3FileDeleteEvent;
 import org.sopt.confeti.global.exception.BadRequestException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.transaction.Tx;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
-import org.sopt.confeti.global.event.S3FileDeleteEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.web.multipart.MultipartFile;
 
@@ -187,20 +195,27 @@ public class AdminFacade {
         String logoPath = null;
 
         try {
-            posterPath = s3FileHandler.uploadFile(dto.posterImage(), FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER));
+            posterPath = s3FileHandler.uploadFile(dto.posterImage(),
+                FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER));
             logoPath = dto.getOptionalLogoImage()
-                .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
+                .map(image -> s3FileHandler.uploadFile(image,
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
                 .orElse(null);
 
             return performanceDraftService.createDraft(dto, posterPath, logoPath);
         } catch (Exception e) {
-            log.warn("AdminFacade.createPerformanceDraft : 공연 초안 생성에 실패해 업로드했던 이미지 파일을 롤백합니다. posterPath : {}, logoPath : {}", posterPath, logoPath);
-            
+            log.warn(
+                "AdminFacade.createPerformanceDraft : 공연 초안 생성에 실패해 업로드했던 이미지 파일을 롤백합니다. posterPath : {}, logoPath : {}",
+                posterPath, logoPath);
+
             if (posterPath != null) {
-                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), posterPath);
+                s3FileHandler.deleteFile(
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER),
+                    posterPath);
             }
             if (logoPath != null) {
-                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), logoPath);
+                s3FileHandler.deleteFile(
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), logoPath);
             }
             throw e;
         }
@@ -213,9 +228,11 @@ public class AdminFacade {
     public void deletePerformanceDraft(Long draftId) {
         PerformanceDraft draft = Tx.readOnlyTx(() -> performanceDraftService.getById(draftId));
         Optional.ofNullable(draft.getPosterPath())
-                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path));
+            .ifPresent(path -> s3FileHandler.deleteFile(
+                FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path));
         Optional.ofNullable(draft.getLogoPath())
-                .ifPresent(path -> s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path));
+            .ifPresent(path -> s3FileHandler.deleteFile(
+                FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path));
         Tx.masterTx(() -> performanceDraftService.deleteDraft(draftId));
     }
 
@@ -223,11 +240,12 @@ public class AdminFacade {
         PerformanceDraft draft = Tx.readOnlyTx(() -> performanceDraftService.getById(draftId));
         PerformanceDraftDto dto = PerformanceDraftDto.from(draft);
 
-        Set<String> artistIds = performanceDraftParser.parseArtistIds(dto.performanceDraftType(), dto.performanceData());
+        Set<String> artistIds = performanceDraftParser.parseArtistIds(dto.performanceDraftType(),
+            dto.performanceData());
         List<ConfetiArtist> artists = Tx.readOnlyTx(() -> artistService.getArtists(artistIds))
-                .stream()
-                .map(Artist::toDomain)
-                .toList();
+            .stream()
+            .map(Artist::toDomain)
+            .toList();
 
         return new PerformanceDraftDetailInfo(dto, artists);
     }
@@ -236,35 +254,47 @@ public class AdminFacade {
         PerformanceDraft existing = Tx.readOnlyTx(() -> performanceDraftService.getById(dto.id()));
 
         String newPosterPath = dto.getOptionalPosterImage()
-            .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER)))
+            .map(image -> s3FileHandler.uploadFile(image,
+                FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER)))
             .orElse(null);
 
         String newLogoPath = null;
         try {
             newLogoPath = dto.getOptionalLogoImage()
-                .map(image -> s3FileHandler.uploadFile(image, FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
+                .map(image -> s3FileHandler.uploadFile(image,
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO)))
                 .orElse(null);
         } catch (Exception e) {
-            log.warn("AdminFacade.updatePerformanceDraft : logo 업로드에 실패해 업로드했던 poster 파일을 롤백합니다. newPosterPath : {}", newPosterPath);
+            log.warn(
+                "AdminFacade.updatePerformanceDraft : logo 업로드에 실패해 업로드했던 poster 파일을 롤백합니다. newPosterPath : {}",
+                newPosterPath);
             if (newPosterPath != null) {
-                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), newPosterPath);
+                s3FileHandler.deleteFile(
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER),
+                    newPosterPath);
             }
             throw e;
         }
 
-        final String finalPosterPath = newPosterPath != null ? newPosterPath : existing.getPosterPath();
+        final String finalPosterPath =
+            newPosterPath != null ? newPosterPath : existing.getPosterPath();
         final String finalLogoPath = newLogoPath != null ? newLogoPath : existing.getLogoPath();
 
         PerformanceDraftDto result;
         try {
-            result = Tx.masterTx(() -> performanceDraftService.updateDraft(dto, finalPosterPath, finalLogoPath));
+            result = Tx.masterTx(
+                () -> performanceDraftService.updateDraft(dto, finalPosterPath, finalLogoPath));
         } catch (Exception e) {
-            log.warn("AdminFacade.updatePerformanceDraft : 공연 초안 수정(DB)에 실패해 업로드했던 새 이미지 파일을 롤백합니다.");
+            log.warn(
+                "AdminFacade.updatePerformanceDraft : 공연 초안 수정(DB)에 실패해 업로드했던 새 이미지 파일을 롤백합니다.");
             if (newPosterPath != null) {
-                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), newPosterPath);
+                s3FileHandler.deleteFile(
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER),
+                    newPosterPath);
             }
             if (newLogoPath != null) {
-                s3FileHandler.deleteFile(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), newLogoPath);
+                s3FileHandler.deleteFile(
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), newLogoPath);
             }
             throw e;
         }
@@ -272,12 +302,16 @@ public class AdminFacade {
         Optional.ofNullable(newPosterPath)
             .filter(path -> existing.getPosterPath() != null)
             .ifPresent(path -> eventPublisher.publishEvent(
-                new S3FileDeleteEvent(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), existing.getPosterPath())
+                new S3FileDeleteEvent(
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER),
+                    existing.getPosterPath())
             ));
         Optional.ofNullable(newLogoPath)
             .filter(path -> existing.getLogoPath() != null)
             .ifPresent(path -> eventPublisher.publishEvent(
-                new S3FileDeleteEvent(FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), existing.getLogoPath())
+                new S3FileDeleteEvent(
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO),
+                    existing.getLogoPath())
             ));
 
         return result;
@@ -427,6 +461,379 @@ public class AdminFacade {
     }
 
     private List<PerformanceArtist> buildPerformanceArtists(AdminConcertCommand command) {
+        return command.artistIds().stream()
+            .map(PerformanceArtist::create)
+            .toList();
+    }
+
+    public PutAdminFestivalResponse upsertFestival(MultipartFile poster, MultipartFile logo,
+        AdminFestivalCommand command) {
+        String posterFolderPath = FolderPath.combine(FolderPath.FESTIVAL, FolderPath.POSTER);
+        String logoFolderPath = FolderPath.combine(FolderPath.FESTIVAL, FolderPath.LOGO);
+
+        if (command.artistIds() != null && !command.artistIds().isEmpty()) {
+            ensureArtistsExist(new HashSet<>(command.artistIds()));
+        }
+
+        if (command.festivalId() == null) {
+            return createFestivalWithFileUpload(poster, logo, command, posterFolderPath,
+                logoFolderPath);
+        }
+        return updateFestivalWithFileUpload(poster, logo, command, posterFolderPath,
+            logoFolderPath);
+    }
+
+    private PutAdminFestivalResponse createFestivalWithFileUpload(
+        MultipartFile poster, MultipartFile logo, AdminFestivalCommand command,
+        String posterFolderPath, String logoFolderPath
+    ) {
+        String posterPath = s3FileHandler.uploadFile(poster, posterFolderPath);
+
+        String logoPath;
+        try {
+            logoPath = s3FileHandler.uploadFile(logo, logoFolderPath);
+        } catch (Exception e) {
+            s3FileHandler.deleteFile(posterFolderPath, posterPath);
+            throw e;
+        }
+
+        try {
+            long festivalId = createFestival(command, posterPath, logoPath);
+            return PutAdminFestivalResponse.from(festivalId);
+        } catch (Exception e) {
+            s3FileHandler.deleteFile(posterFolderPath, posterPath);
+            s3FileHandler.deleteFile(logoFolderPath, logoPath);
+            throw e;
+        }
+    }
+
+    private PutAdminFestivalResponse updateFestivalWithFileUpload(
+        MultipartFile poster, MultipartFile logo, AdminFestivalCommand command,
+        String posterFolderPath, String logoFolderPath
+    ) {
+        Festival festival = Tx.readOnlyTx(
+            () -> festivalService.getWithRelationsById(command.festivalId()));
+
+        boolean hasPoster = poster != null && !poster.isEmpty();
+        boolean hasLogo = logo != null && !logo.isEmpty();
+
+        String oldPosterPath = festival.getPosterPath();
+        String oldLogoPath = festival.getLogoPath();
+
+        String posterPath = oldPosterPath;
+        String logoPath = oldLogoPath;
+
+        if (hasPoster) {
+            posterPath = s3FileHandler.uploadFile(poster, posterFolderPath);
+        }
+
+        if (hasLogo) {
+            try {
+                logoPath = s3FileHandler.uploadFile(logo, logoFolderPath);
+            } catch (Exception e) {
+                if (hasPoster) {
+                    log.warn(
+                        "AdminFacade.upsertFestivalForUpdate : 로고 업로드에 실패해 업로드했던 포스터 파일을 롤백합니다. Folder Path : {}, File Name : {}",
+                        posterFolderPath, posterPath);
+                    s3FileHandler.deleteFile(posterFolderPath, posterPath);
+                }
+                throw e;
+            }
+        }
+
+        final String finalPosterPath = posterPath;
+        final String finalLogoPath = logoPath;
+
+        try {
+            long festivalId = updateFestival(command, finalPosterPath, finalLogoPath);
+
+            // 트랜잭션 커밋 성공 후 기존 S3 파일 삭제
+            if (hasPoster && oldPosterPath != null) {
+                s3FileHandler.deleteFile(posterFolderPath, oldPosterPath);
+            }
+            if (hasLogo && oldLogoPath != null) {
+                s3FileHandler.deleteFile(logoFolderPath, oldLogoPath);
+            }
+
+            return PutAdminFestivalResponse.from(festivalId);
+        } catch (Exception e) {
+            log.warn(
+                "AdminFacade.upsertFestivalForUpdate : 페스티벌 수정에 실패해 업로드했던 이미지 파일을 롤백합니다. Poster Folder Path : {}, Poster File Name : {}, Logo Folder Path : {}, Logo File Name : {}",
+                posterFolderPath, finalPosterPath, logoFolderPath, finalLogoPath);
+            if (hasPoster) {
+                s3FileHandler.deleteFile(posterFolderPath, finalPosterPath);
+            }
+            if (hasLogo) {
+                s3FileHandler.deleteFile(logoFolderPath, finalLogoPath);
+            }
+            throw e;
+        }
+    }
+
+    private long createFestival(AdminFestivalCommand command, String posterPath, String logoPath) {
+        return Tx.masterTx(() -> {
+            Map<Long, TicketVendor> vendorMap = getTicketVendorMapForFestival(command);
+            Map<String, String> artistNameMap = buildArtistNameMap(command);
+
+            List<FestivalDate> dates = buildFestivalDates(command, artistNameMap);
+            List<FestivalReservationUrl> reservationUrls = buildFestivalReservationUrls(
+                command, vendorMap);
+
+            Festival festival = Festival.create(
+                command.title(), command.subtitle(), command.startAt(), command.endAt(),
+                command.area(), posterPath, logoPath, command.reserveAt(),
+                command.ageRating(), command.time(), command.price(), command.address(),
+                command.timetableSupportStatus(), dates, reservationUrls
+            );
+            long festivalId = festivalService.create(festival);
+
+            List<PerformanceArtist> performanceArtists = buildFestivalPerformanceArtists(command);
+            Performance performance = Performance.create(
+                festivalId, command, posterPath, performanceArtists);
+            performanceService.create(performance);
+
+            return festivalId;
+        });
+    }
+
+    private long updateFestival(AdminFestivalCommand command, String posterPath, String logoPath) {
+        return Tx.masterTx(() -> {
+            Map<Long, TicketVendor> vendorMap = getTicketVendorMapForFestival(command);
+            Map<String, String> artistNameMap = buildArtistNameMap(command);
+
+            Festival festival = festivalService.getWithRelationsById(command.festivalId());
+
+            festival.updateBasicFields(
+                command.title(), command.subtitle(), command.startAt(), command.endAt(),
+                command.area(), posterPath, logoPath, command.reserveAt(),
+                command.ageRating(), command.time(), command.price(), command.address(),
+                command.timetableSupportStatus()
+            );
+
+            updateFestivalDates(festival, command, artistNameMap);
+
+            List<FestivalReservationUrl> newReservationUrls = buildFestivalReservationUrls(
+                command, vendorMap);
+            festival.replaceReservationUrls(newReservationUrls);
+
+            List<PerformanceArtist> performanceArtists = buildFestivalPerformanceArtists(command);
+            Performance performance = performanceService.getWithArtistsByTypeAndTypeId(
+                PerformanceType.FESTIVAL, command.festivalId());
+            performance.update(
+                command.title(), command.subtitle(), command.area(),
+                command.startAt(), command.endAt(), posterPath,
+                performanceArtists
+            );
+
+            return command.festivalId();
+        });
+    }
+
+    private void updateFestivalDates(Festival festival, AdminFestivalCommand command,
+        Map<String, String> artistNameMap) {
+        List<AdminFestivalCommand.DateCommand> dateCommands = command.dates();
+
+        Map<Long, FestivalDate> existingDatesMap = festival.getDates().stream()
+            .collect(Collectors.toMap(FestivalDate::getId, d -> d));
+
+        Set<Long> requestDateIds = dateCommands.stream()
+            .map(AdminFestivalCommand.DateCommand::festivalDateId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        festival.getDates().removeIf(date -> !requestDateIds.contains(date.getId()));
+
+        for (AdminFestivalCommand.DateCommand dateCmd : dateCommands) {
+            if (dateCmd.festivalDateId() != null) { // 수정
+                FestivalDate existingDate = existingDatesMap.get(dateCmd.festivalDateId());
+                existingDate.update(dateCmd.festivalAt(), dateCmd.openAt());
+                updateFestivalStages(existingDate, dateCmd, artistNameMap);
+
+                List<FestivalArtist> dateArtists = collectArtistsFromStages(
+                    existingDate.getStages());
+                existingDate.replaceArtists(dateArtists);
+            } else { // 생성
+                List<FestivalStage> stages = buildFestivalStages(dateCmd, artistNameMap);
+                List<FestivalArtist> dateArtists = collectArtistsFromStages(stages);
+                FestivalDate newDate = FestivalDate.create(
+                    dateCmd.festivalAt(), dateCmd.openAt(), stages, dateArtists);
+                festival.addDate(newDate);
+            }
+        }
+    }
+
+    private void updateFestivalStages(FestivalDate existingDate,
+        AdminFestivalCommand.DateCommand dateCmd, Map<String, String> artistNameMap) {
+        List<AdminFestivalCommand.StageCommand> stageCommands = dateCmd.stages();
+
+        Map<Long, FestivalStage> existingStagesMap = existingDate.getStages().stream()
+            .collect(Collectors.toMap(FestivalStage::getId, s -> s));
+
+        Set<Long> requestStageIds = stageCommands.stream()
+            .map(AdminFestivalCommand.StageCommand::festivalStageId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        existingDate.getStages().removeIf(stage -> !requestStageIds.contains(stage.getId()));
+
+        for (AdminFestivalCommand.StageCommand stageCmd : stageCommands) {
+            if (stageCmd.festivalStageId() != null) { // 수정
+                FestivalStage existingStage = existingStagesMap.get(stageCmd.festivalStageId());
+                existingStage.update(stageCmd.name(), stageCmd.order());
+                updateFestivalTimes(existingStage, stageCmd, artistNameMap);
+            } else { // 생성
+                FestivalStage newStage = FestivalStage.create(
+                    stageCmd.name(), stageCmd.order(),
+                    buildFestivalTimes(stageCmd, artistNameMap));
+                existingDate.addStage(newStage);
+            }
+        }
+    }
+
+    private void updateFestivalTimes(FestivalStage existingStage,
+        AdminFestivalCommand.StageCommand stageCmd, Map<String, String> artistNameMap) {
+        Map<Long, FestivalTime> existingTimesMap = existingStage.getTimes().stream()
+            .collect(Collectors.toMap(FestivalTime::getId, t -> t));
+
+        Set<Long> requestTimeIds = stageCmd.times().stream()
+            .map(AdminFestivalCommand.TimeCommand::festivalTimeId)
+            .filter(Objects::nonNull)
+            .collect(Collectors.toSet());
+
+        existingStage.getTimes().removeIf(time -> !requestTimeIds.contains(time.getId()));
+
+        for (AdminFestivalCommand.TimeCommand timeCmd : stageCmd.times()) {
+            String timeName = resolveTimeName(timeCmd, artistNameMap);
+            List<FestivalArtist> newArtists = timeCmd.artistIds().stream()
+                .map(FestivalArtist::create)
+                .toList();
+
+            if (timeCmd.festivalTimeId() != null) { // 수정
+                FestivalTime existingTime = existingTimesMap.get(timeCmd.festivalTimeId());
+                existingTime.update(timeName, timeCmd.startAt(), timeCmd.endAt(), newArtists);
+            } else { // 생성
+                FestivalTime newTime = FestivalTime.create(
+                    timeName, timeCmd.startAt(), timeCmd.endAt(), newArtists);
+                existingStage.addTime(newTime);
+            }
+        }
+    }
+
+    private Map<Long, TicketVendor> getTicketVendorMapForFestival(
+        AdminFestivalCommand command) {
+        List<Long> ticketVendorIds = command.reservationUrls().stream()
+            .map(AdminFestivalCommand.ReservationUrlCommand::ticketVendorId)
+            .toList();
+
+        if (ticketVendorIds.isEmpty()) {
+            return Map.of();
+        }
+
+        return ticketVendorService.findAllByIds(ticketVendorIds).stream()
+            .collect(Collectors.toMap(TicketVendor::getId, v -> v));
+    }
+
+    private Map<String, String> buildArtistNameMap(AdminFestivalCommand command) {
+        Set<String> allArtistIds = new HashSet<>();
+
+        if (command.artistIds() != null) {
+            allArtistIds.addAll(command.artistIds());
+        }
+
+        command.dates().stream()
+            .flatMap(date -> date.stages().stream())
+            .flatMap(stage -> stage.times().stream())
+            .flatMap(time -> time.artistIds().stream())
+            .forEach(allArtistIds::add);
+
+        if (allArtistIds.isEmpty()) {
+            return Map.of();
+        }
+
+        List<Artist> artists = artistService.getArtists(allArtistIds);
+        return artists.stream()
+            .collect(Collectors.toMap(
+                Artist::getId,
+                artist -> artist.getName() != null ? artist.getName() : artist.getId()
+            ));
+    }
+
+    private String resolveTimeName(AdminFestivalCommand.TimeCommand timeCmd,
+        Map<String, String> artistNameMap) {
+        if (timeCmd.name() != null && !timeCmd.name().isBlank()) {
+            return timeCmd.name();
+        }
+
+        return timeCmd.artistIds().stream()
+            .map(id -> artistNameMap.getOrDefault(id, id))
+            .collect(Collectors.joining(" & "));
+    }
+
+    private List<FestivalDate> buildFestivalDates(AdminFestivalCommand command,
+        Map<String, String> artistNameMap) {
+        if (command.dates().isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return command.dates().stream()
+            .map(dateCmd -> {
+                List<FestivalStage> stages = buildFestivalStages(dateCmd, artistNameMap);
+                List<FestivalArtist> dateArtists = collectArtistsFromStages(stages);
+                return FestivalDate.create(
+                    dateCmd.festivalAt(), dateCmd.openAt(), stages, dateArtists);
+            })
+            .toList();
+    }
+
+    private List<FestivalStage> buildFestivalStages(
+        AdminFestivalCommand.DateCommand dateCmd, Map<String, String> artistNameMap) {
+        if (dateCmd.stages().isEmpty()) {
+            return new ArrayList<>();
+        }
+
+        return dateCmd.stages().stream()
+            .map(stageCmd -> FestivalStage.create(
+                stageCmd.name(), stageCmd.order(),
+                buildFestivalTimes(stageCmd, artistNameMap)))
+            .toList();
+    }
+
+    private List<FestivalTime> buildFestivalTimes(
+        AdminFestivalCommand.StageCommand stageCmd, Map<String, String> artistNameMap) {
+        return stageCmd.times().stream()
+            .map(timeCmd -> {
+                List<FestivalArtist> artists = timeCmd.artistIds().stream()
+                    .map(FestivalArtist::create)
+                    .toList();
+
+                return FestivalTime.create(
+                    resolveTimeName(timeCmd, artistNameMap),
+                    timeCmd.startAt(), timeCmd.endAt(), artists);
+            })
+            .toList();
+    }
+
+    private List<FestivalArtist> collectArtistsFromStages(List<FestivalStage> stages) {
+        return stages.stream()
+            .flatMap(stage -> stage.getTimes().stream())
+            .flatMap(time -> time.getArtists().stream())
+            .toList();
+    }
+
+    private List<FestivalReservationUrl> buildFestivalReservationUrls(
+        AdminFestivalCommand command, Map<Long, TicketVendor> vendorMap) {
+        return command.reservationUrls().stream()
+            .map(url -> FestivalReservationUrl.create(
+                url.reservationUrl(), vendorMap.get(url.ticketVendorId())))
+            .toList();
+    }
+
+    private List<PerformanceArtist> buildFestivalPerformanceArtists(
+        AdminFestivalCommand command) {
+        if (command.artistIds() == null || command.artistIds().isEmpty()) {
+            return new ArrayList<>();
+        }
+
         return command.artistIds().stream()
             .map(PerformanceArtist::create)
             .toList();

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -132,7 +132,7 @@ public class AdminFacade {
     }
 
     public TicketVendorDtos getTicketVendors() {
-        return Tx.readOnlyTx(() -> ticketVendorService.findAll());
+        return Tx.readOnlyTx(ticketVendorService::findAll);
     }
 
     public AdminConcertListInfo getAdminConcerts() {
@@ -209,13 +209,16 @@ public class AdminFacade {
                 posterPath, logoPath);
 
             if (posterPath != null) {
-                s3FileHandler.deleteFile(
+                eventPublisher.publishEvent(new S3FileDeleteEvent(
                     FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER),
-                    posterPath);
+                    posterPath
+                ));
             }
             if (logoPath != null) {
-                s3FileHandler.deleteFile(
-                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), logoPath);
+                eventPublisher.publishEvent(new S3FileDeleteEvent(
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO),
+                    logoPath
+                ));
             }
             throw e;
         }
@@ -227,13 +230,21 @@ public class AdminFacade {
 
     public void deletePerformanceDraft(Long draftId) {
         PerformanceDraft draft = Tx.readOnlyTx(() -> performanceDraftService.getById(draftId));
-        Optional.ofNullable(draft.getPosterPath())
-            .ifPresent(path -> s3FileHandler.deleteFile(
-                FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path));
-        Optional.ofNullable(draft.getLogoPath())
-            .ifPresent(path -> s3FileHandler.deleteFile(
-                FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), path));
         Tx.masterTx(() -> performanceDraftService.deleteDraft(draftId));
+
+        if (draft.getPosterPath() != null) {
+            eventPublisher.publishEvent(new S3FileDeleteEvent(
+                FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER),
+                draft.getPosterPath()
+            ));
+        }
+
+        if (draft.getLogoPath() != null) {
+            eventPublisher.publishEvent(new S3FileDeleteEvent(
+                FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO),
+                draft.getLogoPath()
+            ));
+        }
     }
 
     public PerformanceDraftDetailInfo getPerformanceDraftDetail(Long draftId) {
@@ -269,9 +280,10 @@ public class AdminFacade {
                 "AdminFacade.updatePerformanceDraft : logo 업로드에 실패해 업로드했던 poster 파일을 롤백합니다. newPosterPath : {}",
                 newPosterPath);
             if (newPosterPath != null) {
-                s3FileHandler.deleteFile(
+                eventPublisher.publishEvent(new S3FileDeleteEvent(
                     FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER),
-                    newPosterPath);
+                    newPosterPath
+                ));
             }
             throw e;
         }
@@ -288,13 +300,16 @@ public class AdminFacade {
             log.warn(
                 "AdminFacade.updatePerformanceDraft : 공연 초안 수정(DB)에 실패해 업로드했던 새 이미지 파일을 롤백합니다.");
             if (newPosterPath != null) {
-                s3FileHandler.deleteFile(
+                eventPublisher.publishEvent(new S3FileDeleteEvent(
                     FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER),
-                    newPosterPath);
+                    newPosterPath
+                ));
             }
             if (newLogoPath != null) {
-                s3FileHandler.deleteFile(
-                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO), newLogoPath);
+                eventPublisher.publishEvent(new S3FileDeleteEvent(
+                    FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.LOGO),
+                    newLogoPath
+                ));
             }
             throw e;
         }
@@ -335,7 +350,7 @@ public class AdminFacade {
             log.warn(
                 "AdminFacade.upsertConcert : 콘서트 생성에 실패해 업로드했던 이미지 파일을 롤백합니다. Folder Path : {}, File Name : {}",
                 folderPath, posterPath);
-            s3FileHandler.deleteFile(folderPath, posterPath);
+            eventPublisher.publishEvent(new S3FileDeleteEvent(folderPath, posterPath));
             throw e;
         }
 
@@ -409,7 +424,7 @@ public class AdminFacade {
             String oldPosterPath = concert.getPosterPath();
 
             if (oldPosterPath != null) {
-                s3FileHandler.deleteFile(folderPath, oldPosterPath);
+                eventPublisher.publishEvent(new S3FileDeleteEvent(folderPath, oldPosterPath));
             }
 
             concert.update(
@@ -509,8 +524,8 @@ public class AdminFacade {
             long festivalId = createFestival(command, posterPath, logoPath);
             return PutAdminFestivalResponse.from(festivalId);
         } catch (Exception e) {
-            s3FileHandler.deleteFile(posterFolderPath, posterPath);
-            s3FileHandler.deleteFile(logoFolderPath, logoPath);
+            eventPublisher.publishEvent(new S3FileDeleteEvent(posterFolderPath, posterPath));
+            eventPublisher.publishEvent(new S3FileDeleteEvent(logoFolderPath, logoPath));
             throw e;
         }
     }
@@ -552,28 +567,46 @@ public class AdminFacade {
         final String finalPosterPath = posterPath;
         final String finalLogoPath = logoPath;
 
-        try {
-            long festivalId = updateFestival(command, finalPosterPath, finalLogoPath);
+        long festivalId;
 
+        try {
+            festivalId = updateFestival(command, finalPosterPath, finalLogoPath);
+        } catch (Exception e) {
+            log.warn(
+                "AdminFacade.upsertFestivalForUpdate : 페스티벌 수정에 실패해 업로드했던 이미지 파일을 롤백합니다. Poster Folder Path : {}, Poster File Name : {}, Logo Folder Path : {}, Logo File Name : {}",
+                posterFolderPath, finalPosterPath, logoFolderPath, finalLogoPath);
+
+            if (hasPoster) {
+                eventPublisher.publishEvent(
+                    new S3FileDeleteEvent(posterFolderPath, finalPosterPath)
+                );
+            }
+            if (hasLogo) {
+                eventPublisher.publishEvent(
+                    new S3FileDeleteEvent(logoFolderPath, finalLogoPath)
+                );
+            }
+            throw e;
+        }
+
+        try {
             // 트랜잭션 커밋 성공 후 기존 S3 파일 삭제
             if (hasPoster && oldPosterPath != null) {
-                s3FileHandler.deleteFile(posterFolderPath, oldPosterPath);
+                eventPublisher.publishEvent(
+                    new S3FileDeleteEvent(posterFolderPath, oldPosterPath)
+                );
             }
             if (hasLogo && oldLogoPath != null) {
-                s3FileHandler.deleteFile(logoFolderPath, oldLogoPath);
+                eventPublisher.publishEvent(
+                    new S3FileDeleteEvent(logoFolderPath, oldLogoPath)
+                );
             }
 
             return PutAdminFestivalResponse.from(festivalId);
         } catch (Exception e) {
             log.warn(
-                "AdminFacade.upsertFestivalForUpdate : 페스티벌 수정에 실패해 업로드했던 이미지 파일을 롤백합니다. Poster Folder Path : {}, Poster File Name : {}, Logo Folder Path : {}, Logo File Name : {}",
-                posterFolderPath, finalPosterPath, logoFolderPath, finalLogoPath);
-            if (hasPoster) {
-                s3FileHandler.deleteFile(posterFolderPath, finalPosterPath);
-            }
-            if (hasLogo) {
-                s3FileHandler.deleteFile(logoFolderPath, finalLogoPath);
-            }
+                "AdminFacade.upsertFestivalForUpdate : 페스티벌 수정 후 기존 파일 삭제에 실패했습니다. Poster Folder Path : {}, Poster File Name : {}, Logo Folder Path : {}, Logo File Name : {}, Error Message : {}",
+                posterFolderPath, finalPosterPath, logoFolderPath, finalLogoPath, e.getMessage());
             throw e;
         }
     }

--- a/src/main/java/org/sopt/confeti/api/admin/facade/dto/request/AdminFestivalCommand.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/dto/request/AdminFestivalCommand.java
@@ -1,0 +1,91 @@
+package org.sopt.confeti.api.admin.facade.dto.request;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.List;
+import org.sopt.confeti.domain.festival.infra.TimetableSupportStatus;
+
+public record AdminFestivalCommand(
+    Long festivalId,
+    String title,
+    String subtitle,
+    LocalDate startAt,
+    LocalDate endAt,
+    String area,
+    LocalDateTime reserveAt,
+    String ageRating,
+    String time,
+    String price,
+    String address,
+    TimetableSupportStatus timetableSupportStatus,
+    List<ReservationUrlCommand> reservationUrls,
+    List<String> artistIds,
+    List<DateCommand> dates
+) {
+
+    public static AdminFestivalCommand of(
+        Long festivalId, String title, String subtitle,
+        LocalDate startAt, LocalDate endAt, String area,
+        LocalDateTime reserveAt, String ageRating, String time,
+        String price, String address, TimetableSupportStatus timetableSupportStatus,
+        List<ReservationUrlCommand> reservationUrls, List<String> artistIds,
+        List<DateCommand> dates
+    ) {
+        return new AdminFestivalCommand(
+            festivalId, title, subtitle, startAt, endAt, area,
+            reserveAt, ageRating, time, price, address, timetableSupportStatus,
+            reservationUrls, artistIds, dates
+        );
+    }
+
+    public record ReservationUrlCommand(
+        Long ticketVendorId,
+        String reservationUrl
+    ) {
+
+        public static ReservationUrlCommand of(Long ticketVendorId, String reservationUrl) {
+            return new ReservationUrlCommand(ticketVendorId, reservationUrl);
+        }
+    }
+
+    public record DateCommand(
+        Long festivalDateId,
+        LocalDate festivalAt,
+        LocalTime openAt,
+        List<StageCommand> stages
+    ) {
+
+        public static DateCommand of(Long festivalDateId, LocalDate festivalAt,
+            LocalTime openAt, List<StageCommand> stages) {
+            return new DateCommand(festivalDateId, festivalAt, openAt, stages);
+        }
+    }
+
+    public record StageCommand(
+        Long festivalStageId,
+        String name,
+        int order,
+        List<TimeCommand> times
+    ) {
+
+        public static StageCommand of(Long festivalStageId, String name, int order,
+            List<TimeCommand> times) {
+            return new StageCommand(festivalStageId, name, order, times);
+        }
+    }
+
+    public record TimeCommand(
+        Long festivalTimeId,
+        LocalTime startAt,
+        LocalTime endAt,
+        String name,
+        List<String> artistIds
+    ) {
+
+        public static TimeCommand of(Long festivalTimeId, LocalTime startAt, LocalTime endAt,
+            String name, List<String> artistIds) {
+            return new TimeCommand(festivalTimeId, startAt, endAt, name, artistIds);
+        }
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/festival/Festival.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/Festival.java
@@ -162,8 +162,66 @@ public class Festival {
                 .build();
     }
 
+    public static Festival create(
+            String title, String subtitle, LocalDate startAt, LocalDate endAt,
+            String area, String posterPath, String logoPath, LocalDateTime reserveAt,
+            String ageRating, String time, String price, String address,
+            TimetableSupportStatus timetableSupportStatus,
+            List<FestivalDate> dates, List<FestivalReservationUrl> reservationUrls
+    ) {
+        return Festival.builder()
+                .title(title)
+                .subtitle(subtitle)
+                .startAt(startAt)
+                .endAt(endAt)
+                .area(area)
+                .posterPath(posterPath)
+                .logoPath(logoPath)
+                .reserveAt(reserveAt)
+                .ageRating(ageRating)
+                .time(time)
+                .price(price)
+                .address(address)
+                .timetableSupportStatus(timetableSupportStatus)
+                .dates(dates)
+                .reservationUrls(reservationUrls)
+                .build();
+    }
+
+    public void updateBasicFields(
+            String title, String subtitle, LocalDate startAt, LocalDate endAt,
+            String area, String posterPath, String logoPath, LocalDateTime reserveAt,
+            String ageRating, String time, String price, String address,
+            TimetableSupportStatus timetableSupportStatus
+    ) {
+        this.title = title;
+        this.subtitle = subtitle;
+        this.startAt = startAt;
+        this.endAt = endAt;
+        this.area = area;
+        this.posterPath = posterPath;
+        this.logoPath = logoPath;
+        this.reserveAt = reserveAt;
+        this.ageRating = ageRating;
+        this.time = time;
+        this.price = price;
+        this.address = address;
+        this.timetableSupportStatus = timetableSupportStatus;
+    }
+
     public void addDates(List<FestivalDate> dates) {
         this.dates.addAll(dates);
         dates.forEach(date -> date.setFestival(this));
+    }
+
+    public void replaceReservationUrls(List<FestivalReservationUrl> newReservationUrls) {
+        this.reservationUrls.clear();
+        this.reservationUrls.addAll(newReservationUrls);
+        newReservationUrls.forEach(url -> url.setFestival(this));
+    }
+
+    public void addDate(FestivalDate date) {
+        this.dates.add(date);
+        date.setFestival(this);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -160,7 +160,7 @@ public class FestivalService {
         return AdminFestivalDetailInfo.from(festival);
     }
 
-    @Transactional
+    @Transactional(readOnly = true)
     public Festival getWithRelationsById(long festivalId) {
         Festival festival = festivalRepository.findWithDatesById(festivalId)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -10,8 +10,8 @@ import org.sopt.confeti.api.dummy.facade.dto.festival.request.CreateFestivalDate
 import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.dto.FestivalCursorDTO;
-import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
 import org.sopt.confeti.domain.festival.infra.TimetableSupportStatus;
+import org.sopt.confeti.domain.festival.infra.repository.FestivalRepository;
 import org.sopt.confeti.domain.festival_date.FestivalDate;
 import org.sopt.confeti.domain.festival_date.application.FestivalDateService;
 import org.sopt.confeti.domain.festival_stage.FestivalStage;
@@ -80,7 +80,8 @@ public class FestivalService {
     }
 
     @ReadOnlyTransactional
-    public List<Festival> findSupportedTimetableFestivalsUsingInitCursor(final long userId, final int size) {
+    public List<Festival> findSupportedTimetableFestivalsUsingInitCursor(final long userId,
+        final int size) {
         return festivalRepository.findFestivalsUsingInitCursorAndSupportStatus(
             userId,
             getPageRequestWithSort(size, getFestivalSort()),
@@ -157,6 +158,32 @@ public class FestivalService {
         }
 
         return AdminFestivalDetailInfo.from(festival);
+    }
+
+    @Transactional
+    public Festival getWithRelationsById(long festivalId) {
+        Festival festival = festivalRepository.findWithDatesById(festivalId)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+
+        festivalDateService.findDatesWithArtistsByFestivalId(festivalId);
+        festivalDateService.findDatesWithStagesByFestivalId(festivalId);
+
+        List<Long> dateIds = festival.getDates().stream()
+            .map(FestivalDate::getId)
+            .toList();
+        festivalStageService.findStagesWithTimesByDateIds(dateIds);
+
+        List<Long> stageIds = festival.getDates().stream()
+            .flatMap(date -> date.getStages().stream())
+            .map(FestivalStage::getId)
+            .toList();
+        if (!stageIds.isEmpty()) {
+            festivalTimeService.findTimesWithArtistsByStageIds(stageIds);
+        }
+
+        festivalRepository.findUpcomingWithReservationUrlsById(festivalId);
+
+        return festival;
     }
 
     @ReadOnlyTransactional

--- a/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
@@ -32,8 +32,8 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
     @Query("""
                         SELECT DISTINCT f
                         FROM Festival f
-                        JOIN FETCH f.reservationUrls fru
-                        JOIN FETCH fru.ticketVendor
+                        LEFT JOIN FETCH f.reservationUrls fru
+                        LEFT JOIN FETCH fru.ticketVendor
                         WHERE f.id = :festivalId
                     """)
     Optional<Festival> findUpcomingWithReservationUrlsById(@Param("festivalId") long festivalId);

--- a/src/main/java/org/sopt/confeti/domain/festival_artist/FestivalArtist.java
+++ b/src/main/java/org/sopt/confeti/domain/festival_artist/FestivalArtist.java
@@ -52,4 +52,10 @@ public class FestivalArtist {
             .artist(Artist.create(festivalArtistDTO.artistId()))
             .build();
     }
+
+    public static FestivalArtist create(String artistId) {
+        return FestivalArtist.builder()
+            .artist(Artist.create(artistId))
+            .build();
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival_date/FestivalDate.java
+++ b/src/main/java/org/sopt/confeti/domain/festival_date/FestivalDate.java
@@ -66,6 +66,22 @@ public class FestivalDate {
         this.artists.forEach(artist -> artist.setFestivalDate(this));
     }
 
+    public void update(LocalDate festivalAt, LocalTime openAt) {
+        this.festivalAt = festivalAt;
+        this.openAt = openAt;
+    }
+
+    public void replaceArtists(List<FestivalArtist> newArtists) {
+        this.artists.clear();
+        this.artists.addAll(newArtists);
+        newArtists.forEach(artist -> artist.setFestivalDate(this));
+    }
+
+    public void addStage(FestivalStage stage) {
+        this.stages.add(stage);
+        stage.setFestivalDate(this);
+    }
+
     public static FestivalDate create(CreateFestivalDateDTO festivalDateDTO) {
         return FestivalDate.builder()
             .festivalAt(festivalDateDTO.festivalAt())
@@ -80,6 +96,16 @@ public class FestivalDate {
                     .flatMap(time -> time.artists().stream())
                     .map(FestivalArtist::create)
                     .toList())
+            .build();
+    }
+
+    public static FestivalDate create(LocalDate festivalAt, LocalTime openAt,
+            List<FestivalStage> stages, List<FestivalArtist> artists) {
+        return FestivalDate.builder()
+            .festivalAt(festivalAt)
+            .openAt(openAt)
+            .stages(stages)
+            .artists(artists)
             .build();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival_reservation_url/FestivalReservationUrl.java
+++ b/src/main/java/org/sopt/confeti/domain/festival_reservation_url/FestivalReservationUrl.java
@@ -54,4 +54,11 @@ public class FestivalReservationUrl {
             .ticketVendor(ticketVendor)
             .build();
     }
+
+    public static FestivalReservationUrl create(String reservationUrl, TicketVendor ticketVendor) {
+        return FestivalReservationUrl.builder()
+            .reservationUrl(reservationUrl)
+            .ticketVendor(ticketVendor)
+            .build();
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival_stage/FestivalStage.java
+++ b/src/main/java/org/sopt/confeti/domain/festival_stage/FestivalStage.java
@@ -57,6 +57,16 @@ public class FestivalStage {
         });
     }
 
+    public void update(String name, int order) {
+        this.name = name;
+        this.order = order;
+    }
+
+    public void addTime(FestivalTime time) {
+        this.times.add(time);
+        time.setFestivalStage(this);
+    }
+
     public static FestivalStage create(CreateFestivalStageDTO festivalStageDTO) {
         return FestivalStage.builder()
                 .name(festivalStageDTO.name())
@@ -66,6 +76,14 @@ public class FestivalStage {
                                 .map(FestivalTime::create)
                                 .toList()
                 )
+                .build();
+    }
+
+    public static FestivalStage create(String name, int order, List<FestivalTime> times) {
+        return FestivalStage.builder()
+                .name(name)
+                .order(order)
+                .times(times)
                 .build();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival_time/FestivalTime.java
+++ b/src/main/java/org/sopt/confeti/domain/festival_time/FestivalTime.java
@@ -39,6 +39,9 @@ public class FestivalTime {
     @JoinColumn(name = "festival_stage_id", nullable = false)
     private FestivalStage festivalStage;
 
+    @Column(length = 100, nullable = false)
+    private String name;
+
     @Column(nullable = false)
     private LocalTime startAt;
 
@@ -52,7 +55,8 @@ public class FestivalTime {
     private List<FestivalArtist> artists = new ArrayList<>();
 
     @Builder
-    public FestivalTime(LocalTime startAt, LocalTime endAt, List<FestivalArtist> artists) {
+    public FestivalTime(String name, LocalTime startAt, LocalTime endAt, List<FestivalArtist> artists) {
+        this.name = name;
         this.startAt = startAt;
         this.endAt = endAt;
         this.artists = artists;
@@ -64,6 +68,7 @@ public class FestivalTime {
 
     public static FestivalTime create(CreateFestivalTimeDTO festivalTimeDTO) {
         return FestivalTime.builder()
+                .name("")
                 .startAt(festivalTimeDTO.startAt())
                 .endAt(festivalTimeDTO.endAt())
                 .artists(
@@ -72,5 +77,25 @@ public class FestivalTime {
                                 .toList()
                 )
                 .build();
+    }
+
+    public static FestivalTime create(String name, LocalTime startAt, LocalTime endAt,
+            List<FestivalArtist> artists) {
+        return FestivalTime.builder()
+                .name(name)
+                .startAt(startAt)
+                .endAt(endAt)
+                .artists(artists)
+                .build();
+    }
+
+    public void update(String name, LocalTime startAt, LocalTime endAt, List<FestivalArtist> newArtists) {
+        this.name = name;
+        this.startAt = startAt;
+        this.endAt = endAt;
+
+        this.artists.clear();
+        this.artists.addAll(newArtists);
+        newArtists.forEach(artist -> artist.setFestivalTime(this));
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/Performance.java
@@ -19,6 +19,7 @@ import lombok.AccessLevel;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import org.sopt.confeti.api.admin.facade.dto.request.AdminFestivalCommand;
 import org.sopt.confeti.api.dummy.facade.dto.concert.request.CreateConcertDTO;
 import org.sopt.confeti.api.dummy.facade.dto.festival.request.CreateFestivalDTO;
 import org.sopt.confeti.global.common.constant.PerformanceType;
@@ -137,6 +138,21 @@ public class Performance {
                                 .map(PerformanceArtist::create)
                                 .toList()
                 )
+                .build();
+    }
+
+    public static Performance create(long festivalId, AdminFestivalCommand command,
+            String posterPath, List<PerformanceArtist> artists) {
+        return Performance.builder()
+                .typeId(festivalId)
+                .type(PerformanceType.FESTIVAL)
+                .area(command.area())
+                .title(command.title())
+                .subtitle(command.subtitle())
+                .startAt(command.startAt())
+                .endAt(command.endAt())
+                .posterPath(posterPath)
+                .artists(artists)
                 .build();
     }
 

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -210,6 +210,12 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
+    public Performance getWithArtistsByTypeAndTypeId(PerformanceType type, long typeId) {
+        return performanceRepository.findWithArtistsByTypeAndTypeId(type, typeId)
+                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+    }
+
+    @Transactional(readOnly = true)
     public List<PerformanceDTO> getPerformancesByTypeAndTypeIds(PerformanceType type, List<Long> typeIds) {
         return performanceRepository.findPerformancesByTypeAndTypeIdIn(type, typeIds).stream()
                 .map(PerformanceDTO::from)

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -44,6 +44,17 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
 
     Optional<Performance> findPerformanceByTypeAndTypeId(PerformanceType type, long typeId);
 
+    @Query("""
+        SELECT DISTINCT p
+        FROM Performance p
+        LEFT JOIN FETCH p.artists
+        WHERE p.type = :type AND p.typeId = :typeId
+    """)
+    Optional<Performance> findWithArtistsByTypeAndTypeId(
+        @Param("type") PerformanceType type,
+        @Param("typeId") long typeId
+    );
+
     List<Performance> findPerformancesByTypeAndTypeIdIn(PerformanceType type, List<Long> typeIds);
 
     @Query(

--- a/src/main/java/org/sopt/confeti/global/transaction/Tx.java
+++ b/src/main/java/org/sopt/confeti/global/transaction/Tx.java
@@ -10,7 +10,7 @@ public final class Tx {
 
     private static TxRunner txRunner;
 
-    public static void initialize(TxRunner txRunner) {
+    static void initialize(TxRunner txRunner) {
         if (Tx.txRunner != null) {
             log.error("Tx.initialize : Tx가 이미 초기화 되었습니다.");
             throw new ParameterInvalidException(ErrorMessage.INTERNAL_SERVER_ERROR);

--- a/src/main/java/org/sopt/confeti/global/transaction/TxConfig.java
+++ b/src/main/java/org/sopt/confeti/global/transaction/TxConfig.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.global.transaction;
+
+import jakarta.annotation.PostConstruct;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class TxConfig {
+
+    private final TxRunner txRunner;
+
+    @PostConstruct
+    public void init() {
+        Tx.initialize(txRunner);
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/transaction/TxRunner.java
+++ b/src/main/java/org/sopt/confeti/global/transaction/TxRunner.java
@@ -1,6 +1,5 @@
 package org.sopt.confeti.global.transaction;
 
-import jakarta.annotation.PostConstruct;
 import java.util.function.Supplier;
 import org.sopt.confeti.global.annotation.ReadOnlyTransactional;
 import org.springframework.stereotype.Component;
@@ -9,11 +8,6 @@ import org.springframework.transaction.annotation.Transactional;
 
 @Component
 public class TxRunner {
-
-    @PostConstruct
-    protected void initialize() {
-        Tx.initialize(this);
-    }
 
     @Transactional(propagation = Propagation.REQUIRED)
     public void runTx(Runnable runnable) {


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 페스티벌 Upsert API를 구현했습니다.
- 기존 Tx 클래스의 TxRunner 의존성 주입 로직을 TxRunner에서 PostConstructor 에 의해 실행되는 함수에서 자기 자신 (TxRunner 빈)을 Tx 클래스에 주입하도록 했었습니다. 그런데, 트랜잭션은 프록시 객체를 호출해야 롤백 등의 기능이 동작하는데, Tx 클래스에 등록된 TxRunner 빈은 프록시 객체가 아닌 원본 객체가 등록되어 트랜잭션이 적용되지 않는 오류가 있었습니다. AOP 동작에 의한 트랜잭션 미적용 문제를 해결하고자 Configuration 빈에서 TxRunner의 프록시 객체를 주입받고, Tx의 초기화 함수를 실행하는 것으로 해결했습니다. (실제 트랜잭션 정상 적용까지 확인)

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
