### PR TITLE
CONSERVER-36 festival별 timetable 생성 여부 조회 API 추가

### DIFF
--- a/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/UserTimetableController.java
@@ -1,5 +1,6 @@
 package org.sopt.confeti.api.user.controller;
 
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 import org.sopt.confeti.api.user.controller.docs.UserTimetableControllerDocs;
 import org.sopt.confeti.api.user.dto.request.timetable.AddTimetablesRequest;
@@ -8,6 +9,7 @@ import org.sopt.confeti.api.user.dto.request.timetable.PatchTimetablesRequest;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableCursorResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableDatesResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableEntireFestivalResponse;
+import org.sopt.confeti.api.user.dto.response.timetable.TimetableExistenceResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableFestivalResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableHistoryResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetablesPreviewResponse;
@@ -17,6 +19,7 @@ import org.sopt.confeti.api.user.facade.dto.request.timetable.AddTimetablesDTO;
 import org.sopt.confeti.api.user.facade.dto.request.timetable.PatchTimeBlocksDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableDatesDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableEntireFestivalDTO;
+import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableExistenceDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableFestivalBasicDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableHistoryDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableToAddDTO;
@@ -31,6 +34,7 @@ import org.sopt.confeti.global.common.BaseResponse;
 import org.sopt.confeti.global.common.CursorPage;
 import org.sopt.confeti.global.common.constant.Default;
 import org.sopt.confeti.global.common.constant.PerformanceStatus;
+import org.sopt.confeti.global.common.constant.RequestConstraint;
 import org.sopt.confeti.global.common.constant.TimetableSortType;
 import org.sopt.confeti.global.message.SuccessMessage;
 import org.sopt.confeti.global.util.ApiResponseUtil;
@@ -61,6 +65,17 @@ public class UserTimetableController implements UserTimetableControllerDocs {
         TimetableHistoryDTO timetableHistoryDTO = userTimetableFacade.getHasTimetableHistory();
         return ApiResponseUtil.success(SuccessMessage.SUCCESS,
             TimetableHistoryResponse.from(timetableHistoryDTO));
+    }
+
+    @Permission(role = {Role.GENERAL})
+    @GetMapping("/exists")
+    public ResponseEntity<BaseResponse<TimetableExistenceResponse>> getTimetableExistence(
+        @RequestParam(name = "festivalId") @Min(RequestConstraint.ID) Long festivalId
+    ) {
+        TimetableExistenceDTO timetableExistenceDTO = userTimetableFacade.getTimetableExistence(
+            festivalId);
+        return ApiResponseUtil.success(SuccessMessage.SUCCESS,
+            TimetableExistenceResponse.from(timetableExistenceDTO));
     }
 
     @Permission(role = {Role.GENERAL})

--- a/src/main/java/org/sopt/confeti/api/user/controller/docs/UserTimetableControllerDocs.java
+++ b/src/main/java/org/sopt/confeti/api/user/controller/docs/UserTimetableControllerDocs.java
@@ -12,6 +12,7 @@ import org.sopt.confeti.api.user.dto.request.timetable.PatchTimetablesRequest;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableCursorResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableDatesResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableEntireFestivalResponse;
+import org.sopt.confeti.api.user.dto.response.timetable.TimetableExistenceResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableFestivalResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetableHistoryResponse;
 import org.sopt.confeti.api.user.dto.response.timetable.TimetablesPreviewResponse;
@@ -43,6 +44,21 @@ public interface UserTimetableControllerDocs {
     @AuthErrorResponses
     @CommonErrorResponses
     ResponseEntity<BaseResponse<TimetableHistoryResponse>> getHasTimetableHistory();
+
+    @Operation(summary = "페스티벌별 생성된 타임테이블 존재 여부 조회")
+    @ApiResponses(
+        value = {
+            @ApiResponse(
+                responseCode = "200",
+                description = "성공"
+            )
+        }
+    )
+    @AuthErrorResponses
+    @CommonErrorResponses
+    ResponseEntity<BaseResponse<TimetableExistenceResponse>> getTimetableExistence(
+        @RequestParam(name = "festivalId") @Min(RequestConstraint.ID) Long festivalId
+    );
 
     @Operation(summary = "추가할 페스티벌 목록 조회")
     @ApiResponses(

--- a/src/main/java/org/sopt/confeti/api/user/dto/response/timetable/TimetableExistenceResponse.java
+++ b/src/main/java/org/sopt/confeti/api/user/dto/response/timetable/TimetableExistenceResponse.java
@@ -1,0 +1,16 @@
+package org.sopt.confeti.api.user.dto.response.timetable;
+
+import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableExistenceDTO;
+
+public record TimetableExistenceResponse(
+    boolean hasTimetable
+) {
+
+    public static TimetableExistenceResponse from(
+        TimetableExistenceDTO timetableExistenceDTO
+    ) {
+        return new TimetableExistenceResponse(
+            timetableExistenceDTO.hasTimetable()
+        );
+    }
+}

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -17,6 +17,7 @@ import org.sopt.confeti.api.user.facade.dto.request.timetable.PatchTimeBlocksDTO
 import org.sopt.confeti.api.user.facade.dto.request.timetable.PatchTimetablesCommand;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableDatesDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableEntireFestivalDTO;
+import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableExistenceDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableFestivalBasicDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableHistoryDTO;
 import org.sopt.confeti.api.user.facade.dto.response.timetable.TimetableToAddDTO;
@@ -260,6 +261,15 @@ public class UserTimetableFacade {
     public TimetableHistoryDTO getHasTimetableHistory() {
         boolean hasTimetableHistory = userService.hasTimetableHistory(UserContext.get().id());
         return TimetableHistoryDTO.from(hasTimetableHistory);
+    }
+
+    @ReadOnlyTransactional
+    public TimetableExistenceDTO getTimetableExistence(final long festivalId) {
+        boolean hasTimetable = timetableService.existsByUserIdAndFestivalId(
+            UserContext.get().id(),
+            festivalId
+        );
+        return TimetableExistenceDTO.from(hasTimetable);
     }
 
     @ReadOnlyTransactional

--- a/src/main/java/org/sopt/confeti/api/user/facade/dto/response/timetable/TimetableExistenceDTO.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/dto/response/timetable/TimetableExistenceDTO.java
@@ -1,0 +1,12 @@
+package org.sopt.confeti.api.user.facade.dto.response.timetable;
+
+public record TimetableExistenceDTO(
+    boolean hasTimetable
+) {
+
+    public static TimetableExistenceDTO from(boolean hasTimetable) {
+        return new TimetableExistenceDTO(
+            hasTimetable
+        );
+    }
+}


### PR DESCRIPTION
## 🔊 Summaries
- `GET /user/timetables/exists?festivalId={festivalId}` API를 추가했습니다.
- 현재 로그인한 사용자 기준으로, 전달받은 `festivalId`에 매칭되는 생성된 타임테이블 존재 여부를 `hasTimetable` boolean 값으로 반환하도록 구현했습니다.
- `UserTimetableController`, `UserTimetableControllerDocs`, `UserTimetableFacade`에 조회 흐름을 추가했고, 응답용 `TimetableExistenceDTO`, `TimetableExistenceResponse`를 생성했습니다.
- 기존 `TimetableService.existsByUserIdAndFestivalId(...)` 로직을 재사용해 최소 변경으로 구현했습니다.

## ✨ Notification
- 인증된 일반 유저(`Role.GENERAL`) 대상 API입니다.
- `festivalId`는 query parameter로 받고, `@Min(RequestConstraint.ID)` 검증을 적용했습니다.
- 응답 형태는 `hasTimetable: true | false` 입니다
