### PR TITLE
CSERVER-41 어드민 페이지 내 페스티벌 등록 및 조회 오류 해결

### DIFF
--- a/src/main/java/org/sopt/confeti/api/admin/dto/response/AdminFestivalDetailResponse.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/response/AdminFestivalDetailResponse.java
@@ -26,7 +26,8 @@ public record AdminFestivalDetailResponse(
     TimetableSupportStatus timetableSupportStatus,
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
-    List<DateResponse> dates
+    List<DateResponse> dates,
+    List<ReservationUrlResponse> reservationUrls
 ) {
 
     public record DateResponse(
@@ -90,6 +91,21 @@ public record AdminFestivalDetailResponse(
         }
     }
 
+    public record ReservationUrlResponse(
+        long reservationUrlId,
+        String reservationUrl,
+        long ticketVendorId
+    ) {
+
+        public static ReservationUrlResponse from(AdminFestivalDetailInfo.ReservationUrlInfo info) {
+            return new ReservationUrlResponse(
+                info.reservationUrlId(),
+                info.reservationUrl(),
+                info.ticketVendorId()
+            );
+        }
+    }
+
     public record ArtistResponse(
         String artistId,
         String name,
@@ -124,6 +140,9 @@ public record AdminFestivalDetailResponse(
             info.updatedAt(),
             info.dates().stream()
                 .map(DateResponse::from)
+                .toList(),
+            info.reservationUrls().stream()
+                .map(ReservationUrlResponse::from)
                 .toList()
         );
     }

--- a/src/main/java/org/sopt/confeti/api/admin/facade/dto/response/AdminFestivalDetailInfo.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/dto/response/AdminFestivalDetailInfo.java
@@ -7,6 +7,7 @@ import java.util.List;
 import org.sopt.confeti.domain.festival.Festival;
 import org.sopt.confeti.domain.festival.infra.TimetableSupportStatus;
 import org.sopt.confeti.domain.festival_artist.FestivalArtist;
+import org.sopt.confeti.domain.festival_reservation_url.FestivalReservationUrl;
 import org.sopt.confeti.domain.festival_date.FestivalDate;
 import org.sopt.confeti.domain.festival_stage.FestivalStage;
 import org.sopt.confeti.domain.festival_time.FestivalTime;
@@ -27,7 +28,8 @@ public record AdminFestivalDetailInfo(
     TimetableSupportStatus timetableSupportStatus,
     LocalDateTime createdAt,
     LocalDateTime updatedAt,
-    List<DateInfo> dates
+    List<DateInfo> dates,
+    List<ReservationUrlInfo> reservationUrls
 ) {
 
     public record DateInfo(
@@ -91,6 +93,21 @@ public record AdminFestivalDetailInfo(
         }
     }
 
+    public record ReservationUrlInfo(
+        long reservationUrlId,
+        String reservationUrl,
+        long ticketVendorId
+    ) {
+
+        public static ReservationUrlInfo from(FestivalReservationUrl url) {
+            return new ReservationUrlInfo(
+                url.getId(),
+                url.getReservationUrl(),
+                url.getTicketVendor().getId()
+            );
+        }
+    }
+
     public record ArtistInfo(
         String artistId,
         String name,
@@ -125,6 +142,9 @@ public record AdminFestivalDetailInfo(
             festival.getUpdatedAt(),
             festival.getDates().stream()
                 .map(DateInfo::from)
+                .toList(),
+            festival.getReservationUrls().stream()
+                .map(ReservationUrlInfo::from)
                 .toList()
         );
     }

--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailInfoResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalDetailInfoResponse.java
@@ -2,6 +2,7 @@ package org.sopt.confeti.api.performance.dto.response;
 
 import java.util.List;
 import org.sopt.confeti.api.performance.facade.dto.response.FestivalDetailDTO;
+import org.sopt.confeti.domain.festival.infra.TimetableSupportStatus;
 import org.sopt.confeti.global.common.constant.FolderPath;
 import org.sopt.confeti.global.util.DateConvertor;
 import org.sopt.confeti.global.util.S3FileHandler;
@@ -19,7 +20,8 @@ public record FestivalDetailInfoResponse(
     String price,
     boolean isFavorite,
     String address,
-    List<FestivalReservationResponse> reservations
+    List<FestivalReservationResponse> reservations,
+    TimetableSupportStatus timetableSupportStatus
 ) {
 
     public static FestivalDetailInfoResponse of(FestivalDetailDTO festival, boolean isFavorite,
@@ -40,7 +42,8 @@ public record FestivalDetailInfoResponse(
             festival.address(),
             festival.reservations().stream()
                 .map(reservation -> FestivalReservationResponse.of(reservation, s3FileHandler))
-                .toList()
+                .toList(),
+            festival.timetableSupportStatus()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailDTO.java
+++ b/src/main/java/org/sopt/confeti/api/performance/facade/dto/response/FestivalDetailDTO.java
@@ -4,6 +4,7 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.List;
 import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festival.infra.TimetableSupportStatus;
 import org.sopt.confeti.global.annotation.RedisSerializable;
 
 @RedisSerializable
@@ -21,7 +22,8 @@ public record FestivalDetailDTO(
     String price,
     String address,
     List<FestivalReservationDTO> reservations,
-    List<FestivalDetailDateDTO> dates
+    List<FestivalDetailDateDTO> dates,
+    TimetableSupportStatus timetableSupportStatus
 ) {
 
     public static FestivalDetailDTO from(Festival festival) {
@@ -43,7 +45,8 @@ public record FestivalDetailDTO(
                 .toList(),
             festival.getDates().stream()
                 .map(FestivalDetailDateDTO::from)
-                .toList()
+                .toList(),
+            festival.getTimetableSupportStatus()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/application/FestivalService.java
@@ -153,6 +153,8 @@ public class FestivalService {
             festivalTimeService.findTimesWithArtistsByStageIds(stageIds);
         }
 
+        festivalRepository.findWithReservationUrlsById(festivalId);
+
         return AdminFestivalDetailInfo.from(festival);
     }
 

--- a/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
@@ -42,6 +42,7 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
                         SELECT DISTINCT f
                         FROM Festival f
                         LEFT JOIN FETCH f.reservationUrls fru
+                        LEFT JOIN FETCH fru.ticketVendor
                         WHERE f.id = :festivalId
                     """)
     Optional<Festival> findWithReservationUrlsById(@Param("festivalId") long festivalId);

--- a/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
+++ b/src/main/java/org/sopt/confeti/domain/festival/infra/repository/FestivalRepository.java
@@ -38,6 +38,14 @@ public interface FestivalRepository extends JpaRepository<Festival, Long> {
                     """)
     Optional<Festival> findUpcomingWithReservationUrlsById(@Param("festivalId") long festivalId);
 
+    @Query("""
+                        SELECT DISTINCT f
+                        FROM Festival f
+                        LEFT JOIN FETCH f.reservationUrls fru
+                        WHERE f.id = :festivalId
+                    """)
+    Optional<Festival> findWithReservationUrlsById(@Param("festivalId") long festivalId);
+
     List<Festival> findFestivalsByIdIn(final @Param("festivalIds") List<Long> festivalIds);
 
     @Query(value = "SELECT f" +

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceArtistDTO.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceArtistDTO.java
@@ -3,13 +3,14 @@ package org.sopt.confeti.domain.view.performance.application.dto.response;
 import org.sopt.confeti.domain.view.performance.PerformanceArtist;
 
 public record PerformanceArtistDTO(
-        long id,
-        String artistId
+    Long id,
+    String artistId
 ) {
+
     public static PerformanceArtistDTO from(PerformanceArtist artist) {
         return new PerformanceArtistDTO(
-                artist.getId(),
-                artist.getArtistId()
+            artist.getId(),
+            artist.getArtistId()
         );
     }
 }

--- a/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceDTO.java
+++ b/src/main/java/org/sopt/confeti/domain/view/performance/application/dto/response/PerformanceDTO.java
@@ -9,49 +9,50 @@ import org.sopt.confeti.domain.view.performance.Performance;
 import org.sopt.confeti.global.common.constant.PerformanceType;
 
 public record PerformanceDTO(
-        long id,
-        Long typeId,
-        PerformanceType type,
-        String area,
-        String title,
-        LocalDate startAt,
-        LocalDate endAt,
-        String posterPath,
-        LocalDateTime createdAt,
-        LocalDateTime updatedAt,
-        List<PerformanceArtistDTO> artists
+    Long id,
+    Long typeId,
+    PerformanceType type,
+    String area,
+    String title,
+    LocalDate startAt,
+    LocalDate endAt,
+    String posterPath,
+    LocalDateTime createdAt,
+    LocalDateTime updatedAt,
+    List<PerformanceArtistDTO> artists
 ) {
+
     public static PerformanceDTO from(final Performance performance) {
         return new PerformanceDTO(
-                performance.getId(),
-                performance.getTypeId(),
-                performance.getType(),
-                performance.getArea(),
-                performance.getTitle(),
-                performance.getStartAt(),
-                performance.getEndAt(),
-                performance.getPosterPath(),
-                performance.getCreatedAt(),
-                performance.getUpdatedAt(),
-                performance.getArtists().stream()
-                        .map(PerformanceArtistDTO::from)
-                        .toList()
+            performance.getId(),
+            performance.getTypeId(),
+            performance.getType(),
+            performance.getArea(),
+            performance.getTitle(),
+            performance.getStartAt(),
+            performance.getEndAt(),
+            performance.getPosterPath(),
+            performance.getCreatedAt(),
+            performance.getUpdatedAt(),
+            performance.getArtists().stream()
+                .map(PerformanceArtistDTO::from)
+                .toList()
         );
     }
 
     public static PerformanceDTO from(final SearchPerformanceResult searchedPerformance) {
         return new PerformanceDTO(
-                searchedPerformance.id(),
-                searchedPerformance.typeId(),
-                searchedPerformance.type(),
-                searchedPerformance.area(),
-                searchedPerformance.title(),
-                searchedPerformance.startAt(),
-                searchedPerformance.endAt(),
-                searchedPerformance.posterPath(),
-                null,
-                null,
-                List.of()
+            searchedPerformance.id(),
+            searchedPerformance.typeId(),
+            searchedPerformance.type(),
+            searchedPerformance.area(),
+            searchedPerformance.title(),
+            searchedPerformance.startAt(),
+            searchedPerformance.endAt(),
+            searchedPerformance.posterPath(),
+            null,
+            null,
+            List.of()
         );
     }
 


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- 페스티벌 Upsert 시 검색 엔진 업로드를 위해 이벤트를 발행하는데, DB Flush 전이라 id가 null 인 상태에서 Wrapper -> Primitive 변환을 시도해 500 에러가 발생 중
- 페스티벌 단건 조회에 예매 링크를 내려주지 않고 있었음
- 일반 페스티벌 상세 조회에 타임테이블 지원 여부 값 응답 추가

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
