### PR TITLE
CONSERVER-34 타임테이블 추가 응답에 생성 id 목록 반환

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
@@ -5,6 +5,7 @@ import org.sopt.confeti.api.user.controller.docs.UserTimetableControllerDocs;
 import org.sopt.confeti.api.user.dto.request.timetable.AddTimetablesRequest;
 import org.sopt.confeti.api.user.dto.request.timetable.PatchTimeBlocksRequest;
 import org.sopt.confeti.api.user.dto.request.timetable.PatchTimetablesRequest;
+import org.sopt.confeti.api.user.dto.response.timetable.TimetableCreateResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableCursorResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableDatesResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableEntireFestivalResponse;
@@ -15,6 +16,7 @@ import org.sopt.confeti.api.user.dto.response.timetable.TimetablesToAddResponse;
 import org.sopt.confeti.api.user.facade.UserTimetableFacade;
 import org.sopt.confeti.api.user.facade.dto.request.timetable.AddTimetablesDTO;
 import org.sopt.confeti.api.user.facade.dto.request.timetable.PatchTimeBlocksDTO;
+import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableCreateResponseDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableDatesDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableEntireFestivalDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableFestivalBasicDTO;
@@ -76,12 +78,13 @@ public class UserTimetableController implements UserTimetableControllerDocs {
 
     @Permission(role = {Role.GENERAL})
     @PostMapping
-    public ResponseEntity<BaseResponse<Void>> addTimetableFestival(
+    public ResponseEntity<BaseResponse<TimetableCreateResponse>> addTimetableFestival(
         @RequestBody AddTimetablesRequest addTimetablesRequest
     ) {
-        userTimetableFacade.addTimetables(
+        TimetableCreateResponseDTO response = userTimetableFacade.addTimetables(
             AddTimetablesDTO.from(addTimetablesRequest));
-        return ApiResponseUtil.success(SuccessMessage.SUCCESS);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            TimetableCreateResponse.from(response));
     }
 
     @Permission(role = {Role.GENERAL})

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserTimetableControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserTimetableControllerDocs.java
@@ -9,6 +9,7 @@ import jakarta.validation.constraints.Min;
 import org.sopt.confeti.api.user.dto.request.timetable.AddTimetablesRequest;
 import org.sopt.confeti.api.user.dto.request.timetable.PatchTimeBlocksRequest;
 import org.sopt.confeti.api.user.dto.request.timetable.PatchTimetablesRequest;
+import org.sopt.confeti.api.user.dto.response.timetable.TimetableCreateResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableCursorResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableDatesResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableEntireFestivalResponse;
@@ -70,7 +71,7 @@ public interface UserTimetableControllerDocs {
     )
     @AuthErrorResponses
     @CommonErrorResponses
-    ResponseEntity<BaseResponse<Void>> addTimetableFestival(
+    ResponseEntity<BaseResponse<TimetableCreateResponse>> addTimetableFestival(
         @Valid @RequestBody AddTimetablesRequest addTimetablesRequest
     );
 

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/timetable/TimetableCreateResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/timetable/TimetableCreateResponse.java
@@ -1,0 +1,13 @@
+package org.sopt.confeti.api.user.dto.response.timetable;
+
+import java.util.List;
+import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableCreateResponseDTO;
+
+public record TimetableCreateResponse(
+    List<Long> timetableIds
+) {
+
+    public static TimetableCreateResponse from(TimetableCreateResponseDTO dto) {
+        return new TimetableCreateResponse(dto.timetableIds());
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -1,6 +1,7 @@
 package org.sopt.confeti.api.user.facade;
 
 
+import java.util.Comparator;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -8,6 +9,7 @@ import java.util.Set;
 import java.util.function.Function;
 import java.util.function.Predicate;
 import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.user.facade.dto.request.timetable.AddTimetableArtistDTO;
@@ -15,6 +17,7 @@ import org.sopt.confeti.api.user.facade.dto.request.timetable.AddTimetablesDTO;
 import org.sopt.confeti.api.user.facade.dto.request.timetable.PatchTimeBlockDTO;
 import org.sopt.confeti.api.user.facade.dto.request.timetable.PatchTimeBlocksDTO;
 import org.sopt.confeti.api.user.facade.dto.request.timetable.PatchTimetablesCommand;
+import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableCreateResponseDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableDatesDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableEntireFestivalDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableFestivalBasicDTO;
@@ -63,15 +66,17 @@ public class UserTimetableFacade {
     private final TimeBlockService timeBlockService;
 
     @Transactional
-    public void addTimetables(AddTimetablesDTO from) {
+    public TimetableCreateResponseDTO addTimetables(AddTimetablesDTO from) {
         long userId = UserContext.get().id();
+        List<Long> requestedFestivalIds = from.festivals().stream()
+            .map(AddTimetableArtistDTO::festivalId)
+            .distinct()
+            .toList();
 
         User user = userService.findUserTimetablesById(userId);
-        List<Festival> addFestivals = festivalService.findFestivalsByIdIn(
-            from.festivals().stream()
-                .distinct()
-                .map(AddTimetableArtistDTO::festivalId)
-                .toList()
+        List<Festival> addFestivals = sortFestivalsByRequestOrder(
+            festivalService.findFestivalsByIdIn(requestedFestivalIds),
+            requestedFestivalIds
         );
 
         validateSupportedTimetable(addFestivals);
@@ -83,8 +88,23 @@ public class UserTimetableFacade {
         );
         validateCountTimetable(user.getTimetables().size(), addFestivals.size());
 
-        timetableService.addTimetables(user, addFestivals);
+        TimetableCreateResponseDTO response = TimetableCreateResponseDTO.of(
+            timetableService.addTimetables(user, addFestivals)
+        );
         userService.updateHasTimetableHistory(userId);
+        return response;
+    }
+
+    private List<Festival> sortFestivalsByRequestOrder(List<Festival> festivals,
+        List<Long> requestedFestivalIds) {
+        Map<Long, Integer> festivalOrder = IntStream.range(0, requestedFestivalIds.size())
+            .boxed()
+            .collect(Collectors.toMap(requestedFestivalIds::get, Function.identity()));
+
+        return festivals.stream()
+            .sorted(Comparator.comparingInt(festival ->
+                festivalOrder.getOrDefault(festival.getId(), Integer.MAX_VALUE)))
+            .toList();
     }
 
     protected void validateSupportedTimetable(final Collection<Festival> currentFestivals) {

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/timetable/TimetableCreateResponseDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/timetable/TimetableCreateResponseDTO.java
@@ -1,0 +1,17 @@
+package org.sopt.confeti.api.user.facade.dto.response.timetable;
+
+import java.util.List;
+import org.sopt.confeti.domain.timetable.Timetable;
+
+public record TimetableCreateResponseDTO(
+    List<Long> timetableIds
+) {
+
+    public static TimetableCreateResponseDTO of(List<Timetable> timetables) {
+        return new TimetableCreateResponseDTO(
+            timetables.stream()
+                .map(Timetable::getId)
+                .toList()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/domain/timetable/application/TimetableService.java
+++ b/src/main/java/org/sopt/confeti/domain/timetable/application/TimetableService.java
@@ -56,8 +56,8 @@ public class TimetableService {
     }
 
     @Transactional
-    public void addTimetables(final User user, final List<Festival> festivals) {
-        timetableRepository.saveAll(
+    public List<Timetable> addTimetables(final User user, final List<Festival> festivals) {
+        return timetableRepository.saveAll(
             festivals.stream()
                 .map(festival -> Timetable.create(user, festival))
                 .toList()

--- a/src/test/java/org/sopt/confeti/api/user/facade/UserTimetableFacadeTest.java
+++ b/src/test/java/org/sopt/confeti/api/user/facade/UserTimetableFacadeTest.java
@@ -1,0 +1,132 @@
+package org.sopt.confeti.api.user.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.confeti.api.user.facade.dto.request.timetable.AddTimetableArtistDTO;
+import org.sopt.confeti.api.user.facade.dto.request.timetable.AddTimetablesDTO;
+import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableCreateResponseDTO;
+import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.festival.infra.TimetableSupportStatus;
+import org.sopt.confeti.domain.festival_date.application.FestivalDateService;
+import org.sopt.confeti.domain.time_block.application.TimeBlockService;
+import org.sopt.confeti.domain.timetable.Timetable;
+import org.sopt.confeti.domain.timetable.application.TimetableService;
+import org.sopt.confeti.domain.user.OAuthProvider;
+import org.sopt.confeti.domain.user.User;
+import org.sopt.confeti.domain.user.application.UserService;
+import org.sopt.confeti.domain.user.constant.Role;
+import org.sopt.confeti.global.interceptor.auth.UserContext;
+import org.sopt.confeti.global.interceptor.auth.UserInfo;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class UserTimetableFacadeTest {
+
+    @Mock
+    private UserService userService;
+
+    @Mock
+    private TimetableService timetableService;
+
+    @Mock
+    private FestivalService festivalService;
+
+    @Mock
+    private FestivalDateService festivalDateService;
+
+    @Mock
+    private TimeBlockService timeBlockService;
+
+    @InjectMocks
+    private UserTimetableFacade userTimetableFacade;
+
+    @AfterEach
+    void tearDown() {
+        UserContext.clear();
+    }
+
+    @Test
+    void addTimetables_returnsCreatedIdsInRequestOrder() {
+        UserContext.set(UserInfo.builder()
+            .id(1L)
+            .role(Role.GENERAL)
+            .build());
+
+        User user = User.builder()
+            .provider(OAuthProvider.KAKAO)
+            .socialId("social-id")
+            .name("confeti")
+            .profilePath(null)
+            .role(Role.GENERAL)
+            .build();
+
+        Festival firstFestival = createFestival(1L, "First");
+        Festival secondFestival = createFestival(2L, "Second");
+        Timetable firstTimetable = createTimetable(101L, user, firstFestival);
+        Timetable secondTimetable = createTimetable(202L, user, secondFestival);
+        AddTimetablesDTO request = new AddTimetablesDTO(List.of(
+            new AddTimetableArtistDTO(1L),
+            new AddTimetableArtistDTO(2L)
+        ));
+
+        given(userService.findUserTimetablesById(1L)).willReturn(user);
+        given(festivalService.findFestivalsByIdIn(List.of(1L, 2L))).willReturn(
+            List.of(secondFestival, firstFestival));
+        given(timetableService.addTimetables(eq(user), anyList())).willReturn(
+            List.of(firstTimetable, secondTimetable));
+
+        TimetableCreateResponseDTO response = userTimetableFacade.addTimetables(request);
+
+        ArgumentCaptor<List<Festival>> festivalCaptor = ArgumentCaptor.forClass(List.class);
+        verify(timetableService).addTimetables(eq(user), festivalCaptor.capture());
+        verify(userService).updateHasTimetableHistory(1L);
+
+        assertThat(festivalCaptor.getValue())
+            .extracting(Festival::getId)
+            .containsExactly(1L, 2L);
+        assertThat(response.timetableIds()).containsExactly(101L, 202L);
+    }
+
+    private Festival createFestival(long id, String title) {
+        Festival festival = Festival.create(
+            title,
+            "subtitle",
+            LocalDate.of(2026, 3, 20),
+            LocalDate.of(2026, 3, 21),
+            "Seoul",
+            "poster.png",
+            null,
+            LocalDateTime.of(2026, 1, 1, 12, 0),
+            "ALL",
+            "120m",
+            "100000",
+            "address",
+            TimetableSupportStatus.SUPPORTED,
+            List.of(),
+            List.of()
+        );
+        ReflectionTestUtils.setField(festival, "id", id);
+        return festival;
+    }
+
+    private Timetable createTimetable(long id, User user, Festival festival) {
+        Timetable timetable = Timetable.create(user, festival);
+        ReflectionTestUtils.setField(timetable, "id", id);
+        return timetable;
+    }
+}


### PR DESCRIPTION
## 🔊 Summaries
- `POST /user/timetables` 성공 응답에 생성된 타임테이블 ID 목록(`timetableIds`)을 포함하도록 변경했습니다.
- 타임테이블 생성 흐름이 저장된 엔티티 목록을 반환하도록 `controller -> facade -> service` 반환 타입을 정리했습니다.
- 요청한 페스티벌 순서대로 응답 ID가 내려가도록 정렬 로직을 추가했습니다.
- 응답 DTO와 Swagger docs를 함께 반영했습니다.
- 생성된 ID 목록이 요청 순서대로 반환되는지 검증하는 테스트를 추가했습니다.

## ✨ Notification
- 기존에는 성공 시 `data` 없이 내려가던 API가 이제 `data.timetableIds`를 포함합니다.
- 현재 API 요청 구조가 다건 추가이기 때문에 응답도 단건 `timetableId`가 아니라 배열 `timetableIds`로 정의했습니다.
- 검증은 JDK 21 환경에서 수행했습니다.
