### PR TITLE
CONSERVER-30: ADMIN 계정 로그아웃 시 403 응답 발생 수정

### DIFF
--- a/src/main/java/org/sopt/confeti/api/auth/controller/AuthController.java
+++ b/src/main/java/org/sopt/confeti/api/auth/controller/AuthController.java
@@ -39,7 +39,6 @@ public class AuthController {
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, result);
     }
 
-    @Onboarding
     @Permission(role = {Role.GENERAL})
     @PostMapping("/reissue")
     public ResponseEntity<BaseResponse<Token>> reissue(
@@ -49,7 +48,6 @@ public class AuthController {
         return ApiResponseUtil.success(SuccessMessage.SUCCESS, token);
     }
 
-    @Onboarding
     @Permission(role = {Role.GENERAL})
     @PostMapping("/logout")
     public ResponseEntity<BaseResponse<Void>> logout() {
@@ -57,9 +55,6 @@ public class AuthController {
         return ApiResponseUtil.success(SuccessMessage.SUCCESS);
     }
 
-    /**
-     * 개발을 위해 임시로 Role.GENERAL 접근 허용
-     */
     @Onboarding
     @PostMapping("/onboard")
     @Deprecated

--- a/src/main/java/org/sopt/confeti/global/interceptor/auth/OnboardingInterceptor.java
+++ b/src/main/java/org/sopt/confeti/global/interceptor/auth/OnboardingInterceptor.java
@@ -39,7 +39,7 @@ public class OnboardingInterceptor implements HandlerInterceptor, CustomIntercep
             return true;
         }
 
-        // @Onboarding 어노테이션이 있는 API는 온보딩 유저 전용이다. (편의성을 위해 일반 유저와 관리자도 허용)
+        // @Onboarding 어노테이션이 있는 API는 온보딩 유저 전용이다. 관리자는 예외적으로 허용한다.
         if (isNotAllowedOnOnboardingApi()) {
             log.error("OnboardingInterceptor.preHandle : 온보딩 API에 허용되지 않은 유저가 접근 시도. 유저 정보 : {}",
                 UserContext.get());
@@ -53,7 +53,6 @@ public class OnboardingInterceptor implements HandlerInterceptor, CustomIntercep
         Role userRole = UserContext.get().role();
 
         return userRole != Role.ONBOARDING
-            && userRole != Role.GENERAL
             && userRole != Role.ADMIN;
     }
 

--- a/src/main/java/org/sopt/confeti/global/interceptor/auth/OnboardingInterceptor.java
+++ b/src/main/java/org/sopt/confeti/global/interceptor/auth/OnboardingInterceptor.java
@@ -39,8 +39,8 @@ public class OnboardingInterceptor implements HandlerInterceptor, CustomIntercep
             return true;
         }
 
-        // @Onboarding 어노테이션이 있는 API에 온보딩 유저만 접근 가능하다. (편의성을 위해 일반 유저도 임시 허용)
-        if (isNotOnboarding()) {
+        // @Onboarding 어노테이션이 있는 API는 온보딩 유저 전용이다. (편의성을 위해 일반 유저와 관리자도 허용)
+        if (isNotAllowedOnOnboardingApi()) {
             log.error("OnboardingInterceptor.preHandle : 온보딩 API에 허용되지 않은 유저가 접근 시도. 유저 정보 : {}",
                 UserContext.get());
             throw new ForbiddenException(ErrorMessage.FORBIDDEN);
@@ -49,11 +49,12 @@ public class OnboardingInterceptor implements HandlerInterceptor, CustomIntercep
         return true;
     }
 
-    private boolean isNotOnboarding() {
+    private boolean isNotAllowedOnOnboardingApi() {
         Role userRole = UserContext.get().role();
 
         return userRole != Role.ONBOARDING
-            && userRole != Role.GENERAL;
+            && userRole != Role.GENERAL
+            && userRole != Role.ADMIN;
     }
 
     private boolean isOnboarding() {

--- a/src/test/java/org/sopt/confeti/global/interceptor/auth/OnboardingInterceptorTest.java
+++ b/src/test/java/org/sopt/confeti/global/interceptor/auth/OnboardingInterceptorTest.java
@@ -37,6 +37,17 @@ class OnboardingInterceptorTest {
     }
 
     @Test
+    void preHandle_onboardingApi_rejectsGeneral() throws Exception {
+        UserContext.set(userInfo(Role.GENERAL));
+
+        assertThatThrownBy(() -> onboardingInterceptor.preHandle(
+            request,
+            response,
+            handlerMethod("onboardingApi")
+        )).isInstanceOf(ForbiddenException.class);
+    }
+
+    @Test
     void preHandle_nonOnboardingApi_rejectsOnboardingUser() throws Exception {
         UserContext.set(userInfo(Role.ONBOARDING));
 

--- a/src/test/java/org/sopt/confeti/global/interceptor/auth/OnboardingInterceptorTest.java
+++ b/src/test/java/org/sopt/confeti/global/interceptor/auth/OnboardingInterceptorTest.java
@@ -1,0 +1,71 @@
+package org.sopt.confeti.global.interceptor.auth;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.assertThatCode;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.web.method.HandlerMethod;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.annotation.Onboarding;
+import org.sopt.confeti.global.exception.ForbiddenException;
+
+class OnboardingInterceptorTest {
+
+    private final OnboardingInterceptor onboardingInterceptor = new OnboardingInterceptor();
+    private final MockHttpServletRequest request = new MockHttpServletRequest();
+    private final MockHttpServletResponse response = new MockHttpServletResponse();
+    private final TestController controller = new TestController();
+
+    @AfterEach
+    void tearDown() {
+        UserContext.clear();
+    }
+
+    @Test
+    void preHandle_onboardingApi_allowsAdmin() throws Exception {
+        UserContext.set(userInfo(Role.ADMIN));
+
+        assertThatCode(() -> onboardingInterceptor.preHandle(
+            request,
+            response,
+            handlerMethod("onboardingApi")
+        )).doesNotThrowAnyException();
+    }
+
+    @Test
+    void preHandle_nonOnboardingApi_rejectsOnboardingUser() throws Exception {
+        UserContext.set(userInfo(Role.ONBOARDING));
+
+        assertThatThrownBy(() -> onboardingInterceptor.preHandle(
+            request,
+            response,
+            handlerMethod("generalApi")
+        )).isInstanceOf(ForbiddenException.class);
+    }
+
+    private HandlerMethod handlerMethod(String methodName) throws NoSuchMethodException {
+        Method method = TestController.class.getDeclaredMethod(methodName);
+        return new HandlerMethod(controller, method);
+    }
+
+    private UserInfo userInfo(Role role) {
+        return UserInfo.builder()
+            .id(1L)
+            .role(role)
+            .build();
+    }
+
+    private static class TestController {
+
+        @Onboarding
+        public void onboardingApi() {
+        }
+
+        public void generalApi() {
+        }
+    }
+}


### PR DESCRIPTION
🔊 Summaries
•OnboardingInterceptor에서 @Onboarding 엔드포인트 허용 대상에 Role.ADMIN을 추가했습니다.
•ADMIN 계정으로 /auth/logout 호출 시 403이 발생하던 문제를 해결했습니다.
•OnboardingInterceptorTest를 추가해 ADMIN 허용 케이스와 기존 ONBOARDING 제한 동작을 검증했습니다.

✨ Notification
•
권한 인터셉터에서는 이미 ADMIN 우회 처리가 있었고, 이번 이슈는 OnboardingInterceptor의 role 분기 누락이 원인이었습니다.