### PR TITLE
CONSERVER-32(Admin) 등록 공연 삭제 API 및 연관 데이터 정리 로직 추가

### DIFF
--- a/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/AdminController.java
@@ -184,6 +184,15 @@ public class AdminController implements AdminControllerDocs {
     }
 
     @Override
+    @DeleteMapping("/performances/concerts/{concertId}")
+    public ResponseEntity<BaseResponse<Void>> deleteConcert(
+        @PathVariable("concertId") @Min(RequestConstraint.ID) long concertId
+    ) {
+        adminFacade.deleteConcert(concertId);
+        return ApiResponseUtil.success(SuccessMessage.DELETED);
+    }
+
+    @Override
     @GetMapping("/performances/festivals/{festivalId}")
     public ResponseEntity<BaseResponse<AdminFestivalDetailResponse>> getAdminFestivalDetail(
         @PathVariable("festivalId") @Min(RequestConstraint.ID) long festivalId
@@ -191,6 +200,15 @@ public class AdminController implements AdminControllerDocs {
         AdminFestivalDetailInfo festivalDetail = adminFacade.getAdminFestivalDetail(festivalId);
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             AdminFestivalDetailResponse.of(festivalDetail, s3FileHandler));
+    }
+
+    @Override
+    @DeleteMapping("/performances/festivals/{festivalId}")
+    public ResponseEntity<BaseResponse<Void>> deleteFestival(
+        @PathVariable("festivalId") @Min(RequestConstraint.ID) long festivalId
+    ) {
+        adminFacade.deleteFestival(festivalId);
+        return ApiResponseUtil.success(SuccessMessage.DELETED);
     }
 
     @Override

