### PR TITLE
CSERVER-20 (어드민) 목록 조회 시 search 쿼리스트링 추가

### DIFF
--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -106,10 +106,12 @@ public class AdminController implements AdminControllerDocs {
 
     @Override
     @GetMapping("/performances/drafts")
-    public ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts() {
+    public ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts(
+        @RequestParam(required = false) String search
+    ) {
         return ApiResponseUtil.success(
             SuccessMessage.SUCCESS,
-            PerformanceDraftListResponses.from(adminFacade.getPerformanceDrafts(), s3FileHandler)
+            PerformanceDraftListResponses.from(adminFacade.getPerformanceDrafts(search), s3FileHandler)
         );
     }
 

--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -165,8 +165,10 @@ public class AdminController implements AdminControllerDocs {
 
     @Override
     @GetMapping("/performances/concerts")
-    public ResponseEntity<BaseResponse<AdminConcertListResponse>> getAdminConcerts() {
-        AdminConcertListInfo concertList = adminFacade.getAdminConcerts();
+    public ResponseEntity<BaseResponse<AdminConcertListResponse>> getAdminConcerts(
+        @RequestParam(required = false) String search
+    ) {
+        AdminConcertListInfo concertList = adminFacade.getAdminConcerts(search);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             AdminConcertListResponse.of(concertList, s3FileHandler));
     }

--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -195,8 +195,10 @@ public class AdminController implements AdminControllerDocs {
 
     @Override
     @GetMapping("/performances/festivals")
-    public ResponseEntity<BaseResponse<AdminFestivalListResponse>> getAdminFestivals() {
-        AdminFestivalListInfo festivalListInfo = adminFacade.getAdminFestivals();
+    public ResponseEntity<BaseResponse<AdminFestivalListResponse>> getAdminFestivals(
+        @RequestParam(required = false) String search
+    ) {
+        AdminFestivalListInfo festivalListInfo = adminFacade.getAdminFestivals(search);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             AdminFestivalListResponse.of(festivalListInfo, s3FileHandler));
     }

--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -107,7 +107,7 @@ public class AdminController implements AdminControllerDocs {
     @Override
     @GetMapping("/performances/drafts")
     public ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts(
-        @RequestParam(required = false) String search
+        @RequestParam(required = false) @Size(max = 100) String search
     ) {
         return ApiResponseUtil.success(
             SuccessMessage.SUCCESS,
@@ -166,7 +166,7 @@ public class AdminController implements AdminControllerDocs {
     @Override
     @GetMapping("/performances/concerts")
     public ResponseEntity<BaseResponse<AdminConcertListResponse>> getAdminConcerts(
-        @RequestParam(required = false) String search
+        @RequestParam(required = false) @Size(max = 100) String search
     ) {
         AdminConcertListInfo concertList = adminFacade.getAdminConcerts(search);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
@@ -196,7 +196,7 @@ public class AdminController implements AdminControllerDocs {
     @Override
     @GetMapping("/performances/festivals")
     public ResponseEntity<BaseResponse<AdminFestivalListResponse>> getAdminFestivals(
-        @RequestParam(required = false) String search
+        @RequestParam(required = false) @Size(max = 100) String search
     ) {
         AdminFestivalListInfo festivalListInfo = adminFacade.getAdminFestivals(search);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,

--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -1,6 +1,5 @@
 package org.sopt.confeti.api.admin.controller;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
@@ -63,7 +62,6 @@ public class AdminController implements AdminControllerDocs {
 
     private final AdminFacade adminFacade;
     private final S3FileHandler s3FileHandler;
-    private final ObjectMapper objectMapper;
 
     @Override
     @PostMapping("/ticket-vendors")
@@ -111,7 +109,7 @@ public class AdminController implements AdminControllerDocs {
     public ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts() {
         return ApiResponseUtil.success(
             SuccessMessage.SUCCESS,
-            PerformanceDraftListResponses.from(adminFacade.getPerformanceDrafts(), objectMapper)
+            PerformanceDraftListResponses.from(adminFacade.getPerformanceDrafts(), s3FileHandler)
         );
     }
 

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -112,6 +112,7 @@ public interface AdminControllerDocs {
 
     @Operation(summary = "대기 공연 목록 조회", description = 
     """
+    QuertString - search: 생략 가능. title, area를 기준으로 검색
     크롤링한 데이터의 경우 status가 "검토 필요" 반환되고,  
     수동 등록한 데이터의 경우 status가 "보류"로 반환됩니다. (현재 수동 등록의 경우 콘서트, 페스티벌 수정/저장 API를 사용하므로 해당 케이스는 존재하지 않습니다.)
             """)
@@ -309,6 +310,7 @@ public interface AdminControllerDocs {
         summary = "등록된 콘서트 목록 조회",
         description = "어드민 권한으로 등록된 모든 콘서트 목록을 조회합니다. "
             + "진행 예정/진행 중인 콘서트와 종료된 콘서트를 구분하여 반환합니다."
+            + "QuertString - search: 생략 가능. title, area를 기준으로 검색합니다."
     )
     @ApiResponses(
         value = {
@@ -366,6 +368,7 @@ public interface AdminControllerDocs {
         summary = "등록된 페스티벌 목록 조회",
         description = "어드민 권한으로 등록된 모든 페스티벌 목록을 조회합니다. "
             + "진행 예정/진행 중인 페스티벌과 종료된 페스티벌을 구분하여 반환합니다."
+            + "QuertString - search: 생략 가능. title, area를 기준으로 검색합니다."
     )
     @ApiResponses(
         value = {

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -320,7 +320,9 @@ public interface AdminControllerDocs {
     )
     @AuthErrorResponses
     @CommonErrorResponses
-    ResponseEntity<BaseResponse<AdminConcertListResponse>> getAdminConcerts();
+    ResponseEntity<BaseResponse<AdminConcertListResponse>> getAdminConcerts(
+        @RequestParam(required = false) @Size(max = 50) String search
+    );
 
     @Operation(
         summary = "수정할 콘서트 단건 조회",

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -310,7 +310,7 @@ public interface AdminControllerDocs {
         summary = "등록된 콘서트 목록 조회",
         description = "어드민 권한으로 등록된 모든 콘서트 목록을 조회합니다. "
             + "진행 예정/진행 중인 콘서트와 종료된 콘서트를 구분하여 반환합니다."
-            + "QuertString - search: 생략 가능. title, area를 기준으로 검색합니다."
+            + "QuertString - search: 생략 가능. title, subTitle, area를 기준으로 검색합니다."
     )
     @ApiResponses(
         value = {
@@ -368,7 +368,7 @@ public interface AdminControllerDocs {
         summary = "등록된 페스티벌 목록 조회",
         description = "어드민 권한으로 등록된 모든 페스티벌 목록을 조회합니다. "
             + "진행 예정/진행 중인 페스티벌과 종료된 페스티벌을 구분하여 반환합니다."
-            + "QuertString - search: 생략 가능. title, area를 기준으로 검색합니다."
+            + "QuertString - search: 생략 가능. title, subTitle, area를 기준으로 검색합니다."
     )
     @ApiResponses(
         value = {

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -377,7 +377,9 @@ public interface AdminControllerDocs {
     )
     @AuthErrorResponses
     @CommonErrorResponses
-    ResponseEntity<BaseResponse<AdminFestivalListResponse>> getAdminFestivals();
+    ResponseEntity<BaseResponse<AdminFestivalListResponse>> getAdminFestivals(
+        @RequestParam(required = false) @Size(max = 50) String search
+    );
 
     @Operation(
         summary = "콘서트 등록/수정",

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -127,7 +127,7 @@ public interface AdminControllerDocs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts(
-        @RequestParam(required = false) @Size(max = 50) String search
+        @RequestParam(required = false) @Size(max = 100) String search
     );
 
     @Deprecated
@@ -323,7 +323,7 @@ public interface AdminControllerDocs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<AdminConcertListResponse>> getAdminConcerts(
-        @RequestParam(required = false) @Size(max = 50) String search
+        @RequestParam(required = false) @Size(max = 100) String search
     );
 
     @Operation(
@@ -381,7 +381,7 @@ public interface AdminControllerDocs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<AdminFestivalListResponse>> getAdminFestivals(
-        @RequestParam(required = false) @Size(max = 50) String search
+        @RequestParam(required = false) @Size(max = 100) String search
     );
 
     @Operation(

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -125,7 +125,9 @@ public interface AdminControllerDocs {
     )
     @AuthErrorResponses
     @CommonErrorResponses
-    ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts();
+    ResponseEntity<BaseResponse<PerformanceDraftListResponses>> getPerformanceDrafts(
+        @RequestParam(required = false) @Size(max = 50) String search
+    );
 
     @Deprecated
     @Operation(summary = "대기 공연 등록",

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponse.java
@@ -1,11 +1,11 @@
 package org.sopt.confeti.api.admin.dto.response;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonNode;
-import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Optional;
+import org.sopt.confeti.api.admin.facade.dto.response.AdminPerformanceDraftPreviewInfo;
 import org.sopt.confeti.domain.performancedraft.DraftStatus;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraftType;
-import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.util.S3FileHandler;
 
 public record PerformanceDraftListResponse(
         Long id,
@@ -13,30 +13,26 @@ public record PerformanceDraftListResponse(
         DraftStatus status,
         String title,
         String area,
+        String posterUrl,
         String startAt
 ) {
-    public static PerformanceDraftListResponse from(PerformanceDraftDto dto, ObjectMapper objectMapper) {
-        String title = null;
-        String area = null;
-        String startAt = null;
-
-        try {
-            JsonNode rootNode = objectMapper.readTree(dto.performanceData());
-            title = rootNode.hasNonNull("title") ? rootNode.get("title").asText() : null;
-            area = rootNode.hasNonNull("area") ? rootNode.get("area").asText() : null;
-            startAt = rootNode.hasNonNull("startAt") ? rootNode.get("startAt").asText() : null;
-        } catch (JsonProcessingException e) {
-            // 파싱 실패 시 기본값 null
-        }
+    public static PerformanceDraftListResponse from(
+        AdminPerformanceDraftPreviewInfo info,
+        S3FileHandler s3FileHandler
+    ) {
+        String posterUrl = Optional.ofNullable(info.posterPath())
+            .map(path -> s3FileHandler.getFileUrl(
+                FolderPath.combine(FolderPath.PERFORMANCE_DRAFT, FolderPath.POSTER), path).toString())
+            .orElse(null);
 
         return new PerformanceDraftListResponse(
-                dto.id(),
-                dto.performanceDraftType(),
-                dto.status(),
-                title,
-                area,
-                startAt
+            info.id(),
+            info.performanceDraftType(),
+            info.status(),
+            info.title(),
+            info.area(),
+            posterUrl,
+            info.startAt()
         );
     }
 }
-

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponses.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponses.java
@@ -1,18 +1,18 @@
 package org.sopt.confeti.api.admin.dto.response;
 
 import java.util.List;
-import org.sopt.confeti.api.admin.facade.dto.response.AdminPerformanceDraftPreviewInfo;
+import org.sopt.confeti.api.admin.facade.dto.response.AdminPerformanceDraftListInfo;
 import org.sopt.confeti.global.util.S3FileHandler;
 
 public record PerformanceDraftListResponses(
         List<PerformanceDraftListResponse> drafts
 ) {
     public static PerformanceDraftListResponses from(
-        List<AdminPerformanceDraftPreviewInfo> infos,
+        AdminPerformanceDraftListInfo info,
         S3FileHandler s3FileHandler
     ) {
-        List<PerformanceDraftListResponse> responses = infos.stream()
-                .map(info -> PerformanceDraftListResponse.from(info, s3FileHandler))
+        List<PerformanceDraftListResponse> responses = info.drafts().stream()
+                .map(previewInfo -> PerformanceDraftListResponse.from(previewInfo, s3FileHandler))
                 .toList();
         return new PerformanceDraftListResponses(responses);
     }

--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponses.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/PerformanceDraftListResponses.java
@@ -1,16 +1,18 @@
 package org.sopt.confeti.api.admin.dto.response;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDtos;
-
 import java.util.List;
+import org.sopt.confeti.api.admin.facade.dto.response.AdminPerformanceDraftPreviewInfo;
+import org.sopt.confeti.global.util.S3FileHandler;
 
 public record PerformanceDraftListResponses(
         List<PerformanceDraftListResponse> drafts
 ) {
-    public static PerformanceDraftListResponses from(PerformanceDraftDtos dtos, ObjectMapper objectMapper) {
-        List<PerformanceDraftListResponse> responses = dtos.drafts().stream()
-                .map(dto -> PerformanceDraftListResponse.from(dto, objectMapper))
+    public static PerformanceDraftListResponses from(
+        List<AdminPerformanceDraftPreviewInfo> infos,
+        S3FileHandler s3FileHandler
+    ) {
+        List<PerformanceDraftListResponse> responses = infos.stream()
+                .map(info -> PerformanceDraftListResponse.from(info, s3FileHandler))
                 .toList();
         return new PerformanceDraftListResponses(responses);
     }

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -165,9 +165,9 @@ public class AdminFacade {
         return Tx.readOnlyTx(() -> festivalService.getAdminFestivalDetailInfo(festivalId));
     }
 
-    public AdminFestivalListInfo getAdminFestivals() {
+    public AdminFestivalListInfo getAdminFestivals(String keyword) {
         List<AdminFestivalPreviewInfo> festivals = Tx.readOnlyTx(
-            festivalService::getAdminFestivals);
+            () -> festivalService.getAdminFestivals(keyword));
         LocalDate today = LocalDate.now();
 
         Map<Boolean, List<AdminFestivalPreviewInfo>> partitioned = festivals.stream()

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -135,8 +135,8 @@ public class AdminFacade {
         return Tx.readOnlyTx(ticketVendorService::findAll);
     }
 
-    public AdminConcertListInfo getAdminConcerts() {
-        List<ConcertPreviewInfo> concerts = Tx.readOnlyTx(concertService::getAllConcerts);
+    public AdminConcertListInfo getAdminConcerts(String keyword) {
+        List<ConcertPreviewInfo> concerts = Tx.readOnlyTx(() -> concertService.getAllConcerts(keyword));
         LocalDate today = LocalDate.now();
 
         Map<Boolean, List<ConcertPreviewInfo>> partitioned = concerts.stream()

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -224,9 +224,9 @@ public class AdminFacade {
         }
     }
 
-    public AdminPerformanceDraftListInfo getPerformanceDrafts() {
+    public AdminPerformanceDraftListInfo getPerformanceDrafts(String keyword) {
         return AdminPerformanceDraftListInfo.from(
-            Tx.readOnlyTx(performanceDraftService::getAdminPerformanceDraftPreviews)
+            Tx.readOnlyTx(() -> performanceDraftService.getAdminPerformanceDraftPreviews(keyword))
         );
     }
 

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -26,6 +26,7 @@ import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo.Conce
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalPreviewInfo;
+import org.sopt.confeti.api.admin.facade.dto.response.AdminPerformanceDraftPreviewInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.PerformanceDraftDetailInfo;
 import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.application.ConcertService;
@@ -47,7 +48,6 @@ import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftServ
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
-import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDtos;
 import org.sopt.confeti.domain.ticketvendor.TicketVendor;
 import org.sopt.confeti.domain.ticketvendor.application.TicketVendorService;
 import org.sopt.confeti.domain.ticketvendor.application.dto.request.TicketVendorCreateDto;
@@ -224,8 +224,8 @@ public class AdminFacade {
         }
     }
 
-    public PerformanceDraftDtos getPerformanceDrafts() {
-        return Tx.readOnlyTx(performanceDraftService::getAllDrafts);
+    public List<AdminPerformanceDraftPreviewInfo> getPerformanceDrafts() {
+        return Tx.readOnlyTx(performanceDraftService::getAdminPerformanceDraftPreviews);
     }
 
     public void deletePerformanceDraft(Long draftId) {

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -136,7 +136,7 @@ public class AdminFacade {
     }
 
     public AdminConcertListInfo getAdminConcerts(String keyword) {
-        List<ConcertPreviewInfo> concerts = Tx.readOnlyTx(() -> concertService.getAllConcerts(keyword));
+        List<ConcertPreviewInfo> concerts = Tx.readOnlyTx(() -> concertService.getAdminConcertPreviews(keyword));
         LocalDate today = LocalDate.now();
 
         Map<Boolean, List<ConcertPreviewInfo>> partitioned = concerts.stream()
@@ -167,7 +167,7 @@ public class AdminFacade {
 
     public AdminFestivalListInfo getAdminFestivals(String keyword) {
         List<AdminFestivalPreviewInfo> festivals = Tx.readOnlyTx(
-            () -> festivalService.getAdminFestivals(keyword));
+            () -> festivalService.getAdminFestivalPreviews(keyword));
         LocalDate today = LocalDate.now();
 
         Map<Boolean, List<AdminFestivalPreviewInfo>> partitioned = festivals.stream()

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -26,7 +26,7 @@ import org.sopt.confeti.api.admin.facade.dto.response.AdminConcertListInfo.Conce
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalDetailInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.AdminFestivalPreviewInfo;
-import org.sopt.confeti.api.admin.facade.dto.response.AdminPerformanceDraftPreviewInfo;
+import org.sopt.confeti.api.admin.facade.dto.response.AdminPerformanceDraftListInfo;
 import org.sopt.confeti.api.admin.facade.dto.response.PerformanceDraftDetailInfo;
 import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.application.ConcertService;
@@ -224,8 +224,10 @@ public class AdminFacade {
         }
     }
 
-    public List<AdminPerformanceDraftPreviewInfo> getPerformanceDrafts() {
-        return Tx.readOnlyTx(performanceDraftService::getAdminPerformanceDraftPreviews);
+    public AdminPerformanceDraftListInfo getPerformanceDrafts() {
+        return AdminPerformanceDraftListInfo.from(
+            Tx.readOnlyTx(performanceDraftService::getAdminPerformanceDraftPreviews)
+        );
     }
 
     public void deletePerformanceDraft(Long draftId) {

--- a/src/main/java/org/sopt/confeti/api/admin/facade/dto/response/AdminPerformanceDraftListInfo.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/dto/response/AdminPerformanceDraftListInfo.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.api.admin.facade.dto.response;
+
+import java.util.List;
+
+public record AdminPerformanceDraftListInfo(
+    List<AdminPerformanceDraftPreviewInfo> drafts
+) {
+    public static AdminPerformanceDraftListInfo from(
+        List<AdminPerformanceDraftPreviewInfo> drafts
+    ) {
+        return new AdminPerformanceDraftListInfo(drafts);
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/admin/facade/dto/response/AdminPerformanceDraftPreviewInfo.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/dto/response/AdminPerformanceDraftPreviewInfo.java
@@ -1,0 +1,32 @@
+package org.sopt.confeti.api.admin.facade.dto.response;
+
+import org.sopt.confeti.domain.performancedraft.DraftStatus;
+import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
+import org.sopt.confeti.domain.performancedraft.PerformanceDraftType;
+import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftParser;
+
+public record AdminPerformanceDraftPreviewInfo(
+    Long id,
+    PerformanceDraftType performanceDraftType,
+    DraftStatus status,
+    String posterPath,
+    String title,
+    String area,
+    String startAt
+) {
+    public static AdminPerformanceDraftPreviewInfo from(
+        PerformanceDraft draft,
+        PerformanceDraftParser parser
+    ) {
+        String performanceData = draft.getPerformanceData();
+        return new AdminPerformanceDraftPreviewInfo(
+            draft.getId(),
+            draft.getPerformanceDraftType(),
+            draft.getStatus(),
+            draft.getPosterPath(),
+            parser.parseTitle(performanceData),
+            parser.parseArea(performanceData),
+            parser.parseStartAt(performanceData)
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
@@ -52,7 +52,7 @@ public class ConcertService {
     }
 
     @ReadOnlyTransactional
-    public List<ConcertPreviewInfo> getAllConcerts(String keyword) {
+    public List<ConcertPreviewInfo> getAdminConcertPreviews(String keyword) {
         return findConcertsByKeyword(keyword).stream()
             .map(ConcertPreviewInfo::from)
             .toList();
@@ -62,7 +62,8 @@ public class ConcertService {
         if (!StringUtils.hasText(keyword)) {
             return concertRepository.findAll();
         }
-        return concertRepository.findAllByTitleContainingOrAreaContaining(keyword, keyword);
+        return concertRepository.findAllByTitleContainingOrAreaContainingOrSubtitleContaining(
+            keyword, keyword, keyword);
     }
 
     @ReadOnlyTransactional

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
@@ -15,6 +15,7 @@ import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Service
 @RequiredArgsConstructor
@@ -51,10 +52,17 @@ public class ConcertService {
     }
 
     @ReadOnlyTransactional
-    public List<ConcertPreviewInfo> getAllConcerts() {
-        return concertRepository.findAll().stream()
+    public List<ConcertPreviewInfo> getAllConcerts(String keyword) {
+        return findConcertsByKeyword(keyword).stream()
             .map(ConcertPreviewInfo::from)
             .toList();
+    }
+
+    private List<Concert> findConcertsByKeyword(String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return concertRepository.findAll();
+        }
+        return concertRepository.findAllByTitleContainingOrAreaContaining(keyword, keyword);
     }
 
     @ReadOnlyTransactional

--- a/src/main/java/org/sopt/confeti/domain/concert/infra/repository/ConcertRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/infra/repository/ConcertRepository.java
@@ -46,4 +46,6 @@ public interface ConcertRepository extends JpaRepository<Concert, Long> {
     Optional<Concert> findWithReservationUrlsById(@Param("concertId") long concertId);
 
     List<Concert> findAllByIdIn(final List<Long> concertIds);
+
+    List<Concert> findAllByTitleContainingOrAreaContaining(String title, String area);
 }

--- a/src/main/java/org/sopt/confeti/domain/concert/infra/repository/ConcertRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/infra/repository/ConcertRepository.java
@@ -47,5 +47,6 @@ public interface ConcertRepository extends JpaRepository<Concert, Long> {
 
     List<Concert> findAllByIdIn(final List<Long> concertIds);
 
-    List<Concert> findAllByTitleContainingOrAreaContaining(String title, String area);
+    List<Concert> findAllByTitleContainingOrAreaContainingOrSubtitleContaining(
+        String title, String area, String subtitle);
 }

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -193,7 +193,7 @@ public class FestivalService {
     }
 
     @ReadOnlyTransactional
-    public List<AdminFestivalPreviewInfo> getAdminFestivals(String keyword) {
+    public List<AdminFestivalPreviewInfo> getAdminFestivalPreviews(String keyword) {
         return findFestivalsByKeyword(keyword).stream()
             .map(AdminFestivalPreviewInfo::from)
             .toList();
@@ -203,6 +203,7 @@ public class FestivalService {
         if (!StringUtils.hasText(keyword)) {
             return festivalRepository.findAll();
         }
-        return festivalRepository.findAllByTitleContainingOrAreaContaining(keyword, keyword);
+        return festivalRepository.findAllByTitleContainingOrAreaContainingOrSubtitleContaining(
+            keyword, keyword, keyword);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -27,6 +27,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Order;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 @Slf4j
 @Service
@@ -192,9 +193,16 @@ public class FestivalService {
     }
 
     @ReadOnlyTransactional
-    public List<AdminFestivalPreviewInfo> getAdminFestivals() {
-        return festivalRepository.findAll().stream()
+    public List<AdminFestivalPreviewInfo> getAdminFestivals(String keyword) {
+        return findFestivalsByKeyword(keyword).stream()
             .map(AdminFestivalPreviewInfo::from)
             .toList();
+    }
+
+    private List<Festival> findFestivalsByKeyword(String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return festivalRepository.findAll();
+        }
+        return festivalRepository.findAllByTitleContainingOrAreaContaining(keyword, keyword);
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
@@ -102,5 +102,6 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
 
     List<Festival> findByIdIn(final List<Long> festivalIds);
 
-    List<Festival> findAllByTitleContainingOrAreaContaining(String title, String area);
+    List<Festival> findAllByTitleContainingOrAreaContainingOrSubtitleContaining(
+        String title, String area, String subtitle);
 }

--- a/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
@@ -101,4 +101,6 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
                     final PageRequest pageRequest);
 
     List<Festival> findByIdIn(final List<Long> festivalIds);
+
+    List<Festival> findAllByTitleContainingOrAreaContaining(String title, String area);
 }

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftParser.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftParser.java
@@ -40,5 +40,24 @@ public class PerformanceDraftParser {
         return artistIds;
     }
 
+    public String parseTitle(String performanceData) {
+        return parseField(performanceData, "title");
+    }
 
+    public String parseArea(String performanceData) {
+        return parseField(performanceData, "area");
+    }
+
+    public String parseStartAt(String performanceData) {
+        return parseField(performanceData, "startAt");
+    }
+
+    private String parseField(String performanceData, String fieldName) {
+        try {
+            JsonNode root = objectMapper.readTree(performanceData);
+            return root.hasNonNull(fieldName) ? root.get(fieldName).asText() : null;
+        } catch (Exception e) {
+            return null;
+        }
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
@@ -14,6 +14,7 @@ import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 
 @Service
@@ -47,10 +48,17 @@ public class PerformanceDraftService {
     }
 
     @ReadOnlyTransactional
-    public List<AdminPerformanceDraftPreviewInfo> getAdminPerformanceDraftPreviews() {
-        return draftRepository.findAll().stream()
+    public List<AdminPerformanceDraftPreviewInfo> getAdminPerformanceDraftPreviews(String keyword) {
+        return findDraftsByKeyword(keyword).stream()
             .map(draft -> AdminPerformanceDraftPreviewInfo.from(draft, draftParser))
             .toList();
+    }
+
+    private List<PerformanceDraft> findDraftsByKeyword(String keyword) {
+        if (!StringUtils.hasText(keyword)) {
+            return draftRepository.findAll();
+        }
+        return draftRepository.searchByKeyword(keyword);
     }
 
     @Transactional

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/application/PerformanceDraftService.java
@@ -1,12 +1,15 @@
 package org.sopt.confeti.domain.performancedraft.application;
 
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.sopt.confeti.api.admin.facade.dto.response.AdminPerformanceDraftPreviewInfo;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDtos;
 import org.sopt.confeti.domain.performancedraft.infra.PerformanceDraftRepository;
+import org.sopt.confeti.global.annotation.ReadOnlyTransactional;
 import org.sopt.confeti.global.exception.NotFoundException;
 import org.sopt.confeti.global.message.ErrorMessage;
 import org.springframework.stereotype.Service;
@@ -18,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class PerformanceDraftService {
 
     private final PerformanceDraftRepository draftRepository;
+    private final PerformanceDraftParser draftParser;
 
     @Transactional
     public PerformanceDraftDto createDraft(PerformanceDraftCreateDto dto, String posterPath, String logoPath) {
@@ -40,6 +44,13 @@ public class PerformanceDraftService {
                         .map(PerformanceDraftDto::from)
                         .toList()
         );
+    }
+
+    @ReadOnlyTransactional
+    public List<AdminPerformanceDraftPreviewInfo> getAdminPerformanceDraftPreviews() {
+        return draftRepository.findAll().stream()
+            .map(draft -> AdminPerformanceDraftPreviewInfo.from(draft, draftParser))
+            .toList();
     }
 
     @Transactional

--- a/src/main/java/org/sopt/confeti/domain/performancedraft/infra/PerformanceDraftRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/performancedraft/infra/PerformanceDraftRepository.java
@@ -1,8 +1,18 @@
 package org.sopt.confeti.domain.performancedraft.infra;
 
+import java.util.List;
 import org.sopt.confeti.domain.performancedraft.PerformanceDraft;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PerformanceDraftRepository extends JpaRepository<PerformanceDraft, Long> {
 
+    @Query(
+        value = "SELECT * FROM performance_drafts " +
+                "WHERE JSON_UNQUOTE(JSON_EXTRACT(performance_data, '$.title')) LIKE CONCAT('%', :keyword, '%') " +
+                "   OR JSON_UNQUOTE(JSON_EXTRACT(performance_data, '$.area'))  LIKE CONCAT('%', :keyword, '%')",
+        nativeQuery = true
+    )
+    List<PerformanceDraft> searchByKeyword(@Param("keyword") String keyword);
 }


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 목록 조회 시 search 쿼리스트링을 통해 검색이 가능하도록 목록 조회 API 변경
  - search: 생략 가능. title, area 기준으로 검색 진행
  - 아래 세가지 도메인의 Admin 목록 조회 API에 해당함
    - PerformanceDraft: 현재 데이터를 json으로 저장하고 있는데, 요구사항에 맞춰 title, area를 기준으로 검색을 하기 위해 네이티브쿼리를 사용하여 JSON_EXTRACT 함수를 사용함. (모든 레코드를 DB에서 가져와서 애플리케이션에서 필터링 하는 방법보단 네이티브 쿼리를 사용하는 방법이 더 좋다고 판단하여..)
    - Concert: Jpa 자동 생성 메서드로 like %keyword% 로 가져옴
    - Festival: Jpa 자동 생성 메서드로 like %keyword% 로 가져옴

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
