### PR TITLE
CSERVER-27 홈 공연 조회 개선

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/PerformanceReservationDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/PerformanceReservationDetailResponse.java
@@ -9,16 +9,17 @@ public record PerformanceReservationDetailResponse(
         long typeId,
         PerformanceType type,
         String title,
-        String reserveAt
+        String reserveAt,
+        boolean isFavorite
 ) {
     public static PerformanceReservationDetailResponse from(PerformanceReservationDetailDTO performanceReservation) {
-
         return new PerformanceReservationDetailResponse(
                 performanceReservation.index(),
                 performanceReservation.typeId(),
                 performanceReservation.type(),
                 performanceReservation.title(),
-                DateConvertor.convertToDefaultFormat(performanceReservation.reserveAt())
+                DateConvertor.convertToDefaultFormat(performanceReservation.reserveAt()),
+                performanceReservation.isFavorite()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/PerformanceReservationResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/PerformanceReservationResponse.java
@@ -4,7 +4,6 @@ import java.util.List;
 import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
 
 public record PerformanceReservationResponse(
-    boolean isPersonalized,
     int performanceCount,
     List<PerformanceReservationDetailResponse> performances
 ) {
@@ -12,7 +11,6 @@ public record PerformanceReservationResponse(
     public static PerformanceReservationResponse from(
         PerformanceReservationDTO performanceReservation) {
         return new PerformanceReservationResponse(
-            performanceReservation.isPersonalized(),
             performanceReservation.performanceReservation().size(),
             performanceReservation.performanceReservation().stream()
                 .map(PerformanceReservationDetailResponse::from)

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecentPerformanceResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecentPerformanceResponse.java
@@ -13,7 +13,8 @@ public record RecentPerformanceResponse(
         String title,
         String area,
         String startAt,
-        String posterUrl
+        String posterUrl,
+        boolean isFavorite
 ) {
     public static RecentPerformanceResponse of(final RecentPerformanceDTO recentPerformanceDTO,
                                                final S3FileHandler s3FileHandler) {
@@ -27,7 +28,8 @@ public record RecentPerformanceResponse(
                 recentPerformanceDTO.area(),
                 DateConvertor.convertToDefaultFormat(recentPerformanceDTO.startAt()),
                 s3FileHandler.getFileUrl(FolderPath.combine(topFolder, FolderPath.POSTER),
-                        recentPerformanceDTO.posterPath()).toString()
+                        recentPerformanceDTO.posterPath()).toString(),
+                recentPerformanceDTO.isFavorite()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/RecentPerformancesResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/RecentPerformancesResponse.java
@@ -5,13 +5,11 @@ import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDT
 import org.sopt.confeti.global.util.S3FileHandler;
 
 public record RecentPerformancesResponse(
-        boolean isPersonalized,
         List<RecentPerformanceResponse> performances
 ) {
     public static RecentPerformancesResponse of(final RecentPerformancesDTO recentPerformancesDTO,
                                                 final S3FileHandler s3FileHandler) {
         return new RecentPerformancesResponse(
-                recentPerformancesDTO.isPersonalized(),
                 recentPerformancesDTO.performances().stream()
                         .map(recentPerformanceDTO -> RecentPerformanceResponse.of(recentPerformanceDTO, s3FileHandler))
                         .toList()

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -67,7 +67,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 @Facade
 public class PerformanceFacade {
 
-    private static final int RECENT_PERFORMANCES_SIZE = 7;
     private static final int RECOMMEND_SONG_SIZE = 3;
     private static final int RECOMMEND_SONG_FETCH_SIZE = 20;
     private final ConcertService concertService;

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -15,6 +15,8 @@ import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import lombok.extern.slf4j.Slf4j;
+import org.sopt.confeti.api.performance.facade.context.PerformanceReservationContext;
+import org.sopt.confeti.api.performance.facade.context.RecentPerformanceContext;
 import org.sopt.confeti.api.performance.facade.dto.request.GetUpcomingPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.ArtistPerformancesDetailDTO;
@@ -34,7 +36,6 @@ import org.sopt.confeti.api.performance.facade.dto.response.RecommendSongsPerfor
 import org.sopt.confeti.api.performance.facade.dto.response.SearchACPerformancesDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.SongRecommendDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.UpcomingPerformancesDTO;
-import org.sopt.confeti.domain.artist_favorite.ArtistFavorite;
 import org.sopt.confeti.domain.artist_favorite.application.ArtistFavoriteService;
 import org.sopt.confeti.domain.concert.application.ConcertService;
 import org.sopt.confeti.domain.concert_favorite.application.ConcertFavoriteService;
@@ -61,7 +62,6 @@ import org.sopt.confeti.global.message.ErrorMessage;
 import org.sopt.confeti.global.resolver.music_api.song.vo.ConfetiSong;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.transaction.annotation.Transactional;
 
 @Slf4j
 @Facade
@@ -70,9 +70,6 @@ public class PerformanceFacade {
     private static final int RECENT_PERFORMANCES_SIZE = 7;
     private static final int RECOMMEND_SONG_SIZE = 3;
     private static final int RECOMMEND_SONG_FETCH_SIZE = 20;
-    private static final boolean PERSONALIZED = true;
-    private static final boolean UNPERSONALIZED = false;
-
     private final ConcertService concertService;
     private final FestivalService festivalService;
     private final UserService userService;
@@ -138,54 +135,55 @@ public class PerformanceFacade {
 
     @ReadOnlyTransactional
     public PerformanceReservationDTO getPerformanceReservationInfo() {
-        boolean existsFavoritePerformance = UserContext.getOptional()
-            .map(userInfo ->
-                concertFavoriteService.existsUpcomingReservationByUserId(userInfo.id())
-                    || festivalFavoriteService.existsUpcomingReservationByUserId(userInfo.id())
-            )
-            .orElse(false);
+        PerformanceReservationContext context = new PerformanceReservationContext();
 
-        if (existsFavoritePerformance) {
-            List<PerformanceTicketDTO> performanceReserve = performanceService.getFavoritePerformancesReservation(
-                UserContext.get().id());
-            return PerformanceReservationDTO.of(PERSONALIZED, performanceReserve);
+        UserContext.getOptional().ifPresent(userInfo -> {
+            List<PerformanceTicketDTO> favorites =
+                performanceService.getFavoritePerformancesReservation(userInfo.id(),
+                    PerformanceReservationContext.MAX_SIZE);
+            context.addFavoritePerformances(favorites);
+        });
+
+        if (!context.isFull()) {
+            List<PerformanceTicketDTO> general =
+                performanceService.getPerformancesReservationExcluding(
+                    context.getExcludedConcertIds(),
+                    context.getExcludedFestivalIds(),
+                    context.remainingSlots()
+                );
+            context.addGeneralPerformances(general);
         }
 
-        List<PerformanceTicketDTO> performanceReserve = performanceService.getPerformancesReservation();
-        return PerformanceReservationDTO.of(UNPERSONALIZED, performanceReserve);
+        return context.build();
     }
 
     @ReadOnlyTransactional
     public RecentPerformancesDTO getRecentPerformances() {
-        return UserContext.getOptional()
-            .map(userInfo -> getRecentPerformancesWithFavorites(userInfo.id()))
-            .filter(recentPerformancesDTO -> !recentPerformancesDTO.performances().isEmpty())
-            .orElseGet(this::getRecentPerformancesWithoutFavorites);
-    }
+        RecentPerformanceContext context = new RecentPerformanceContext();
 
-    @Transactional(readOnly = true)
-    public RecentPerformancesDTO getRecentPerformancesWithFavorites(final long userId) {
-        List<ArtistFavorite> artistFavorites = artistFavoriteService.getArtistIdsByUserId(userId);
+        UserContext.getOptional().ifPresent(userInfo -> {
+            List<String> favoriteArtistIds =
+                artistFavoriteService.getArtistIdsByUserId(userInfo.id());
+            if (!favoriteArtistIds.isEmpty()) {
+                List<Performance> favoritePerformances =
+                    performanceService.getPerformancesByArtistIds(
+                        favoriteArtistIds,
+                        RecentPerformanceContext.MAX_SIZE
+                    );
+                context.addFavoritePerformances(favoritePerformances);
+            }
+        });
 
-        return RecentPerformancesDTO.of(
-            PERSONALIZED,
-            performanceService.getPerformancesByArtistIds(
-                artistFavorites.stream()
-                    .map(artistFavorite -> artistFavorite.getArtist().getId())
-                    .toList(),
-                RECENT_PERFORMANCES_SIZE
-            )
-        );
-    }
+        if (!context.isFull()) {
+            List<Performance> general =
+                performanceService.getRecentPerformancesExcluding(
+                    context.getExcludedPerformanceIds(),
+                    context.remainingSlots()
+                );
+            context.addGeneralPerformances(general);
+        }
 
-    @ReadOnlyTransactional
-    public RecentPerformancesDTO getRecentPerformancesWithoutFavorites() {
-        List<Performance> performances = performanceService.getRecentPerformances(
-            RECENT_PERFORMANCES_SIZE);
-        return RecentPerformancesDTO.of(
-            UNPERSONALIZED,
-            performances
-        );
+        return context.build();
     }
 
     @ReadOnlyTransactional

--- a/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/PerformanceFacade.java
@@ -176,7 +176,8 @@ public class PerformanceFacade {
         if (!context.isFull()) {
             List<Performance> general =
                 performanceService.getRecentPerformancesExcluding(
-                    context.getExcludedPerformanceIds(),
+                    context.getExcludedConcertIds(),
+                    context.getExcludedFestivalIds(),
                     context.remainingSlots()
                 );
             context.addGeneralPerformances(general);

--- a/src/main/java/org/sopt/confeti/api/performance/facade/context/PerformanceKey.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/context/PerformanceKey.java
@@ -1,0 +1,7 @@
+package org.sopt.confeti.api.performance.facade.context;
+
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+public record PerformanceKey(PerformanceType type, Long id) {
+
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/context/PerformanceReservationContext.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/context/PerformanceReservationContext.java
@@ -66,15 +66,14 @@ public class PerformanceReservationContext {
     }
 
     public PerformanceReservationDTO build() {
-        List<PerformanceReservationDetailDTO> performancesWithIndex = new ArrayList<>();
-        for (int i = 0; i < performances.size(); i++) {
-            performancesWithIndex.add(performances.get(i).withIndex(i + 1));
-        }
+        List<PerformanceReservationDetailDTO> sorted = performances.stream()
+            .sorted(Comparator.comparing(PerformanceReservationDetailDTO::reserveAt))
+            .toList();
 
-        return new PerformanceReservationDTO(
-            performancesWithIndex.stream()
-                .sorted(Comparator.comparing(PerformanceReservationDetailDTO::reserveAt))
-                .toList()
-        );
+        List<PerformanceReservationDetailDTO> result = new ArrayList<>();
+        for (int i = 0; i < sorted.size(); i++) {
+            result.add(sorted.get(i).withIndex(i + 1));
+        }
+        return new PerformanceReservationDTO(result);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/context/PerformanceReservationContext.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/context/PerformanceReservationContext.java
@@ -15,7 +15,7 @@ public class PerformanceReservationContext {
     public static final int MAX_SIZE = 5;
 
     private final List<PerformanceReservationDetailDTO> performances = new ArrayList<>();
-    private final Set<String> addedKeys = new HashSet<>();
+    private final Set<PerformanceKey> addedKeys = new HashSet<>();
 
     public boolean isFull() {
         return performances.size() >= MAX_SIZE;
@@ -30,7 +30,7 @@ public class PerformanceReservationContext {
             if (isFull()) {
                 break;
             }
-            String key = ticket.type().name() + "_" + ticket.typeId();
+            PerformanceKey key = new PerformanceKey(ticket.type(), ticket.typeId());
             if (addedKeys.add(key)) {
                 performances.add(PerformanceReservationDetailDTO.of(ticket, true));
             }
@@ -42,7 +42,7 @@ public class PerformanceReservationContext {
             if (isFull()) {
                 break;
             }
-            String key = ticket.type().name() + "_" + ticket.typeId();
+            PerformanceKey key = new PerformanceKey(ticket.type(), ticket.typeId());
             if (addedKeys.add(key)) {
                 performances.add(PerformanceReservationDetailDTO.of(ticket, false));
             }
@@ -51,16 +51,16 @@ public class PerformanceReservationContext {
 
     public List<Long> getExcludedConcertIds() {
         List<Long> ids = addedKeys.stream()
-            .filter(key -> key.startsWith(PerformanceType.CONCERT.name() + "_"))
-            .map(key -> Long.parseLong(key.substring(key.indexOf("_") + 1)))
+            .filter(key -> key.type() == PerformanceType.CONCERT)
+            .map(PerformanceKey::id)
             .toList();
         return ids.isEmpty() ? List.of(-1L) : ids;
     }
 
     public List<Long> getExcludedFestivalIds() {
         List<Long> ids = addedKeys.stream()
-            .filter(key -> key.startsWith(PerformanceType.FESTIVAL.name() + "_"))
-            .map(key -> Long.parseLong(key.substring(key.indexOf("_") + 1)))
+            .filter(key -> key.type() == PerformanceType.FESTIVAL)
+            .map(PerformanceKey::id)
             .toList();
         return ids.isEmpty() ? List.of(-1L) : ids;
     }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/context/PerformanceReservationContext.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/context/PerformanceReservationContext.java
@@ -1,0 +1,80 @@
+package org.sopt.confeti.api.performance.facade.context;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.PerformanceReservationDetailDTO;
+import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+
+public class PerformanceReservationContext {
+
+    public static final int MAX_SIZE = 5;
+
+    private final List<PerformanceReservationDetailDTO> performances = new ArrayList<>();
+    private final Set<String> addedKeys = new HashSet<>();
+
+    public boolean isFull() {
+        return performances.size() >= MAX_SIZE;
+    }
+
+    public int remainingSlots() {
+        return MAX_SIZE - performances.size();
+    }
+
+    public void addFavoritePerformances(List<PerformanceTicketDTO> tickets) {
+        for (PerformanceTicketDTO ticket : tickets) {
+            if (isFull()) {
+                break;
+            }
+            String key = ticket.type().name() + "_" + ticket.typeId();
+            if (addedKeys.add(key)) {
+                performances.add(PerformanceReservationDetailDTO.of(ticket, true));
+            }
+        }
+    }
+
+    public void addGeneralPerformances(List<PerformanceTicketDTO> tickets) {
+        for (PerformanceTicketDTO ticket : tickets) {
+            if (isFull()) {
+                break;
+            }
+            String key = ticket.type().name() + "_" + ticket.typeId();
+            if (addedKeys.add(key)) {
+                performances.add(PerformanceReservationDetailDTO.of(ticket, false));
+            }
+        }
+    }
+
+    public List<Long> getExcludedConcertIds() {
+        List<Long> ids = addedKeys.stream()
+            .filter(key -> key.startsWith(PerformanceType.CONCERT.name() + "_"))
+            .map(key -> Long.parseLong(key.substring(key.indexOf("_") + 1)))
+            .toList();
+        return ids.isEmpty() ? List.of(-1L) : ids;
+    }
+
+    public List<Long> getExcludedFestivalIds() {
+        List<Long> ids = addedKeys.stream()
+            .filter(key -> key.startsWith(PerformanceType.FESTIVAL.name() + "_"))
+            .map(key -> Long.parseLong(key.substring(key.indexOf("_") + 1)))
+            .toList();
+        return ids.isEmpty() ? List.of(-1L) : ids;
+    }
+
+    public PerformanceReservationDTO build() {
+        List<PerformanceReservationDetailDTO> performancesWithIndex = new ArrayList<>();
+        for (int i = 0; i < performances.size(); i++) {
+            performancesWithIndex.add(performances.get(i).withIndex(i + 1));
+        }
+
+        return new PerformanceReservationDTO(
+            performancesWithIndex.stream()
+                .sorted(Comparator.comparing(PerformanceReservationDetailDTO::reserveAt))
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/context/RecentPerformanceContext.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/context/RecentPerformanceContext.java
@@ -1,0 +1,60 @@
+package org.sopt.confeti.api.performance.facade.context;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformanceDTO;
+import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
+import org.sopt.confeti.domain.view.performance.Performance;
+
+public class RecentPerformanceContext {
+
+    public static final int MAX_SIZE = 7;
+
+    private final List<RecentPerformanceDTO> performances = new ArrayList<>();
+    private final Set<Long> addedPerformanceIds = new HashSet<>();
+
+    public boolean isFull() {
+        return performances.size() >= MAX_SIZE;
+    }
+
+    public int remainingSlots() {
+        return MAX_SIZE - performances.size();
+    }
+
+    public void addFavoritePerformances(List<Performance> favoritePerformances) {
+        for (Performance performance : favoritePerformances) {
+            if (isFull()) {
+                break;
+            }
+            if (addedPerformanceIds.add(performance.getId())) {
+                performances.add(RecentPerformanceDTO.of(performance, true));
+            }
+        }
+    }
+
+    public void addGeneralPerformances(List<Performance> generalPerformances) {
+        for (Performance performance : generalPerformances) {
+            if (isFull()) {
+                break;
+            }
+            if (addedPerformanceIds.add(performance.getId())) {
+                performances.add(RecentPerformanceDTO.of(performance, false));
+            }
+        }
+    }
+
+    public Set<Long> getExcludedPerformanceIds() {
+        return addedPerformanceIds.isEmpty() ? Set.of(-1L) : addedPerformanceIds;
+    }
+
+    public RecentPerformancesDTO build() {
+        return new RecentPerformancesDTO(
+            performances.stream()
+                .sorted(Comparator.comparing(RecentPerformanceDTO::startAt))
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/performance/facade/context/RecentPerformanceContext.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/context/RecentPerformanceContext.java
@@ -46,8 +46,8 @@ public class RecentPerformanceContext {
         }
     }
 
-    public Set<Long> getExcludedPerformanceIds() {
-        return addedPerformanceIds.isEmpty() ? Set.of(-1L) : addedPerformanceIds;
+    public List<Long> getExcludedPerformanceIds() {
+        return addedPerformanceIds.isEmpty() ? List.of(-1L) : List.copyOf(addedPerformanceIds);
     }
 
     public RecentPerformancesDTO build() {

--- a/src/main/java/org/sopt/confeti/api/performance/facade/context/RecentPerformanceContext.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/context/RecentPerformanceContext.java
@@ -8,13 +8,14 @@ import java.util.Set;
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformanceDTO;
 import org.sopt.confeti.api.performance.facade.dto.response.RecentPerformancesDTO;
 import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.global.common.constant.PerformanceType;
 
 public class RecentPerformanceContext {
 
     public static final int MAX_SIZE = 7;
 
     private final List<RecentPerformanceDTO> performances = new ArrayList<>();
-    private final Set<Long> addedPerformanceIds = new HashSet<>();
+    private final Set<PerformanceKey> addedPerformanceKeys = new HashSet<>();
 
     public boolean isFull() {
         return performances.size() >= MAX_SIZE;
@@ -29,7 +30,8 @@ public class RecentPerformanceContext {
             if (isFull()) {
                 break;
             }
-            if (addedPerformanceIds.add(performance.getId())) {
+            PerformanceKey key = new PerformanceKey(performance.getType(), performance.getTypeId());
+            if (addedPerformanceKeys.add(key)) {
                 performances.add(RecentPerformanceDTO.of(performance, true));
             }
         }
@@ -40,14 +42,27 @@ public class RecentPerformanceContext {
             if (isFull()) {
                 break;
             }
-            if (addedPerformanceIds.add(performance.getId())) {
+            PerformanceKey key = new PerformanceKey(performance.getType(), performance.getTypeId());
+            if (addedPerformanceKeys.add(key)) {
                 performances.add(RecentPerformanceDTO.of(performance, false));
             }
         }
     }
 
-    public List<Long> getExcludedPerformanceIds() {
-        return addedPerformanceIds.isEmpty() ? List.of(-1L) : List.copyOf(addedPerformanceIds);
+    public List<Long> getExcludedConcertIds() {
+        List<Long> ids = addedPerformanceKeys.stream()
+            .filter(key -> key.type() == PerformanceType.CONCERT)
+            .map(PerformanceKey::id)
+            .toList();
+        return ids.isEmpty() ? List.of(-1L) : ids;
+    }
+
+    public List<Long> getExcludedFestivalIds() {
+        List<Long> ids = addedPerformanceKeys.stream()
+            .filter(key -> key.type() == PerformanceType.FESTIVAL)
+            .map(PerformanceKey::id)
+            .toList();
+        return ids.isEmpty() ? List.of(-1L) : ids;
     }
 
     public RecentPerformancesDTO build() {

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/PerformanceReservationDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/PerformanceReservationDTO.java
@@ -1,21 +1,8 @@
 package org.sopt.confeti.api.performance.facade.dto.response;
 
 import java.util.List;
-import org.sopt.confeti.domain.view.performance.PerformanceTicketDTO;
 
 public record PerformanceReservationDTO(
-    boolean isPersonalized,
     List<PerformanceReservationDetailDTO> performanceReservation
 ) {
-
-    public static PerformanceReservationDTO of(
-        boolean isPersonalized,
-        List<PerformanceTicketDTO> performanceTickets) {
-        return new PerformanceReservationDTO(
-            isPersonalized,
-            performanceTickets.stream()
-                .map(PerformanceReservationDetailDTO::from)
-                .toList()
-        );
-    }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/PerformanceReservationDetailDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/PerformanceReservationDetailDTO.java
@@ -9,15 +9,28 @@ public record PerformanceReservationDetailDTO(
         long typeId,
         PerformanceType type,
         String title,
-        LocalDateTime reserveAt
+        LocalDateTime reserveAt,
+        boolean isFavorite
 ) {
-    public static PerformanceReservationDetailDTO from(PerformanceTicketDTO performanceTicketDTO) {
+    public static PerformanceReservationDetailDTO of(PerformanceTicketDTO performanceTicketDTO, boolean isFavorite) {
         return new PerformanceReservationDetailDTO(
                 performanceTicketDTO.index(),
                 performanceTicketDTO.typeId(),
                 performanceTicketDTO.type(),
                 performanceTicketDTO.title(),
-                performanceTicketDTO.reserveAt()
+                performanceTicketDTO.reserveAt(),
+                isFavorite
+        );
+    }
+
+    public PerformanceReservationDetailDTO withIndex(int newIndex) {
+        return new PerformanceReservationDetailDTO(
+                newIndex,
+                typeId,
+                type,
+                title,
+                reserveAt,
+                isFavorite
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecentPerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecentPerformanceDTO.java
@@ -1,8 +1,6 @@
 package org.sopt.confeti.api.performance.facade.dto.response;
 
 import java.time.LocalDate;
-import org.sopt.confeti.domain.concert.Concert;
-import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 
@@ -13,33 +11,10 @@ public record RecentPerformanceDTO(
         String title,
         String area,
         LocalDate startAt,
-        String posterPath
+        String posterPath,
+        boolean isFavorite
 ) {
-    public static RecentPerformanceDTO of(final Concert concert, final long performanceId) {
-        return new RecentPerformanceDTO(
-                performanceId,
-                concert.getId(),
-                PerformanceType.CONCERT,
-                concert.getTitle(),
-                concert.getArea(),
-                concert.getStartAt(),
-                concert.getPosterPath()
-        );
-    }
-
-    public static RecentPerformanceDTO of(final Festival festival, final long performanceId) {
-        return new RecentPerformanceDTO(
-                performanceId,
-                festival.getId(),
-                PerformanceType.FESTIVAL,
-                festival.getTitle(),
-                festival.getArea(),
-                festival.getStartAt(),
-                festival.getPosterPath()
-        );
-    }
-
-    public static RecentPerformanceDTO from(final Performance performance) {
+    public static RecentPerformanceDTO of(final Performance performance, final boolean isFavorite) {
         return new RecentPerformanceDTO(
                 performance.getId(),
                 performance.getTypeId(),
@@ -47,7 +22,12 @@ public record RecentPerformanceDTO(
                 performance.getTitle(),
                 performance.getArea(),
                 performance.getStartAt(),
-                performance.getPosterPath()
+                performance.getPosterPath(),
+                isFavorite
         );
+    }
+
+    public static RecentPerformanceDTO from(final Performance performance) {
+        return of(performance, false);
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecentPerformancesDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/RecentPerformancesDTO.java
@@ -1,18 +1,8 @@
 package org.sopt.confeti.api.performance.facade.dto.response;
 
 import java.util.List;
-import org.sopt.confeti.domain.view.performance.Performance;
 
 public record RecentPerformancesDTO(
-        boolean isPersonalized,
         List<RecentPerformanceDTO> performances
 ) {
-    public static RecentPerformancesDTO of(boolean isPersonalized, List<Performance> performances) {
-        return new RecentPerformancesDTO(
-                isPersonalized,
-                performances.stream()
-                        .map(RecentPerformanceDTO::from)
-                        .toList()
-        );
-    }
 }

--- a/src/main/java/org/sopt/confeti/domain/artist_favorite/application/ArtistFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/artist_favorite/application/ArtistFavoriteService.java
@@ -8,19 +8,23 @@ import lombok.AllArgsConstructor;
 import org.sopt.confeti.domain.artist_favorite.ArtistFavorite;
 import org.sopt.confeti.domain.artist_favorite.infra.repository.ArtistFavoriteRepository;
 import org.sopt.confeti.domain.user.User;
+import org.sopt.confeti.global.annotation.ReadOnlyTransactional;
 import org.sopt.confeti.global.resolver.music_api.MusicAPIResolver;
+import org.sopt.confeti.global.resolver.music_api.artist.vo.ConfetiArtist;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @AllArgsConstructor
 public class ArtistFavoriteService {
-    ArtistFavoriteRepository artistFavoriteRepository;
+
     private final MusicAPIResolver musicAPIResolver;
+    ArtistFavoriteRepository artistFavoriteRepository;
 
     @Transactional(readOnly = true)
     public List<ArtistFavorite> getFavoriteArtistsPreview(Long userId) {
-        List<ArtistFavorite> artistList = artistFavoriteRepository.findTop4ByUserIdOrderByRand(userId);
+        List<ArtistFavorite> artistList = artistFavoriteRepository.findTop4ByUserIdOrderByRand(
+            userId);
         musicAPIResolver.load(artistList);
 
         return artistList;
@@ -34,15 +38,15 @@ public class ArtistFavoriteService {
     @Transactional
     public void addFavorite(final User user, final String artistId) {
         artistFavoriteRepository.save(
-                ArtistFavorite.create(user, artistId)
+            ArtistFavorite.create(user, artistId)
         );
     }
 
     @Transactional
     public void addFavorites(final User user, final Set<String> artistIds) {
         Set<ArtistFavorite> artistFavorites = artistIds.stream()
-                .map(artistId -> ArtistFavorite.create(user, artistId))
-                .collect(Collectors.toSet());
+            .map(artistId -> ArtistFavorite.create(user, artistId))
+            .collect(Collectors.toSet());
 
         artistFavoriteRepository.saveAll(artistFavorites);
     }
@@ -57,14 +61,18 @@ public class ArtistFavoriteService {
         return artistFavoriteRepository.existsByUserId(userId);
     }
 
-    @Transactional(readOnly = true)
-    public List<ArtistFavorite> getArtistIdsByUserId(final long userId) {
-        return artistFavoriteRepository.findArtistFavoritesByUserId(userId);
+    @ReadOnlyTransactional
+    public List<String> getArtistIdsByUserId(final long userId) {
+        return artistFavoriteRepository.findArtistFavoritesByUserId(userId).stream()
+            .map(ArtistFavorite::getArtist)
+            .map(ConfetiArtist::getId)
+            .toList();
     }
 
     @Transactional(readOnly = true)
     public List<ArtistFavorite> getFavoriteArtists(Long userId, String sortBy) {
-        List<ArtistFavorite> artistList = artistFavoriteRepository.findArtistFavoritesByUserId(userId);
+        List<ArtistFavorite> artistList = artistFavoriteRepository.findArtistFavoritesByUserId(
+            userId);
         musicAPIResolver.load(artistList);
 
         if ("createdAt".equalsIgnoreCase(sortBy)) {

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -5,7 +5,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -107,7 +106,7 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
-    public List<Performance> getRecentPerformancesExcluding(final Set<Long> excludedIds,
+    public List<Performance> getRecentPerformancesExcluding(final List<Long> excludedIds,
         final int size) {
         return performanceRepository.findRecentPerformancesExcluding(
             excludedIds,

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -106,11 +106,16 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
-    public List<Performance> getRecentPerformancesExcluding(final List<Long> excludedIds,
+    public List<Performance> getRecentPerformancesExcluding(
+        final List<Long> excludedConcertIds,
+        final List<Long> excludedFestivalIds,
         final int size) {
         return performanceRepository.findRecentPerformancesExcluding(
-            excludedIds,
+            excludedConcertIds,
+            excludedFestivalIds,
             LocalDate.now(),
+            PerformanceType.CONCERT,
+            PerformanceType.FESTIVAL,
             getPageRequest(size, getRecentPerformancesSort())
         );
     }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -5,6 +5,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -47,18 +48,15 @@ public class PerformanceService {
     @Transactional(readOnly = true)
     public List<PerformanceDTO> getFavoritePerformancesAll(final long userId, final String type) {
         return performanceRepository.findPerformancesByUserFavorites(userId, type).stream()
-                .map(PerformanceDTO::from)
-                .toList();
+            .map(PerformanceDTO::from)
+            .toList();
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceTicketDTO> getFavoritePerformancesReservation(final Long userId) {
-        return performanceDTORepository.findFavoritePerformancesReservation(userId);
-    }
-
-    @Transactional(readOnly = true)
-    public List<PerformanceTicketDTO> getPerformancesReservation() {
-        return performanceDTORepository.findPerformancesReservation();
+    public List<PerformanceTicketDTO> getFavoritePerformancesReservation(final Long userId,
+        final int reservationPerformanceCount) {
+        return performanceDTORepository.findFavoritePerformancesReservation(userId,
+            reservationPerformanceCount);
     }
 
     @Transactional
@@ -67,10 +65,11 @@ public class PerformanceService {
     }
 
     @Transactional(readOnly = true)
-    public List<Performance> getPerformancesByArtistIds(final List<String> artistIds, final int size) {
+    public List<Performance> getPerformancesByArtistIds(final List<String> artistIds,
+        final int size) {
         return performanceRepository.findPerformancesByArtistIds(
-                artistIds,
-                getPageRequest(size, getRecentPerformancesSort())
+            artistIds,
+            getPageRequest(size, getRecentPerformancesSort())
         );
     }
 
@@ -80,39 +79,51 @@ public class PerformanceService {
 
     private Sort getRecentPerformancesSort() {
         return Sort.by(
-                Order.desc(CREATED_AT_COLUMN)
+            Order.desc(CREATED_AT_COLUMN)
         );
     }
 
     @Transactional(readOnly = true)
     public List<PerformanceDTO> getPerformancesByArtistId(final String artistId) {
         return performanceRepository.findPerformancesByArtistId(artistId).stream()
-                .map(PerformanceDTO::from)
-                .toList();
+            .map(PerformanceDTO::from)
+            .toList();
     }
 
     @Transactional(readOnly = true)
     public List<PerformanceDTO> getAllPerformancesByArtistId(final String artistId) {
         return performanceRepository.findPerformancesByArtists_ArtistId(artistId).stream()
-                .map(PerformanceDTO::from)
-                .toList();
+            .map(PerformanceDTO::from)
+            .toList();
     }
 
     @Transactional(readOnly = true)
-    public List<Performance> getRecentPerformances(final int recentPerformancesSize) {
-        return performanceRepository.findRecentPerformancesByEndAtGreaterThanEqual(
-                LocalDate.now(),
-                getPageRequest(recentPerformancesSize, getRecentPerformancesSort())
-        ).stream().toList();
+    public List<PerformanceTicketDTO> getPerformancesReservationExcluding(
+        final List<Long> excludedConcertIds,
+        final List<Long> excludedFestivalIds,
+        final int limit) {
+        return performanceDTORepository.findPerformancesReservationExcluding(
+            excludedConcertIds, excludedFestivalIds, limit);
+    }
+
+    @Transactional(readOnly = true)
+    public List<Performance> getRecentPerformancesExcluding(final Set<Long> excludedIds,
+        final int size) {
+        return performanceRepository.findRecentPerformancesExcluding(
+            excludedIds,
+            LocalDate.now(),
+            getPageRequest(size, getRecentPerformancesSort())
+        );
     }
 
     @Transactional
     public void addPerformanceArtists(PerformanceType performanceType, long festivalId,
-                                      List<PerformanceArtist> performanceArtists) {
-        Performance performance = performanceRepository.findPerformanceByTypeAndTypeId(performanceType, festivalId)
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
-                );
+        List<PerformanceArtist> performanceArtists) {
+        Performance performance = performanceRepository.findPerformanceByTypeAndTypeId(
+                performanceType, festivalId)
+            .orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+            );
 
         performance.addArtists(performanceArtists);
     }
@@ -120,14 +131,14 @@ public class PerformanceService {
     @Transactional
     public Performance getUpcomingPerformanceByUserId(final Long userId) {
         return performanceRepository.upcomingPerformanceByUserId(userId)
-                .orElse(null);
+            .orElse(null);
     }
 
     @Transactional(readOnly = true)
     public List<PerformanceDTO> getAllPerformances() {
         return performanceRepository.findAll().stream()
-                .map(PerformanceDTO::from)
-                .toList();
+            .map(PerformanceDTO::from)
+            .toList();
     }
 
     @Deprecated
@@ -144,26 +155,27 @@ public class PerformanceService {
     @Transactional(readOnly = true)
     public PerformanceDTO getPerformance(long performanceId) {
         Performance performance = performanceRepository.findPerformanceByIdAndEndAtGreaterThanEqual(
-                        performanceId,
-                        LocalDate.now())
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
-                );
+                performanceId,
+                LocalDate.now())
+            .orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+            );
 
         return PerformanceDTO.from(performance);
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceDTO> getPerformancesByArtistIdAndType(String artistId, PerformanceType type) {
+    public List<PerformanceDTO> getPerformancesByArtistIdAndType(String artistId,
+        PerformanceType type) {
         if (type == PerformanceType.PERFORMANCE) {
             return performanceRepository.findPerformancesByArtistId(artistId).stream()
-                    .map(PerformanceDTO::from)
-                    .toList();
+                .map(PerformanceDTO::from)
+                .toList();
         }
 
         return performanceRepository.findPerformancesByTypeAndArtistId(type, artistId).stream()
-                .map(PerformanceDTO::from)
-                .toList();
+            .map(PerformanceDTO::from)
+            .toList();
     }
 
     @Transactional(readOnly = true)
@@ -179,53 +191,57 @@ public class PerformanceService {
     @Transactional(readOnly = true)
     public Performance getPerformanceById(long performanceId) {
         return performanceRepository.findById(performanceId)
-                .orElseThrow(
-                        () -> new NotFoundException(ErrorMessage.NOT_FOUND)
-                );
+            .orElseThrow(
+                () -> new NotFoundException(ErrorMessage.NOT_FOUND)
+            );
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceDTO> getUpcomingPerformances(GetUpcomingPerformancesDTO upcomingPerformancesDTO) {
-        List<Pair<PerformanceType, Long>> performancePairs = convertToPairs(upcomingPerformancesDTO);
+    public List<PerformanceDTO> getUpcomingPerformances(
+        GetUpcomingPerformancesDTO upcomingPerformancesDTO) {
+        List<Pair<PerformanceType, Long>> performancePairs = convertToPairs(
+            upcomingPerformancesDTO);
         List<Performance> performances = performanceCriteriaRepository.findPerformancesByTypeAndTypeId(
-                performancePairs);
+            performancePairs);
 
         Map<Pair<PerformanceType, Long>, Performance> performanceMapper = performances.stream()
-                .collect(Collectors.toMap(
-                        performance -> Pair.of(performance.getType(), performance.getTypeId()),
-                        Function.identity()
-                ));
+            .collect(Collectors.toMap(
+                performance -> Pair.of(performance.getType(), performance.getTypeId()),
+                Function.identity()
+            ));
 
         return performancePairs.stream()
-                .map(performanceMapper::get)
-                .filter(Objects::nonNull)
-                .map(PerformanceDTO::from)
-                .toList();
+            .map(performanceMapper::get)
+            .filter(Objects::nonNull)
+            .map(PerformanceDTO::from)
+            .toList();
     }
 
     @Transactional(readOnly = true)
     public Performance getPerformanceByTypeAndTypeId(PerformanceType type, long typeId) {
         return performanceRepository.findPerformanceByTypeAndTypeId(type, typeId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
     public Performance getWithArtistsByTypeAndTypeId(PerformanceType type, long typeId) {
         return performanceRepository.findWithArtistsByTypeAndTypeId(type, typeId)
-                .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceDTO> getPerformancesByTypeAndTypeIds(PerformanceType type, List<Long> typeIds) {
+    public List<PerformanceDTO> getPerformancesByTypeAndTypeIds(PerformanceType type,
+        List<Long> typeIds) {
         return performanceRepository.findPerformancesByTypeAndTypeIdIn(type, typeIds).stream()
-                .map(PerformanceDTO::from)
-                .toList();
+            .map(PerformanceDTO::from)
+            .toList();
     }
 
-    private List<Pair<PerformanceType, Long>> convertToPairs(GetUpcomingPerformancesDTO upcomingPerformancesDTO) {
+    private List<Pair<PerformanceType, Long>> convertToPairs(
+        GetUpcomingPerformancesDTO upcomingPerformancesDTO) {
         return upcomingPerformancesDTO.upcomingPerformanceDTOs().stream()
-                .map(performanceDTO -> Pair.of(performanceDTO.type(), performanceDTO.typeId()))
-                .toList();
+            .map(performanceDTO -> Pair.of(performanceDTO.type(), performanceDTO.typeId()))
+            .toList();
     }
 
     @Transactional(readOnly = true)
@@ -236,14 +252,15 @@ public class PerformanceService {
     @Transactional(readOnly = true)
     public List<PerformanceDTO> getRandomUpcomingPerformances(int fetchSize) {
         return performanceRepository.findUpcomingPerformancesByRand(fetchSize).stream()
-                .map(PerformanceDTO::from)
-                .toList();
+            .map(PerformanceDTO::from)
+            .toList();
     }
 
     @Transactional(readOnly = true)
-    public List<PerformanceArtistDTO> getRandomPerformanceArtists(long performanceId, int fetchSize) {
+    public List<PerformanceArtistDTO> getRandomPerformanceArtists(long performanceId,
+        int fetchSize) {
         return performanceRepository.findPerformanceArtistsByRand(performanceId, fetchSize).stream()
-                .map(PerformanceArtistDTO::from)
-                .toList();
+            .map(PerformanceArtistDTO::from)
+            .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceDTORepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceDTORepository.java
@@ -17,23 +17,22 @@ import org.springframework.stereotype.Repository;
 @RequiredArgsConstructor
 public class PerformanceDTORepository {
 
-    private final EntityManager em;
-
     private static final int PREVIEW_FAVORITE_PERFORMANCE_COUNT = 4;
-    private static final int RESERVE_FAVORITE_PERFORMANCE_COUNT = 5;
+    private final EntityManager em;
 
     public List<PerformancePreviewDTO> findFavoritePerformancesPreview(final Long userId) {
         String sql =
-                "SELECT c.id id, :concertType type, c.title title, c.poster_path posterPath, c.start_at startAt" +
-                        " FROM concert_favorites cf INNER JOIN concerts c ON cf.concert_id = c.id" +
-                        " WHERE cf.user_id = :userId AND c.end_at >= CURRENT_DATE" +
-                        " UNION" +
-                        " SELECT f.id id, :festivalType type, f.title title, f.poster_path posterPath, f.start_at startAt"
-                        +
-                        " FROM festival_favorites ff INNER JOIN festivals f ON ff.festival_id = f.id" +
-                        " WHERE ff.user_id = :userId AND f.end_at >= CURRENT_DATE" +
-                        " ORDER BY startAt ASC" +
-                        " LIMIT :performancePreviewCount";
+            "SELECT c.id id, :concertType type, c.title title, c.poster_path posterPath, c.start_at startAt"
+                +
+                " FROM concert_favorites cf INNER JOIN concerts c ON cf.concert_id = c.id" +
+                " WHERE cf.user_id = :userId AND c.end_at >= CURRENT_DATE" +
+                " UNION" +
+                " SELECT f.id id, :festivalType type, f.title title, f.poster_path posterPath, f.start_at startAt"
+                +
+                " FROM festival_favorites ff INNER JOIN festivals f ON ff.festival_id = f.id" +
+                " WHERE ff.user_id = :userId AND f.end_at >= CURRENT_DATE" +
+                " ORDER BY startAt ASC" +
+                " LIMIT :performancePreviewCount";
 
         Query query = em.createNativeQuery(sql);
         query.setParameter("userId", userId);
@@ -46,63 +45,69 @@ public class PerformanceDTORepository {
 
     private List<PerformancePreviewDTO> convertToPerformanceDTOs(final List<Object[]> results) {
         return results.stream()
-                .map(result -> PerformancePreviewDTO.of(
-                        ((Number) result[0]).longValue(),
-                        (String) result[1],
-                        (String) result[2],
-                        (String) result[3]
-                ))
-                .toList();
+            .map(result -> PerformancePreviewDTO.of(
+                ((Number) result[0]).longValue(),
+                (String) result[1],
+                (String) result[2],
+                (String) result[3]
+            ))
+            .toList();
     }
 
-    public List<PerformanceTicketDTO> findFavoritePerformancesReservation(final Long userId) {
+    public List<PerformanceTicketDTO> findFavoritePerformancesReservation(final Long userId,
+        final int reservationPerformanceSize) {
         String sql = """
-                SELECT ROW_NUMBER() OVER (ORDER BY reserve_at ASC) AS ind, performance_id, type, title, reserve_at
-                FROM (
-                    SELECT c.id performance_id, :concertType type, c.title title, c.reserve_at
-                    FROM concert_favorites cf
-                    JOIN concerts c ON cf.concert_id = c.id
-                    WHERE cf.user_id = :userId AND c.reserve_at >= CURRENT_DATE 
-                    UNION ALL
-                    SELECT f.id performance_id, :festivalType type, f.title title, f.reserve_at
-                    FROM festival_favorites ff
-                    JOIN festivals f ON ff.festival_id = f.id
-                    WHERE ff.user_id = :userId AND f.reserve_at >= CURRENT_DATE
-                ) AS favorite_performances
-                ORDER BY reserve_at ASC
-                LIMIT :performanceReservationCount
-                """;
+            SELECT ROW_NUMBER() OVER (ORDER BY reserve_at ASC) AS ind, performance_id, type, title, reserve_at
+            FROM (
+                SELECT c.id performance_id, :concertType type, c.title title, c.reserve_at
+                FROM concert_favorites cf
+                JOIN concerts c ON cf.concert_id = c.id
+                WHERE cf.user_id = :userId AND c.reserve_at >= CURRENT_DATE 
+                UNION ALL
+                SELECT f.id performance_id, :festivalType type, f.title title, f.reserve_at
+                FROM festival_favorites ff
+                JOIN festivals f ON ff.festival_id = f.id
+                WHERE ff.user_id = :userId AND f.reserve_at >= CURRENT_DATE
+            ) AS favorite_performances
+            ORDER BY reserve_at ASC
+            LIMIT :performanceReservationCount
+            """;
 
         Query query = em.createNativeQuery(sql)
-                .setParameter("userId", userId)
-                .setParameter("concertType", PerformanceType.CONCERT.getName())
-                .setParameter("festivalType", PerformanceType.FESTIVAL.getName())
-                .setParameter("performanceReservationCount", RESERVE_FAVORITE_PERFORMANCE_COUNT);
+            .setParameter("userId", userId)
+            .setParameter("concertType", PerformanceType.CONCERT.getName())
+            .setParameter("festivalType", PerformanceType.FESTIVAL.getName())
+            .setParameter("performanceReservationCount", reservationPerformanceSize);
 
         List<Object[]> results = query.getResultList();
         return convertToPerformanceTicketDTOs(results);
     }
 
-    public List<PerformanceTicketDTO> findPerformancesReservation() {
+    public List<PerformanceTicketDTO> findPerformancesReservationExcluding(
+        final List<Long> excludedConcertIds,
+        final List<Long> excludedFestivalIds,
+        final int limit) {
         String sql = """
-                SELECT ROW_NUMBER() OVER (ORDER BY reserve_at ASC) AS ind, performance_id, type, title, reserve_at
-                FROM (
-                    SELECT c.id performance_id, :concertType type, c.title title, c.reserve_at
-                    FROM concerts c
-                    WHERE c.reserve_at >= CURRENT_DATE
-                    UNION ALL
-                    SELECT f.id performance_id, :festivalType type, f.title title, f.reserve_at
-                    FROM festivals f
-                    WHERE f.reserve_at >= CURRENT_DATE
-                ) AS all_performances
-                ORDER BY reserve_at ASC
-                LIMIT :performanceReservationCount
-                """;
+            SELECT ROW_NUMBER() OVER (ORDER BY reserve_at ASC) AS ind, performance_id, type, title, reserve_at
+            FROM (
+                SELECT c.id performance_id, :concertType type, c.title title, c.reserve_at
+                FROM concerts c
+                WHERE c.reserve_at >= CURRENT_DATE AND c.id NOT IN (:excludedConcertIds)
+                UNION ALL
+                SELECT f.id performance_id, :festivalType type, f.title title, f.reserve_at
+                FROM festivals f
+                WHERE f.reserve_at >= CURRENT_DATE AND f.id NOT IN (:excludedFestivalIds)
+            ) AS all_performances
+            ORDER BY reserve_at ASC
+            LIMIT :limit
+            """;
 
         Query query = em.createNativeQuery(sql)
-                .setParameter("concertType", PerformanceType.CONCERT.getName())
-                .setParameter("festivalType", PerformanceType.FESTIVAL.getName())
-                .setParameter("performanceReservationCount", RESERVE_FAVORITE_PERFORMANCE_COUNT);
+            .setParameter("concertType", PerformanceType.CONCERT.getName())
+            .setParameter("festivalType", PerformanceType.FESTIVAL.getName())
+            .setParameter("excludedConcertIds", excludedConcertIds)
+            .setParameter("excludedFestivalIds", excludedFestivalIds)
+            .setParameter("limit", limit);
 
         List<Object[]> results = query.getResultList();
         return convertToPerformanceTicketDTOs(results);
@@ -110,13 +115,14 @@ public class PerformanceDTORepository {
 
     private List<PerformanceTicketDTO> convertToPerformanceTicketDTOs(List<Object[]> results) {
         return results.stream()
-                .map(row -> PerformanceTicketDTO.of(
-                        ((Number) row[0]).intValue(),
-                        ((Number) row[1]).longValue(),
-                        (String) row[2],
-                        (String) row[3],
-                        LocalDateTime.ofInstant(Instant.ofEpochMilli(((Timestamp) row[4]).getTime()), ZoneId.of("UTC"))
-                ))
-                .toList();
+            .map(row -> PerformanceTicketDTO.of(
+                ((Number) row[0]).intValue(),
+                ((Number) row[1]).longValue(),
+                (String) row[2],
+                (String) row[3],
+                LocalDateTime.ofInstant(Instant.ofEpochMilli(((Timestamp) row[4]).getTime()),
+                    ZoneId.of("UTC"))
+            ))
+            .toList();
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -3,6 +3,7 @@ package org.sopt.confeti.domain.view.performance.infra.repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceArtist;
 import org.sopt.confeti.global.common.constant.PerformanceType;
@@ -112,6 +113,13 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
     Optional<Performance> getPerformanceByUserFavorites(final @Param("userId") Long userId);
 
     List<Performance> findRecentPerformancesByEndAtGreaterThanEqual(LocalDate now, PageRequest pageRequest);
+
+    @Query("SELECT p FROM Performance p WHERE p.endAt >= :date AND p.id NOT IN :excludedIds")
+    List<Performance> findRecentPerformancesExcluding(
+            @Param("excludedIds") Set<Long> excludedIds,
+            @Param("date") LocalDate date,
+            PageRequest pageRequest
+    );
 
     List<Performance> findByEndAtGreaterThanEqual(LocalDate now);
 

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -3,7 +3,6 @@ package org.sopt.confeti.domain.view.performance.infra.repository;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.domain.view.performance.PerformanceArtist;
 import org.sopt.confeti.global.common.constant.PerformanceType;
@@ -116,7 +115,7 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
 
     @Query("SELECT p FROM Performance p WHERE p.endAt >= :date AND p.id NOT IN :excludedIds")
     List<Performance> findRecentPerformancesExcluding(
-            @Param("excludedIds") Set<Long> excludedIds,
+            @Param("excludedIds") List<Long> excludedIds,
             @Param("date") LocalDate date,
             PageRequest pageRequest
     );

--- a/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/infra/repository/PerformanceRepository.java
@@ -113,10 +113,15 @@ public interface PerformanceRepository extends JpaRepository<Performance, Long> 
 
     List<Performance> findRecentPerformancesByEndAtGreaterThanEqual(LocalDate now, PageRequest pageRequest);
 
-    @Query("SELECT p FROM Performance p WHERE p.endAt >= :date AND p.id NOT IN :excludedIds")
+    @Query("SELECT p FROM Performance p WHERE p.endAt >= :date " +
+            "AND NOT (p.type = :concertType AND p.typeId IN :excludedConcertIds) " +
+            "AND NOT (p.type = :festivalType AND p.typeId IN :excludedFestivalIds)")
     List<Performance> findRecentPerformancesExcluding(
-            @Param("excludedIds") List<Long> excludedIds,
+            @Param("excludedConcertIds") List<Long> excludedConcertIds,
+            @Param("excludedFestivalIds") List<Long> excludedFestivalIds,
             @Param("date") LocalDate date,
+            @Param("concertType") PerformanceType concertType,
+            @Param("festivalType") PerformanceType festivalType,
             PageRequest pageRequest
     );
 


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 홈 상단의 최신 등록 순 공연 정보 조회 와 그 밑의 최신 공연 티켓팅 정보 조회 에서 폴백 전략으로 전체 공연을 조회하도록 수정 

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
