### PR TITLE
CSERVER-25 MusicApiService에서 이벤트를 사용해 영속화하도록 개선

### DIFF
--- a/src/main/java/org/sopt/confeti/domain/music/artist/CreateArtistsEvent.java
+++ b/src/main/java/org/sopt/confeti/domain/music/artist/CreateArtistsEvent.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.domain.music.artist;
+
+import java.util.List;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record CreateArtistsEvent(
+        List<ConfetiArtist> artists
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/music/artist/application/ArtistEventListener.java
+++ b/src/main/java/org/sopt/confeti/domain/music/artist/application/ArtistEventListener.java
@@ -1,0 +1,27 @@
+package org.sopt.confeti.domain.music.artist.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.domain.music.artist.CreateArtistsEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class ArtistEventListener {
+
+    private final ArtistService artistService;
+
+    @Async
+    @EventListener
+    public void handleCreateArtistsEvent(CreateArtistsEvent event) {
+        try {
+            artistService.create(event.artists());
+            log.info("ArtistEventListener.handleCreateArtistsEvent : 아티스트 저장 완료. size : {}", event.artists().size());
+        } catch (Exception e) {
+            log.error("ArtistEventListener.handleCreateArtistsEvent : 아티스트 저장 실패. size : {}", event.artists().size(), e);
+        }
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/music/artist/application/ArtistEventListener.java
+++ b/src/main/java/org/sopt/confeti/domain/music/artist/application/ArtistEventListener.java
@@ -3,6 +3,8 @@ package org.sopt.confeti.domain.music.artist.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.domain.music.artist.CreateArtistsEvent;
+import org.sopt.confeti.global.common.ExecutorName;
+import org.sopt.confeti.global.transaction.Tx;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -14,11 +16,11 @@ public class ArtistEventListener {
 
     private final ArtistService artistService;
 
-    @Async
+    @Async(ExecutorName.MUSIC_API_EVENT_EXECUTOR)
     @EventListener
     public void handleCreateArtistsEvent(CreateArtistsEvent event) {
         try {
-            artistService.create(event.artists());
+            Tx.masterTx(() -> artistService.create(event.artists()));
             log.info("ArtistEventListener.handleCreateArtistsEvent : 아티스트 저장 완료. size : {}", event.artists().size());
         } catch (Exception e) {
             log.error("ArtistEventListener.handleCreateArtistsEvent : 아티스트 저장 실패. size : {}", event.artists().size(), e);

--- a/src/main/java/org/sopt/confeti/domain/music/artist/application/ArtistMusicAPIService.java
+++ b/src/main/java/org/sopt/confeti/domain/music/artist/application/ArtistMusicAPIService.java
@@ -10,12 +10,14 @@ import org.sopt.confeti.domain.music.application.dto.FetchResult;
 import org.sopt.confeti.domain.music.application.dto.MusicAPICondition;
 import org.sopt.confeti.domain.music.application.dto.PersistResult;
 import org.sopt.confeti.domain.music.artist.Artist;
+import org.sopt.confeti.domain.music.artist.CreateArtistsEvent;
 import org.sopt.confeti.global.common.redis.RedisHandler;
 import org.sopt.confeti.global.common.redis.RedisHandler.RedisData;
 import org.sopt.confeti.global.common.redis.RedisKey;
 import org.sopt.confeti.global.common.redis.RedisKey.KeyInfo;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -25,6 +27,7 @@ public class ArtistMusicAPIService extends MusicAPIService<ConfetiArtist> {
     private final RedisHandler redisHandler;
     private final ArtistService artistService;
     private final MusicAPIHandler musicAPIHandler;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     protected void cache(List<ConfetiArtist> targetList) {
@@ -40,7 +43,7 @@ public class ArtistMusicAPIService extends MusicAPIService<ConfetiArtist> {
 
     @Override
     protected void persist(List<ConfetiArtist> targetList) {
-        artistService.create(targetList);
+        eventPublisher.publishEvent(new CreateArtistsEvent(targetList));
     }
 
     @Override

--- a/src/main/java/org/sopt/confeti/domain/music/artist/application/ArtistService.java
+++ b/src/main/java/org/sopt/confeti/domain/music/artist/application/ArtistService.java
@@ -5,7 +5,7 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.music.artist.Artist;
-import org.sopt.confeti.domain.music.artist.application.dto.request.CreateArtistDTO;
+import org.sopt.confeti.domain.music.artist.application.dto.request.CreateArtistCommand;
 import org.sopt.confeti.domain.music.artist.infra.repository.ArtistRepository;
 import org.sopt.confeti.global.annotation.ReadOnlyTransactional;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
@@ -25,8 +25,8 @@ public class ArtistService {
     }
 
     @Transactional
-    public String create(CreateArtistDTO createArtistDTO) {
-        Artist artist = createArtistDTO.toArtist();
+    public String create(CreateArtistCommand createArtistCommand) {
+        Artist artist = createArtistCommand.toArtist();
         return artistRepository.save(artist).getId();
     }
 

--- a/src/main/java/org/sopt/confeti/domain/music/artist/application/dto/request/CreateArtistCommand.java
+++ b/src/main/java/org/sopt/confeti/domain/music/artist/application/dto/request/CreateArtistCommand.java
@@ -4,7 +4,7 @@ import lombok.Builder;
 import org.sopt.confeti.domain.music.artist.Artist;
 
 @Builder
-public record CreateArtistDTO(
+public record CreateArtistCommand(
     String artistId,
     String name,
     String artworkUrl

--- a/src/main/java/org/sopt/confeti/domain/music/relatedartist/CreateRelatedArtistsEvent.java
+++ b/src/main/java/org/sopt/confeti/domain/music/relatedartist/CreateRelatedArtistsEvent.java
@@ -1,0 +1,11 @@
+package org.sopt.confeti.domain.music.relatedartist;
+
+import java.util.List;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+
+public record CreateRelatedArtistsEvent(
+    ConfetiArtist artist,
+    List<ConfetiArtist> relatedArtists
+) {
+
+}

--- a/src/main/java/org/sopt/confeti/domain/music/relatedartist/application/RelatedArtistEventListener.java
+++ b/src/main/java/org/sopt/confeti/domain/music/relatedartist/application/RelatedArtistEventListener.java
@@ -1,0 +1,49 @@
+package org.sopt.confeti.domain.music.relatedartist.application;
+
+import java.util.Set;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.domain.music.artist.application.ArtistService;
+import org.sopt.confeti.domain.music.relatedartist.CreateRelatedArtistsEvent;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
+import org.sopt.confeti.global.transaction.Tx;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class RelatedArtistEventListener {
+
+    private final ArtistService artistService;
+    private final RelatedArtistService relatedArtistService;
+
+    @Async
+    @EventListener
+    public void handleCreateRelatedArtistsEvent(CreateRelatedArtistsEvent event) {
+        try {
+            Tx.masterTx(() -> {
+                if (!artistService.isExistByArtistId(event.artist().getId())) {
+                    artistService.create(event.artist().toCommand());
+                }
+
+                artistService.create(event.relatedArtists());
+
+                Set<String> relatedArtistIds = event.relatedArtists().stream()
+                    .map(ConfetiArtist::getId)
+                    .collect(Collectors.toSet());
+                relatedArtistService.createRelatedArtists(event.artist().getId(), relatedArtistIds);
+            });
+
+            log.info(
+                "RelatedArtistEventListener.handleCreateRelatedArtistsEvent : 관련 아티스트 저장 완료. artistId : {}",
+                event.artist().getId());
+        } catch (Exception e) {
+            log.error(
+                "RelatedArtistEventListener.handleCreateRelatedArtistsEvent : 관련 아티스트 저장 실패. artistId : {}",
+                event.artist().getId(), e);
+        }
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/music/relatedartist/application/RelatedArtistEventListener.java
+++ b/src/main/java/org/sopt/confeti/domain/music/relatedartist/application/RelatedArtistEventListener.java
@@ -1,11 +1,14 @@
 package org.sopt.confeti.domain.music.relatedartist.application;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.domain.music.artist.application.ArtistService;
 import org.sopt.confeti.domain.music.relatedartist.CreateRelatedArtistsEvent;
+import org.sopt.confeti.global.common.ExecutorName;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.sopt.confeti.global.transaction.Tx;
 import org.springframework.context.event.EventListener;
@@ -20,16 +23,15 @@ public class RelatedArtistEventListener {
     private final ArtistService artistService;
     private final RelatedArtistService relatedArtistService;
 
-    @Async
+    @Async(ExecutorName.MUSIC_API_EVENT_EXECUTOR)
     @EventListener
     public void handleCreateRelatedArtistsEvent(CreateRelatedArtistsEvent event) {
         try {
             Tx.masterTx(() -> {
-                if (!artistService.isExistByArtistId(event.artist().getId())) {
-                    artistService.create(event.artist().toCommand());
-                }
-
-                artistService.create(event.relatedArtists());
+                List<ConfetiArtist> allArtists = new ArrayList<>();
+                allArtists.add(event.artist());
+                allArtists.addAll(event.relatedArtists());
+                artistService.create(allArtists);
 
                 Set<String> relatedArtistIds = event.relatedArtists().stream()
                     .map(ConfetiArtist::getId)

--- a/src/main/java/org/sopt/confeti/domain/music/relatedartist/application/RelatedArtistMusicAPIService.java
+++ b/src/main/java/org/sopt/confeti/domain/music/relatedartist/application/RelatedArtistMusicAPIService.java
@@ -2,20 +2,19 @@ package org.sopt.confeti.domain.music.relatedartist.application;
 
 import java.util.List;
 import java.util.Set;
-import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.music.application.MusicAPIService;
 import org.sopt.confeti.domain.music.application.dto.CacheResult;
 import org.sopt.confeti.domain.music.application.dto.FetchResult;
 import org.sopt.confeti.domain.music.application.dto.MusicAPICondition;
 import org.sopt.confeti.domain.music.application.dto.PersistResult;
-import org.sopt.confeti.domain.music.artist.application.ArtistService;
+import org.sopt.confeti.domain.music.relatedartist.CreateRelatedArtistsEvent;
 import org.sopt.confeti.domain.music.relatedartist.application.dto.RelatedArtistInfo;
 import org.sopt.confeti.global.common.redis.RedisHandler;
 import org.sopt.confeti.global.common.redis.RedisKey;
 import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
-import org.sopt.confeti.global.transaction.Tx;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -26,8 +25,8 @@ public class RelatedArtistMusicAPIService extends MusicAPIService<RelatedArtistI
 
     private final RedisHandler redisHandler;
     private final RelatedArtistService relatedArtistService;
-    private final ArtistService artistService;
     private final MusicAPIHandler musicAPIHandler;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     protected void cache(List<RelatedArtistInfo> targetList) {
@@ -40,20 +39,14 @@ public class RelatedArtistMusicAPIService extends MusicAPIService<RelatedArtistI
         if (targetList.isEmpty()) {
             return;
         }
-        String artistId = targetList.getFirst().artist().getId();
+
+        ConfetiArtist artist = targetList.getFirst().artist();
 
         List<ConfetiArtist> relatedArtists = targetList.stream()
             .map(RelatedArtistInfo::relatedArtist)
             .toList();
 
-        Set<String> relatedArtistIds = relatedArtists.stream()
-            .map(ConfetiArtist::getId)
-            .collect(Collectors.toSet());
-
-        Tx.masterTx(() -> {
-            artistService.create(relatedArtists);
-            relatedArtistService.createRelatedArtists(artistId, relatedArtistIds);
-        });
+        eventPublisher.publishEvent(new CreateRelatedArtistsEvent(artist, relatedArtists));
     }
 
     @Override

--- a/src/main/java/org/sopt/confeti/domain/music/song/CreateSongsEvent.java
+++ b/src/main/java/org/sopt/confeti/domain/music/song/CreateSongsEvent.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.domain.music.song;
+
+import java.util.List;
+import org.sopt.confeti.global.resolver.music_api.song.vo.ConfetiSong;
+
+public record CreateSongsEvent(
+        List<ConfetiSong> songs
+) {
+}

--- a/src/main/java/org/sopt/confeti/domain/music/song/application/SongEventListener.java
+++ b/src/main/java/org/sopt/confeti/domain/music/song/application/SongEventListener.java
@@ -3,6 +3,8 @@ package org.sopt.confeti.domain.music.song.application;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.domain.music.song.CreateSongsEvent;
+import org.sopt.confeti.global.common.ExecutorName;
+import org.sopt.confeti.global.transaction.Tx;
 import org.springframework.context.event.EventListener;
 import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Component;
@@ -14,11 +16,11 @@ public class SongEventListener {
 
     private final SongService songService;
 
-    @Async
+    @Async(ExecutorName.MUSIC_API_EVENT_EXECUTOR)
     @EventListener
     public void handleCreateSongsEvent(CreateSongsEvent event) {
         try {
-            songService.create(event.songs());
+            Tx.masterTx(() -> songService.create(event.songs()));
             log.info("SongEventListener.handleCreateSongsEvent : 노래 저장 완료. size : {}", event.songs().size());
         } catch (Exception e) {
             log.error("SongEventListener.handleCreateSongsEvent : 노래 저장 실패. size : {}", event.songs().size(), e);

--- a/src/main/java/org/sopt/confeti/domain/music/song/application/SongEventListener.java
+++ b/src/main/java/org/sopt/confeti/domain/music/song/application/SongEventListener.java
@@ -1,0 +1,27 @@
+package org.sopt.confeti.domain.music.song.application;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.domain.music.song.CreateSongsEvent;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class SongEventListener {
+
+    private final SongService songService;
+
+    @Async
+    @EventListener
+    public void handleCreateSongsEvent(CreateSongsEvent event) {
+        try {
+            songService.create(event.songs());
+            log.info("SongEventListener.handleCreateSongsEvent : 노래 저장 완료. size : {}", event.songs().size());
+        } catch (Exception e) {
+            log.error("SongEventListener.handleCreateSongsEvent : 노래 저장 실패. size : {}", event.songs().size(), e);
+        }
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/music/song/application/SongMusicAPIService.java
+++ b/src/main/java/org/sopt/confeti/domain/music/song/application/SongMusicAPIService.java
@@ -10,6 +10,7 @@ import org.sopt.confeti.domain.music.application.dto.CacheResult;
 import org.sopt.confeti.domain.music.application.dto.FetchResult;
 import org.sopt.confeti.domain.music.application.dto.MusicAPICondition;
 import org.sopt.confeti.domain.music.application.dto.PersistResult;
+import org.sopt.confeti.domain.music.song.CreateSongsEvent;
 import org.sopt.confeti.domain.music.song.Song;
 import org.sopt.confeti.global.common.redis.RedisHandler;
 import org.sopt.confeti.global.common.redis.RedisHandler.RedisData;
@@ -17,6 +18,7 @@ import org.sopt.confeti.global.common.redis.RedisKey;
 import org.sopt.confeti.global.common.redis.RedisKey.KeyInfo;
 import org.sopt.confeti.global.resolver.music_api.song.vo.ConfetiSong;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -27,6 +29,7 @@ public class SongMusicAPIService extends MusicAPIService<ConfetiSong> {
     private final RedisHandler redisHandler;
     private final SongService songService;
     private final MusicAPIHandler musicAPIHandler;
+    private final ApplicationEventPublisher eventPublisher;
 
     @Override
     protected void cache(List<ConfetiSong> targetList) {
@@ -42,7 +45,7 @@ public class SongMusicAPIService extends MusicAPIService<ConfetiSong> {
 
     @Override
     protected void persist(List<ConfetiSong> targetList) {
-        songService.create(targetList);
+        eventPublisher.publishEvent(new CreateSongsEvent(targetList));
     }
 
     @Override

--- a/src/main/java/org/sopt/confeti/domain/music/song/application/SongService.java
+++ b/src/main/java/org/sopt/confeti/domain/music/song/application/SongService.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.domain.music.song.application;
 
 import java.util.List;
 import java.util.Set;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.domain.music.song.Song;
 import org.sopt.confeti.domain.music.song.application.dto.request.CreateSongDTO;
@@ -34,10 +35,19 @@ public class SongService {
 
     @Transactional
     public void create(List<ConfetiSong> confetiSongs) {
-        List<Song> songs = confetiSongs.stream()
+        Set<String> requestedIds = confetiSongs.stream()
+            .map(ConfetiSong::getId)
+            .collect(Collectors.toSet());
+
+        Set<String> existingIds = songRepository.findAllById(requestedIds).stream()
+            .map(Song::getId)
+            .collect(Collectors.toSet());
+
+        List<Song> newSongs = confetiSongs.stream()
+            .filter(song -> !existingIds.contains(song.getId()))
             .map(ConfetiSong::toSong)
             .toList();
 
-        songRepository.saveAll(songs);
+        songRepository.saveAll(newSongs);
     }
 }

--- a/src/main/java/org/sopt/confeti/global/common/ExecutorName.java
+++ b/src/main/java/org/sopt/confeti/global/common/ExecutorName.java
@@ -7,4 +7,5 @@ import lombok.NoArgsConstructor;
 public final class ExecutorName {
 
     public static final String PERFORMANCE_EXECUTOR = "performanceExecutor";
+    public static final String MUSIC_API_EVENT_EXECUTOR = "musicApiEventExecutor";
 }

--- a/src/main/java/org/sopt/confeti/global/config/AsyncConfig.java
+++ b/src/main/java/org/sopt/confeti/global/config/AsyncConfig.java
@@ -40,4 +40,17 @@ public class AsyncConfig {
         executor.initialize();
         return executor;
     }
+
+    @Bean(ExecutorName.MUSIC_API_EVENT_EXECUTOR)
+    public Executor musicApiEventExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+        executor.setCorePoolSize(5);
+        executor.setMaxPoolSize(10);
+        executor.setQueueCapacity(30);
+        executor.setThreadNamePrefix("music-api-event-");
+        executor.setTaskDecorator(compositeTaskDecorator);
+        executor.setRejectedExecutionHandler(new ThreadPoolExecutor.CallerRunsPolicy());
+        executor.initialize();
+        return executor;
+    }
 }

--- a/src/main/java/org/sopt/confeti/global/messagebroker/sqs/message/artist/CreateArtistMessage.java
+++ b/src/main/java/org/sopt/confeti/global/messagebroker/sqs/message/artist/CreateArtistMessage.java
@@ -1,6 +1,6 @@
 package org.sopt.confeti.global.messagebroker.sqs.message.artist;
 
-import org.sopt.confeti.domain.music.artist.application.dto.request.CreateArtistDTO;
+import org.sopt.confeti.domain.music.artist.application.dto.request.CreateArtistCommand;
 import org.sopt.confeti.global.messagebroker.message.CreateMessage;
 
 public record CreateArtistMessage(
@@ -9,8 +9,8 @@ public record CreateArtistMessage(
     String artworkUrl
 ) implements CreateMessage {
 
-    public CreateArtistDTO toCreateDTO() {
-        return CreateArtistDTO.builder()
+    public CreateArtistCommand toCreateDTO() {
+        return CreateArtistCommand.builder()
             .artistId(artistId)
             .name(name)
             .artworkUrl(artworkUrl)

--- a/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
+++ b/src/main/java/org/sopt/confeti/global/resolver/music_api/artist/vo/ConfetiArtist.java
@@ -11,6 +11,7 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.Setter;
+import org.sopt.confeti.domain.music.artist.application.dto.request.CreateArtistCommand;
 import org.sopt.confeti.global.annotation.RedisSerializable;
 import org.sopt.confeti.global.common.constant.ArtistConstant;
 import org.sopt.confeti.global.util.music.dto.artist.AppleMusicArtistArtworkResponse;
@@ -70,6 +71,14 @@ public class ConfetiArtist {
     public static ConfetiArtist of(final String artistId, final String name,
         final String profileUrl) {
         return new ConfetiArtist(artistId, name, profileUrl);
+    }
+
+    public CreateArtistCommand toCommand() {
+        return CreateArtistCommand.builder()
+            .artistId(id)
+            .name(name)
+            .artworkUrl(profileUrl)
+            .build();
     }
 
     @Override


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- DB 영속화를 비동기 이벤트 처리로 진행해 응답 속도를 개선
- 반드시 실패한다고 가정하고, 영속화 대상 엔티티가 의존성 객체에 의해 영속화에 실패하지 않도록 로직을 구성
- 실패하더라도 다음에 성공한다고 가정 (멱등성 보장)

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