--- a/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/admin/controller/docs/AdminControllerDocs.java
@@ -346,6 +346,24 @@ public interface AdminControllerDocs {
     );
 
     @Operation(
+        summary = "등록된 콘서트 삭제",
+        description = "어드민 권한으로 등록된 콘서트와 연관 데이터를 삭제합니다."
+    )
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<Void>> deleteConcert(
+        @PathVariable("concertId") @Min(RequestConstraint.ID) long concertId
+    );
+
+    @Operation(
         summary = "수정할 페스티벌 단건 조회",
         description = "어드민 권한으로 수정할 페스티벌의 전체 상세 정보를 조회합니다. "
             + "예정된 공연 여부와 관계없이 모든 페스티벌을 조회할 수 있습니다."
@@ -361,6 +379,24 @@ public interface AdminControllerDocs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<AdminFestivalDetailResponse>> getAdminFestivalDetail(
+        @PathVariable("festivalId") @Min(RequestConstraint.ID) long festivalId
+    );
+
+    @Operation(
+        summary = "등록된 페스티벌 삭제",
+        description = "어드민 권한으로 등록된 페스티벌과 연관 데이터를 삭제합니다."
+    )
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<Void>> deleteFestival(
         @PathVariable("festivalId") @Min(RequestConstraint.ID) long festivalId
     );
 

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -32,7 +32,9 @@ import org.sopt.confeti.domain.concert.Concert;
 import org.sopt.confeti.domain.concert.application.ConcertService;
 import org.sopt.confeti.domain.concert.application.dto.ConcertPreviewInfo;
 import org.sopt.confeti.domain.concert_artist.ConcertArtist;
+import org.sopt.confeti.domain.concert_favorite.application.ConcertFavoriteService;
 import org.sopt.confeti.domain.concert_reservation_url.ConcertReservationUrl;
+import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.application.FestivalService;
 import org.sopt.confeti.domain.festival_artist.FestivalArtist;
@@ -50,6 +52,8 @@ import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftServ
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftCreateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.request.PerformanceDraftUpdateDto;
 import org.sopt.confeti.domain.performancedraft.application.dto.response.PerformanceDraftDto;
+import org.sopt.confeti.domain.setlist.SetlistType;
+import org.sopt.confeti.domain.setlist.application.SetlistService;
 import org.sopt.confeti.domain.ticketvendor.TicketVendor;
 import org.sopt.confeti.domain.ticketvendor.application.TicketVendorService;
 import org.sopt.confeti.domain.ticketvendor.application.dto.request.TicketVendorCreateDto;
@@ -82,11 +86,14 @@ public class AdminFacade {
     private final TicketVendorService ticketVendorService;
     private final ConcertService concertService;
     private final FestivalService festivalService;
+    private final ConcertFavoriteService concertFavoriteService;
+    private final SetlistService setlistService;
     private final MusicAPIHandler musicAPIHandler;
     private final S3FileHandler s3FileHandler;
     private final PerformanceDraftService performanceDraftService;
     private final ArtistService artistService;
     private final PerformanceService performanceService;
+    private final PerformanceSearchService performanceSearchService;
     private final ApplicationEventPublisher eventPublisher;
     private final PerformanceDraftParser performanceDraftParser;
     private final ArtistMusicAPIService artistMusicAPIService;
@@ -165,8 +172,51 @@ public class AdminFacade {
         return Tx.readOnlyTx(() -> concertService.getAdminConcertDetailInfo(concertId));
     }
 
+    public void deleteConcert(long concertId) {
+        Concert concert = Tx.readOnlyTx(() -> concertService.findById(concertId));
+
+        long performanceId = Tx.masterTx(() -> {
+            concertFavoriteService.deleteAllByConcertId(concertId);
+            setlistService.deleteByTypeAndTypeId(SetlistType.CONCERT, concertId);
+            long deletedPerformanceId = performanceService.deleteByTypeAndTypeId(
+                PerformanceType.CONCERT, concertId);
+            concertService.delete(concertId);
+            return deletedPerformanceId;
+        });
+
+        concertService.deleteDetailCache(concertId);
+        publishS3DeleteEventIfExists(
+            FolderPath.combine(FolderPath.CONCERT, FolderPath.POSTER),
+            concert.getPosterPath()
+        );
+        deletePerformanceSearchDocument(performanceId);
+    }
+
     public AdminFestivalDetailInfo getAdminFestivalDetail(long festivalId) {
         return Tx.readOnlyTx(() -> festivalService.getAdminFestivalDetailInfo(festivalId));
+    }
+
+    public void deleteFestival(long festivalId) {
+        Festival festival = Tx.readOnlyTx(() -> festivalService.findById(festivalId));
+
+        long performanceId = Tx.masterTx(() -> {
+            setlistService.deleteByTypeAndTypeId(SetlistType.FESTIVAL, festivalId);
+            long deletedPerformanceId = performanceService.deleteByTypeAndTypeId(
+                PerformanceType.FESTIVAL, festivalId);
+            festivalService.delete(festivalId);
+            return deletedPerformanceId;
+        });
+
+        festivalService.deleteDetailCache(festivalId);
+        publishS3DeleteEventIfExists(
+            FolderPath.combine(FolderPath.FESTIVAL, FolderPath.POSTER),
+            festival.getPosterPath()
+        );
+        publishS3DeleteEventIfExists(
+            FolderPath.combine(FolderPath.FESTIVAL, FolderPath.LOGO),
+            festival.getLogoPath()
+        );
+        deletePerformanceSearchDocument(performanceId);
     }
 
     public AdminFestivalListInfo getAdminFestivals(String keyword) {
@@ -486,6 +536,22 @@ public class AdminFacade {
         return command.artistIds().stream()
             .map(PerformanceArtist::create)
             .toList();
+    }
+
+    private void publishS3DeleteEventIfExists(String folderPath, String filePath) {
+        Optional.ofNullable(filePath)
+            .ifPresent(path -> eventPublisher.publishEvent(new S3FileDeleteEvent(folderPath, path)));
+    }
+
+    private void deletePerformanceSearchDocument(long performanceId) {
+        try {
+            performanceSearchService.deleteById(performanceId);
+        } catch (Exception e) {
+            log.warn(
+                "AdminFacade.deletePerformanceSearchDocument : 검색 인덱스 문서 삭제에 실패했습니다. performanceId : {}, message : {}",
+                performanceId, e.getMessage(), e
+            );
+        }
     }
 
     public PutAdminFestivalResponse upsertFestival(MultipartFile poster, MultipartFile logo,

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -76,6 +76,8 @@ import org.sopt.confeti.global.transaction.Tx;
 import org.sopt.confeti.global.util.S3FileHandler;
 import org.sopt.confeti.global.util.music.MusicAPIHandler;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.transaction.support.TransactionSynchronization;
+import org.springframework.transaction.support.TransactionSynchronizationManager;
 import org.springframework.web.multipart.MultipartFile;
 
 @Slf4j
@@ -175,21 +177,20 @@ public class AdminFacade {
     public void deleteConcert(long concertId) {
         Concert concert = Tx.readOnlyTx(() -> concertService.findById(concertId));
 
-        long performanceId = Tx.masterTx(() -> {
+        Tx.masterTx(() -> {
+            concertService.deleteDetailCache(concertId);
             concertFavoriteService.deleteAllByConcertId(concertId);
             setlistService.deleteByTypeAndTypeId(SetlistType.CONCERT, concertId);
             long deletedPerformanceId = performanceService.deleteByTypeAndTypeId(
                 PerformanceType.CONCERT, concertId);
             concertService.delete(concertId);
-            return deletedPerformanceId;
+            registerAfterCommitCleanup(() -> publishS3DeleteEventIfExists(
+                FolderPath.combine(FolderPath.CONCERT, FolderPath.POSTER),
+                concert.getPosterPath()
+            ));
+            registerAfterCommitCleanup(
+                () -> deletePerformanceSearchDocument(deletedPerformanceId));
         });
-
-        concertService.deleteDetailCache(concertId);
-        publishS3DeleteEventIfExists(
-            FolderPath.combine(FolderPath.CONCERT, FolderPath.POSTER),
-            concert.getPosterPath()
-        );
-        deletePerformanceSearchDocument(performanceId);
     }
 
     public AdminFestivalDetailInfo getAdminFestivalDetail(long festivalId) {
@@ -199,24 +200,23 @@ public class AdminFacade {
     public void deleteFestival(long festivalId) {
         Festival festival = Tx.readOnlyTx(() -> festivalService.findById(festivalId));
 
-        long performanceId = Tx.masterTx(() -> {
+        Tx.masterTx(() -> {
+            festivalService.deleteDetailCache(festivalId);
             setlistService.deleteByTypeAndTypeId(SetlistType.FESTIVAL, festivalId);
             long deletedPerformanceId = performanceService.deleteByTypeAndTypeId(
                 PerformanceType.FESTIVAL, festivalId);
             festivalService.delete(festivalId);
-            return deletedPerformanceId;
+            registerAfterCommitCleanup(() -> publishS3DeleteEventIfExists(
+                FolderPath.combine(FolderPath.FESTIVAL, FolderPath.POSTER),
+                festival.getPosterPath()
+            ));
+            registerAfterCommitCleanup(() -> publishS3DeleteEventIfExists(
+                FolderPath.combine(FolderPath.FESTIVAL, FolderPath.LOGO),
+                festival.getLogoPath()
+            ));
+            registerAfterCommitCleanup(
+                () -> deletePerformanceSearchDocument(deletedPerformanceId));
         });
-
-        festivalService.deleteDetailCache(festivalId);
-        publishS3DeleteEventIfExists(
-            FolderPath.combine(FolderPath.FESTIVAL, FolderPath.POSTER),
-            festival.getPosterPath()
-        );
-        publishS3DeleteEventIfExists(
-            FolderPath.combine(FolderPath.FESTIVAL, FolderPath.LOGO),
-            festival.getLogoPath()
-        );
-        deletePerformanceSearchDocument(performanceId);
     }
 
     public AdminFestivalListInfo getAdminFestivals(String keyword) {
@@ -541,6 +541,22 @@ public class AdminFacade {
     private void publishS3DeleteEventIfExists(String folderPath, String filePath) {
         Optional.ofNullable(filePath)
             .ifPresent(path -> eventPublisher.publishEvent(new S3FileDeleteEvent(folderPath, path)));
+    }
+
+    private void registerAfterCommitCleanup(Runnable cleanup) {
+        if (!TransactionSynchronizationManager.isSynchronizationActive()) {
+            cleanup.run();
+            return;
+        }
+
+        TransactionSynchronizationManager.registerSynchronization(
+            new TransactionSynchronization() {
+                @Override
+                public void afterCommit() {
+                    cleanup.run();
+                }
+            }
+        );
     }
 
     private void deletePerformanceSearchDocument(long performanceId) {

--- a/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
+++ b/src/main/java/org/sopt/confeti/domain/concert/application/ConcertService.java
@@ -85,10 +85,20 @@ public class ConcertService {
     }
 
     @Transactional
+    public void delete(long concertId) {
+        Concert concert = findById(concertId);
+        concertRepository.delete(concert);
+    }
+
+    @Transactional
     public Concert findWithRelationsById(long concertId) {
         Concert concert = concertRepository.findWithArtistsById(concertId)
             .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
         concertRepository.findWithReservationUrlsById(concertId);
         return concert;
+    }
+
+    public void deleteDetailCache(long concertId) {
+        redisHandler.delete(RedisKey.PERFORMANCE_CONCERTS.createKeyInfo(concertId));
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/concert_favorite/application/ConcertFavoriteService.java
+++ b/src/main/java/org/sopt/confeti/domain/concert_favorite/application/ConcertFavoriteService.java
@@ -39,6 +39,11 @@ public class ConcertFavoriteService {
         concertFavoriteRepository.deleteByUserIdAndConcertId(userId, concertId);
     }
 
+    @Transactional
+    public void deleteAllByConcertId(final long concertId) {
+        concertFavoriteRepository.deleteAllByConcertId(concertId);
+    }
+
     @Transactional(readOnly = true)
     public boolean existsUpcomingReservationByUserId(final Long userId) {
         return concertFavoriteRepository.existsUpcomingReservationByUserId(userId);

--- a/src/main/java/org/sopt/confeti/domain/concert_favorite/infra/repository/ConcertFavoriteRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/concert_favorite/infra/repository/ConcertFavoriteRepository.java
@@ -26,6 +26,8 @@ public interface ConcertFavoriteRepository extends JpaRepository<ConcertFavorite
 
     void deleteByUserIdAndConcertId(final long userId, final long concertId);
 
+    void deleteAllByConcertId(final long concertId);
+
     @Query("SELECT CASE WHEN COUNT(cf) > 0 THEN true ELSE false END " +
         "FROM ConcertFavorite cf " +
         "WHERE cf.user.id = :userId " +

--- a/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
+++ b/src/main/java/org/sopt/confeti/domain/elastic_search/application/PerformanceSearchService.java
@@ -26,6 +26,10 @@ public class PerformanceSearchService {
         performanceSearchRepository.saveAll(performanceDocuments);
     }
 
+    public void deleteById(long performanceId) {
+        performanceSearchRepository.deleteById(performanceId);
+    }
+
     public List<SearchPerformanceResult> getPerformancesByTitleAndTypePartialMatched(String ptitle,
                                                                                      PerformanceType ptype) {
         List<PerformanceDocument> performances = performanceSearchOperator.searchByTitleAndTypePartialMatch(

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -125,6 +125,12 @@ public class FestivalService {
         return festivalRepository.save(festival).getId();
     }
 
+    @Transactional
+    public void delete(long festivalId) {
+        Festival festival = findById(festivalId);
+        festivalRepository.delete(festival);
+    }
+
     @Transactional(readOnly = true)
     public AdminFestivalDetailInfo getAdminFestivalDetailInfo(long festivalId) {
         Festival festival = festivalRepository.findWithDatesById(festivalId)
@@ -194,5 +200,9 @@ public class FestivalService {
         }
         return festivalRepository.findAllByTitleContainingOrAreaContainingOrSubtitleContaining(
             keyword, keyword, keyword);
+    }
+
+    public void deleteDetailCache(long festivalId) {
+        redisHandler.delete(RedisKey.PERFORMANCE_FESTIVALS.createKeyInfo(festivalId));
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival_time/FestivalTime.java
+++ b/src/main/java/org/sopt/confeti/domain/festival_time/FestivalTime.java
@@ -44,7 +44,7 @@ public class FestivalTime {
     private LocalTime startAt;
     @Column(nullable = false)
     private LocalTime endAt;
-    @OneToMany(mappedBy = "festivalTime", cascade = CascadeType.ALL, orphanRemoval = true)
+    @OneToMany(mappedBy = "festivalTime")
     private List<FestivalArtist> artists = new ArrayList<>();
 
     @Builder

--- a/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/application/SetlistService.java
@@ -227,4 +227,9 @@ public class SetlistService {
     public List<Long> findConcertIdsByUserId(final Long userId) {
         return setlistRepository.findConcertIdsByUserId(userId);
     }
+
+    @Transactional
+    public void deleteByTypeAndTypeId(SetlistType type, Long typeId) {
+        setlistRepository.deleteAllByTypeAndTypeId(type, typeId);
+    }
 }

--- a/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/setlist/infra/repository/SetlistRepository.java
@@ -24,4 +24,6 @@ public interface SetlistRepository extends JpaRepository<Setlist, Long> {
 
     @Query("SELECT s.typeId FROM Setlist s WHERE s.type =  org.sopt.confeti.domain.setlist.SetlistType.CONCERT AND s.user.id = :userId")
     List<Long> findConcertIdsByUserId(@Param("userId") Long userId);
+
+    void deleteAllByTypeAndTypeId(SetlistType type, Long typeId);
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/PerformanceService.java
@@ -62,6 +62,15 @@ public class PerformanceService {
         performanceRepository.save(performances);
     }
 
+    @Transactional
+    public long deleteByTypeAndTypeId(PerformanceType type, long typeId) {
+        Performance performance = performanceRepository.findPerformanceByTypeAndTypeId(type, typeId)
+            .orElseThrow(() -> new NotFoundException(ErrorMessage.NOT_FOUND));
+        long performanceId = performance.getId();
+        performanceRepository.delete(performance);
+        return performanceId;
+    }
+
     @Transactional(readOnly = true)
     public List<Performance> getPerformancesByArtistIds(final List<String> artistIds,
         final int size) {

--- a/src/test/java/org/sopt/confeti/api/admin/facade/AdminFacadeDeleteTest.java
+++ b/src/test/java/org/sopt/confeti/api/admin/facade/AdminFacadeDeleteTest.java
@@ -1,0 +1,154 @@
+package org.sopt.confeti.api.admin.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.confeti.domain.concert.Concert;
+import org.sopt.confeti.domain.concert.application.ConcertService;
+import org.sopt.confeti.domain.concert_favorite.application.ConcertFavoriteService;
+import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
+import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.music.artist.application.ArtistMusicAPIService;
+import org.sopt.confeti.domain.music.artist.application.ArtistService;
+import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftParser;
+import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftService;
+import org.sopt.confeti.domain.setlist.SetlistType;
+import org.sopt.confeti.domain.setlist.application.SetlistService;
+import org.sopt.confeti.domain.ticketvendor.application.TicketVendorService;
+import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.global.common.constant.FolderPath;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.event.S3FileDeleteEvent;
+import org.sopt.confeti.global.transaction.Tx;
+import org.sopt.confeti.global.transaction.TxRunner;
+import org.sopt.confeti.global.util.S3FileHandler;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class AdminFacadeDeleteTest {
+
+    @Mock
+    private TicketVendorService ticketVendorService;
+    @Mock
+    private ConcertService concertService;
+    @Mock
+    private FestivalService festivalService;
+    @Mock
+    private ConcertFavoriteService concertFavoriteService;
+    @Mock
+    private SetlistService setlistService;
+    @Mock
+    private MusicAPIHandler musicAPIHandler;
+    @Mock
+    private S3FileHandler s3FileHandler;
+    @Mock
+    private PerformanceDraftService performanceDraftService;
+    @Mock
+    private ArtistService artistService;
+    @Mock
+    private PerformanceService performanceService;
+    @Mock
+    private PerformanceSearchService performanceSearchService;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private PerformanceDraftParser performanceDraftParser;
+    @Mock
+    private ArtistMusicAPIService artistMusicAPIService;
+
+    private AdminFacade adminFacade;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(Tx.class, "txRunner", new TxRunner());
+        adminFacade = new AdminFacade(
+            ticketVendorService,
+            concertService,
+            festivalService,
+            concertFavoriteService,
+            setlistService,
+            musicAPIHandler,
+            s3FileHandler,
+            performanceDraftService,
+            artistService,
+            performanceService,
+            performanceSearchService,
+            eventPublisher,
+            performanceDraftParser,
+            artistMusicAPIService
+        );
+    }
+
+    @Test
+    void deleteConcert_연관_데이터를_함께_정리한다() {
+        long concertId = 1L;
+        long performanceId = 11L;
+        Concert concert = org.mockito.Mockito.mock(Concert.class);
+
+        given(concertService.findById(concertId)).willReturn(concert);
+        given(concert.getPosterPath()).willReturn("poster.png");
+        given(performanceService.deleteByTypeAndTypeId(PerformanceType.CONCERT, concertId))
+            .willReturn(performanceId);
+
+        adminFacade.deleteConcert(concertId);
+
+        verify(concertFavoriteService).deleteAllByConcertId(concertId);
+        verify(setlistService).deleteByTypeAndTypeId(SetlistType.CONCERT, concertId);
+        verify(performanceService).deleteByTypeAndTypeId(PerformanceType.CONCERT, concertId);
+        verify(concertService).delete(concertId);
+        verify(concertService).deleteDetailCache(concertId);
+        verify(performanceSearchService).deleteById(performanceId);
+
+        ArgumentCaptor<S3FileDeleteEvent> captor = ArgumentCaptor.forClass(S3FileDeleteEvent.class);
+        verify(eventPublisher).publishEvent(captor.capture());
+        assertThat(captor.getValue().folderPath()).isEqualTo(
+            FolderPath.combine(FolderPath.CONCERT, FolderPath.POSTER));
+        assertThat(captor.getValue().filePath()).isEqualTo("poster.png");
+    }
+
+    @Test
+    void deleteFestival_포스터와_로고까지_정리한다() {
+        long festivalId = 2L;
+        long performanceId = 22L;
+        Festival festival = org.mockito.Mockito.mock(Festival.class);
+
+        given(festivalService.findById(festivalId)).willReturn(festival);
+        given(festival.getPosterPath()).willReturn("poster.png");
+        given(festival.getLogoPath()).willReturn("logo.png");
+        given(performanceService.deleteByTypeAndTypeId(PerformanceType.FESTIVAL, festivalId))
+            .willReturn(performanceId);
+
+        adminFacade.deleteFestival(festivalId);
+
+        verify(setlistService).deleteByTypeAndTypeId(SetlistType.FESTIVAL, festivalId);
+        verify(performanceService).deleteByTypeAndTypeId(PerformanceType.FESTIVAL, festivalId);
+        verify(festivalService).delete(festivalId);
+        verify(festivalService).deleteDetailCache(festivalId);
+        verify(performanceSearchService).deleteById(performanceId);
+
+        ArgumentCaptor<S3FileDeleteEvent> captor = ArgumentCaptor.forClass(S3FileDeleteEvent.class);
+        verify(eventPublisher, org.mockito.Mockito.times(2)).publishEvent(captor.capture());
+        assertThat(captor.getAllValues())
+            .extracting(S3FileDeleteEvent::folderPath, S3FileDeleteEvent::filePath)
+            .containsExactlyInAnyOrder(
+                org.assertj.core.groups.Tuple.tuple(
+                    FolderPath.combine(FolderPath.FESTIVAL, FolderPath.POSTER),
+                    "poster.png"
+                ),
+                org.assertj.core.groups.Tuple.tuple(
+                    FolderPath.combine(FolderPath.FESTIVAL, FolderPath.LOGO),
+                    "logo.png"
+                )
+            );
+    }
+}


### PR DESCRIPTION
🔊 Summaries

• 어드민에서 등록된 콘서트/페스티벌을 삭제할 수 있도록 삭제 API를 추가했습니다.
• 공연 삭제 시 연관 데이터가 함께 정리되도록 로직을 구현했습니다.
• 콘서트: 즐겨찾기, 셋리스트, performances 데이터, Redis 상세 캐시, S3 포스터, Elasticsearch 문서를 함께 삭제합니다.
• 페스티벌: 셋리스트, performances 데이터, Redis 상세 캐시, S3 포스터/로고, Elasticsearch 문서를 함께 삭제합니다.
• 삭제 오케스트레이션이 의도대로 동작하는지 확인하는 테스트를 추가했습니다.


✨ Notification

• 기존에는 performance draft 삭제만 존재했고, 등록된 공연 삭제 기능은 없었습니다.
•현재 삭제 API는 활성/종료 여부를 구분하지 않고 등록된 공연이면 삭제 가능합니다.
• ./gradlew test는 로컬 기본 JDK 25 환경에서 Gradle 이슈가 있어, JDK 21 환경에서 검증했습니다.
• Elasticsearch 삭제는 후처리성 정리로 들어가 있어, ES 장애 시 DB 삭제는 성공하고 검색 반영만 지연될 수 있습니다.