### PR TITLE
CSERVER-47 s3 file url 개선 - Phase 1 : CDN Domain 연결

### DIFF
--- a/src/main/java/org/sopt/confeti/global/common/CdnFileDomainResolveService.java
+++ b/src/main/java/org/sopt/confeti/global/common/CdnFileDomainResolveService.java
@@ -1,0 +1,22 @@
+package org.sopt.confeti.global.common;
+
+import org.sopt.confeti.global.config.aws.AwsProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+public class CdnFileDomainResolveService {
+
+    private final String fileDomain;
+
+    public CdnFileDomainResolveService(AwsProperties awsProperties) {
+        this.fileDomain = awsProperties.cloudfront().domain().fileDomain();
+    }
+
+    public String resolve(String filePath) {
+        if (filePath == null) {
+            return null;
+        }
+
+        return fileDomain + "/" + filePath;
+    }
+}

--- a/src/main/java/org/sopt/confeti/global/common/CdnFileDomainResolveService.java
+++ b/src/main/java/org/sopt/confeti/global/common/CdnFileDomainResolveService.java
@@ -17,6 +17,10 @@ public class CdnFileDomainResolveService {
             return null;
         }
 
+        if (filePath.startsWith("/")) {
+            return fileDomain + filePath;
+        }
+
         return fileDomain + "/" + filePath;
     }
 }

--- a/src/main/java/org/sopt/confeti/global/config/aws/AwsConfiguration.java
+++ b/src/main/java/org/sopt/confeti/global/config/aws/AwsConfiguration.java
@@ -1,0 +1,9 @@
+package org.sopt.confeti.global.config.aws;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@EnableConfigurationProperties(AwsProperties.class)
+public class AwsConfiguration {
+}

--- a/src/main/java/org/sopt/confeti/global/config/aws/AwsProperties.java
+++ b/src/main/java/org/sopt/confeti/global/config/aws/AwsProperties.java
@@ -1,17 +1,11 @@
 package org.sopt.confeti.global.config.aws;
 
-import jakarta.annotation.PostConstruct;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @Slf4j
 @ConfigurationProperties(prefix = "aws")
 public record AwsProperties(CloudFrontProperties cloudfront) {
-
-    @PostConstruct
-    public void init() {
-        log.debug(cloudfront.domain.fileDomain);
-    }
 
     public record CloudFrontProperties(CdnProperties domain) {
 

--- a/src/main/java/org/sopt/confeti/global/config/aws/AwsProperties.java
+++ b/src/main/java/org/sopt/confeti/global/config/aws/AwsProperties.java
@@ -1,0 +1,22 @@
+package org.sopt.confeti.global.config.aws;
+
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@Slf4j
+@ConfigurationProperties(prefix = "aws")
+public record AwsProperties(CloudFrontProperties cloudfront) {
+
+    @PostConstruct
+    public void init() {
+        log.debug(cloudfront.domain.fileDomain);
+    }
+
+    public record CloudFrontProperties(CdnProperties domain) {
+
+        public record CdnProperties(String fileDomain) {
+
+        }
+    }
+}

--- a/src/main/resources/common/application-cloud.yml
+++ b/src/main/resources/common/application-cloud.yml
@@ -3,13 +3,36 @@ spring:
     aws:
       s3:
         host: https://confeti-s3-prod.s3.ap-northeast-2.amazonaws.com/
-        bucket-name: confeti-s3-prod
+        bucket-name: confeti-s3-prod # 환경 분리 필요
       credentials:
         access-key: ${cloud-secrets.aws.credentials.access-key}
         secret-key: ${cloud-secrets.aws.credentials.secret-key}
       region:
         static: ap-northeast-2
 
+aws:
+  cloudfront:
+    domain:
+      file-domain: ${cloud-secrets.aws.cloudfront.cdn.file-domain}
+
 event:
   queues:
     confeti-server: https://sqs.ap-northeast-2.amazonaws.com/078129922291/confeti-server-event-sqs
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: local
+    import:
+      - aws-secretsmanager:/confeti-api/dev/cloud?prefix=cloud-secrets.
+
+---
+
+spring:
+  config:
+    activate:
+      on-profile: prod
+    import:
+      - aws-secretsmanager:/confeti-api/prod/cloud?prefix=cloud-secrets.


### PR DESCRIPTION
## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
- Cdn domain 에 s3 를 연결하고, 애플리케이션에서 전체 서비스에 서빙할 수 있도록 공통 파일 서비스를 만듭니다.
- 기존에 확장성을 고려해 관리되던 폴더 경로는 Drop 처리하고, DB에서 Cdn domain 을 제외한 full path 를 가지고 있도록 수정합니다.
- Cdn domain 은 이후 환경 분리가 되면 환경별로 도메인명이 달라질 예정입니다. -> aws secrets 항목에서 확인 가능합니다~!

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
전체 도메인에 이미 적용해봤었는데, 변경 파일이 130개가 넘어가서 PR 분리해서 작업합니다.
이후에 도메인 하나씩 반영할 예정입니다!
