### PR TITLE
CONSERVER-51  어드민 수정 후 공연 상세 캐시 무효화 처리

### DIFF
--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -406,6 +406,7 @@ public class AdminFacade {
                 concertId = createConcert(command, posterPath);
             } else {
                 concertId = updateConcert(command, posterPath, folderPath);
+                concertService.deleteDetailCache(concertId);
             }
         } catch (Exception e) {
             log.warn(
@@ -677,6 +678,7 @@ public class AdminFacade {
 
         try {
             festivalId = updateFestival(command, finalPosterPath, finalLogoPath);
+            festivalService.deleteDetailCache(festivalId);
         } catch (Exception e) {
             log.warn(
                 "AdminFacade.upsertFestivalForUpdate : 페스티벌 수정에 실패해 업로드했던 이미지 파일을 롤백합니다. Poster Folder Path : {}, Poster File Name : {}, Logo Folder Path : {}, Logo File Name : {}",

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -415,10 +415,6 @@ public class AdminFacade {
             throw e;
         }
 
-        if (command.concertId() != null) {
-            invalidateConcertDetailCacheQuietly(concertId);
-        }
-
         return PutAdminConcertResponse.from(concertId);
     }
 
@@ -481,7 +477,7 @@ public class AdminFacade {
     }
 
     private long updateConcert(AdminConcertCommand command, String posterPath, String folderPath) {
-        return Tx.masterTx(() -> {
+        long concertId = Tx.masterTx(() -> {
             Map<Long, TicketVendor> vendorMap = getTicketVendorMap(command);
 
             List<ConcertArtist> concertArtists = buildConcertArtists(command);
@@ -514,6 +510,9 @@ public class AdminFacade {
 
             return command.concertId();
         });
+
+        invalidateConcertDetailCacheQuietly(concertId);
+        return concertId;
     }
 
     private Map<Long, TicketVendor> getTicketVendorMap(AdminConcertCommand command) {

--- a/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
+++ b/src/main/java/org/sopt/confeti/api/admin/facade/AdminFacade.java
@@ -406,7 +406,6 @@ public class AdminFacade {
                 concertId = createConcert(command, posterPath);
             } else {
                 concertId = updateConcert(command, posterPath, folderPath);
-                concertService.deleteDetailCache(concertId);
             }
         } catch (Exception e) {
             log.warn(
@@ -414,6 +413,10 @@ public class AdminFacade {
                 folderPath, posterPath);
             eventPublisher.publishEvent(new S3FileDeleteEvent(folderPath, posterPath));
             throw e;
+        }
+
+        if (command.concertId() != null) {
+            invalidateConcertDetailCacheQuietly(concertId);
         }
 
         return PutAdminConcertResponse.from(concertId);
@@ -560,6 +563,28 @@ public class AdminFacade {
             .ifPresent(path -> eventPublisher.publishEvent(new S3FileDeleteEvent(folderPath, path)));
     }
 
+    private void invalidateConcertDetailCacheQuietly(long concertId) {
+        try {
+            concertService.deleteDetailCache(concertId);
+        } catch (Exception e) {
+            log.warn(
+                "AdminFacade.invalidateConcertDetailCacheQuietly : 콘서트 상세 캐시 삭제에 실패했습니다. concertId : {}, message : {}",
+                concertId, e.getMessage(), e
+            );
+        }
+    }
+
+    private void invalidateFestivalDetailCacheQuietly(long festivalId) {
+        try {
+            festivalService.deleteDetailCache(festivalId);
+        } catch (Exception e) {
+            log.warn(
+                "AdminFacade.invalidateFestivalDetailCacheQuietly : 페스티벌 상세 캐시 삭제에 실패했습니다. festivalId : {}, message : {}",
+                festivalId, e.getMessage(), e
+            );
+        }
+    }
+
     private void registerAfterCommitCleanup(Runnable cleanup) {
         if (!TransactionSynchronizationManager.isSynchronizationActive()) {
             cleanup.run();
@@ -678,7 +703,6 @@ public class AdminFacade {
 
         try {
             festivalId = updateFestival(command, finalPosterPath, finalLogoPath);
-            festivalService.deleteDetailCache(festivalId);
         } catch (Exception e) {
             log.warn(
                 "AdminFacade.upsertFestivalForUpdate : 페스티벌 수정에 실패해 업로드했던 이미지 파일을 롤백합니다. Poster Folder Path : {}, Poster File Name : {}, Logo Folder Path : {}, Logo File Name : {}",
@@ -696,6 +720,8 @@ public class AdminFacade {
             }
             throw e;
         }
+
+        invalidateFestivalDetailCacheQuietly(festivalId);
 
         try {
             // 트랜잭션 커밋 성공 후 기존 S3 파일 삭제

--- a/src/test/java/org/sopt/confeti/api/admin/facade/AdminFacadeDeleteTest.java
+++ b/src/test/java/org/sopt/confeti/api/admin/facade/AdminFacadeDeleteTest.java
@@ -4,8 +4,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.verify;
 
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
@@ -35,6 +37,7 @@ import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.util.ReflectionTestUtils;
 
 @ExtendWith(MockitoExtension.class)
+@ResourceLock("Tx.txRunner")
 class AdminFacadeDeleteTest {
 
     @Mock
@@ -87,6 +90,11 @@ class AdminFacadeDeleteTest {
             performanceDraftParser,
             artistMusicAPIService
         );
+    }
+
+    @AfterEach
+    void tearDown() {
+        ReflectionTestUtils.setField(Tx.class, "txRunner", null);
     }
 
     @Test

--- a/src/test/java/org/sopt/confeti/api/admin/facade/AdminFacadeUpdateTest.java
+++ b/src/test/java/org/sopt/confeti/api/admin/facade/AdminFacadeUpdateTest.java
@@ -2,14 +2,17 @@ package org.sopt.confeti.api.admin.facade;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.parallel.ResourceLock;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -44,6 +47,7 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.web.multipart.MultipartFile;
 
 @ExtendWith(MockitoExtension.class)
+@ResourceLock("Tx.txRunner")
 class AdminFacadeUpdateTest {
 
     @Mock
@@ -98,6 +102,11 @@ class AdminFacadeUpdateTest {
             performanceDraftParser,
             artistMusicAPIService
         );
+    }
+
+    @AfterEach
+    void tearDown() {
+        ReflectionTestUtils.setField(Tx.class, "txRunner", null);
     }
 
     @Test
@@ -195,6 +204,57 @@ class AdminFacadeUpdateTest {
             .extracting(ConcertReservationSchedule::getRoundName)
             .containsExactly("1차", "2차");
         verify(concertService).deleteDetailCache(concertId);
+    }
+
+    @Test
+    void upsertConcert_캐시무효화에_실패해도_S3_롤백없이_응답한다() {
+        long concertId = 78L;
+        Concert concert = Concert.create(
+            "SUMMER SONIC 2026",
+            LocalDate.of(2026, 8, 15),
+            LocalDate.of(2026, 8, 15),
+            "KSPO DOME",
+            "old-poster.png",
+            "전체 관람가",
+            "180분",
+            "132,000원",
+            "서울특별시 송파구 올림픽로 424",
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new ArrayList<>(List.of(
+                ConcertReservationSchedule.create(
+                    "1차",
+                    LocalDateTime.of(2026, 6, 1, 20, 0)
+                )
+            ))
+        );
+        Performance performance = Performance.createConcert(
+            concertId,
+            "SUMMER SONIC 2026",
+            "KSPO DOME",
+            LocalDate.of(2026, 8, 15),
+            LocalDate.of(2026, 8, 15),
+            "old-poster.png",
+            new ArrayList<>()
+        );
+
+        given(s3FileHandler.uploadFile(poster, "concert/poster/")).willReturn("new-poster.png");
+        given(concertService.findWithRelationsById(concertId)).willReturn(concert);
+        given(performanceService.getPerformanceByTypeAndTypeId(PerformanceType.CONCERT, concertId))
+            .willReturn(performance);
+        org.mockito.Mockito.doThrow(new RuntimeException("redis down"))
+            .when(concertService).deleteDetailCache(concertId);
+
+        PutAdminConcertResponse response = adminFacade.upsertConcert(
+            poster,
+            concertUpdateCommand(concertId)
+        );
+
+        assertThat(response.concertId()).isEqualTo(concertId);
+        verify(eventPublisher, never()).publishEvent(org.mockito.ArgumentMatchers.<Object>argThat(
+            event -> event instanceof org.sopt.confeti.global.event.S3FileDeleteEvent s3Event
+                && "new-poster.png".equals(s3Event.filePath())
+        ));
     }
 
     private AdminFestivalCommand festivalUpdateCommand(long festivalId) {

--- a/src/test/java/org/sopt/confeti/api/admin/facade/AdminFacadeUpdateTest.java
+++ b/src/test/java/org/sopt/confeti/api/admin/facade/AdminFacadeUpdateTest.java
@@ -1,0 +1,256 @@
+package org.sopt.confeti.api.admin.facade;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.sopt.confeti.api.admin.dto.response.PutAdminConcertResponse;
+import org.sopt.confeti.api.admin.dto.response.PutAdminFestivalResponse;
+import org.sopt.confeti.api.admin.facade.dto.request.AdminConcertCommand;
+import org.sopt.confeti.api.admin.facade.dto.request.AdminFestivalCommand;
+import org.sopt.confeti.domain.concert.Concert;
+import org.sopt.confeti.domain.concert.application.ConcertService;
+import org.sopt.confeti.domain.concert_favorite.application.ConcertFavoriteService;
+import org.sopt.confeti.domain.concert_reservation_schedule.ConcertReservationSchedule;
+import org.sopt.confeti.domain.elastic_search.application.PerformanceSearchService;
+import org.sopt.confeti.domain.festival.Festival;
+import org.sopt.confeti.domain.festival.application.FestivalService;
+import org.sopt.confeti.domain.festival.infra.TimetableSupportStatus;
+import org.sopt.confeti.domain.festival_reservation_schedule.FestivalReservationSchedule;
+import org.sopt.confeti.domain.music.artist.application.ArtistMusicAPIService;
+import org.sopt.confeti.domain.music.artist.application.ArtistService;
+import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftParser;
+import org.sopt.confeti.domain.performancedraft.application.PerformanceDraftService;
+import org.sopt.confeti.domain.setlist.application.SetlistService;
+import org.sopt.confeti.domain.ticketvendor.application.TicketVendorService;
+import org.sopt.confeti.domain.view.performance.Performance;
+import org.sopt.confeti.domain.view.performance.application.PerformanceService;
+import org.sopt.confeti.global.common.constant.PerformanceType;
+import org.sopt.confeti.global.transaction.Tx;
+import org.sopt.confeti.global.transaction.TxRunner;
+import org.sopt.confeti.global.util.S3FileHandler;
+import org.sopt.confeti.global.util.music.MusicAPIHandler;
+import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.web.multipart.MultipartFile;
+
+@ExtendWith(MockitoExtension.class)
+class AdminFacadeUpdateTest {
+
+    @Mock
+    private TicketVendorService ticketVendorService;
+    @Mock
+    private ConcertService concertService;
+    @Mock
+    private FestivalService festivalService;
+    @Mock
+    private ConcertFavoriteService concertFavoriteService;
+    @Mock
+    private SetlistService setlistService;
+    @Mock
+    private MusicAPIHandler musicAPIHandler;
+    @Mock
+    private S3FileHandler s3FileHandler;
+    @Mock
+    private PerformanceDraftService performanceDraftService;
+    @Mock
+    private ArtistService artistService;
+    @Mock
+    private PerformanceService performanceService;
+    @Mock
+    private PerformanceSearchService performanceSearchService;
+    @Mock
+    private ApplicationEventPublisher eventPublisher;
+    @Mock
+    private PerformanceDraftParser performanceDraftParser;
+    @Mock
+    private ArtistMusicAPIService artistMusicAPIService;
+    @Mock
+    private MultipartFile poster;
+
+    private AdminFacade adminFacade;
+
+    @BeforeEach
+    void setUp() {
+        ReflectionTestUtils.setField(Tx.class, "txRunner", new TxRunner());
+        adminFacade = new AdminFacade(
+            ticketVendorService,
+            concertService,
+            festivalService,
+            concertFavoriteService,
+            setlistService,
+            musicAPIHandler,
+            s3FileHandler,
+            performanceDraftService,
+            artistService,
+            performanceService,
+            performanceSearchService,
+            eventPublisher,
+            performanceDraftParser,
+            artistMusicAPIService
+        );
+    }
+
+    @Test
+    void upsertFestival_수정시_상세_캐시를_비우고_예약일정을_갱신한다() {
+        long festivalId = 55L;
+        Festival festival = Festival.create(
+            "PEAK FESTIVAL 2026",
+            LocalDate.of(2026, 5, 23),
+            LocalDate.of(2026, 5, 24),
+            "난지한강공원",
+            "poster.png",
+            "logo.png",
+            "전체 관람가",
+            "540분",
+            "일일권 110,000원 / 양일권 149,000원",
+            "서울특별시 마포구 한강난지로 162(상암동) 난지한강공원",
+            TimetableSupportStatus.NOT_SUPPORTED,
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new ArrayList<>(List.of(
+                FestivalReservationSchedule.create(
+                    "1차",
+                    LocalDateTime.of(2026, 3, 4, 18, 0)
+                )
+            ))
+        );
+        Performance performance = Performance.create(
+            festivalId,
+            festivalUpdateCommand(festivalId),
+            "poster.png",
+            new ArrayList<>()
+        );
+
+        given(festivalService.getWithRelationsById(festivalId)).willReturn(festival);
+        given(performanceService.getWithArtistsByTypeAndTypeId(PerformanceType.FESTIVAL, festivalId))
+            .willReturn(performance);
+
+        PutAdminFestivalResponse response = adminFacade.upsertFestival(
+            null,
+            null,
+            festivalUpdateCommand(festivalId)
+        );
+
+        assertThat(response.festivalId()).isEqualTo(festivalId);
+        assertThat(festival.getReservationSchedules())
+            .extracting(FestivalReservationSchedule::getRoundName)
+            .containsExactly("1차", "2차", "휠체어석");
+        verify(festivalService).deleteDetailCache(festivalId);
+    }
+
+    @Test
+    void upsertConcert_수정시_상세_캐시를_비우고_예약일정을_갱신한다() {
+        long concertId = 77L;
+        Concert concert = Concert.create(
+            "SUMMER SONIC 2026",
+            LocalDate.of(2026, 8, 15),
+            LocalDate.of(2026, 8, 15),
+            "KSPO DOME",
+            "old-poster.png",
+            "전체 관람가",
+            "180분",
+            "132,000원",
+            "서울특별시 송파구 올림픽로 424",
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new ArrayList<>(List.of(
+                ConcertReservationSchedule.create(
+                    "1차",
+                    LocalDateTime.of(2026, 6, 1, 20, 0)
+                )
+            ))
+        );
+        Performance performance = Performance.createConcert(
+            concertId,
+            "SUMMER SONIC 2026",
+            "KSPO DOME",
+            LocalDate.of(2026, 8, 15),
+            LocalDate.of(2026, 8, 15),
+            "old-poster.png",
+            new ArrayList<>()
+        );
+
+        given(s3FileHandler.uploadFile(poster, "concert/poster/")).willReturn("new-poster.png");
+        given(concertService.findWithRelationsById(concertId)).willReturn(concert);
+        given(performanceService.getPerformanceByTypeAndTypeId(PerformanceType.CONCERT, concertId))
+            .willReturn(performance);
+
+        PutAdminConcertResponse response = adminFacade.upsertConcert(
+            poster,
+            concertUpdateCommand(concertId)
+        );
+
+        assertThat(response.concertId()).isEqualTo(concertId);
+        assertThat(concert.getReservationSchedules())
+            .extracting(ConcertReservationSchedule::getRoundName)
+            .containsExactly("1차", "2차");
+        verify(concertService).deleteDetailCache(concertId);
+    }
+
+    private AdminFestivalCommand festivalUpdateCommand(long festivalId) {
+        return AdminFestivalCommand.of(
+            festivalId,
+            "PEAK FESTIVAL 2026",
+            LocalDate.of(2026, 5, 23),
+            LocalDate.of(2026, 5, 24),
+            "난지한강공원",
+            "전체 관람가",
+            "540분",
+            "일일권 110,000원 / 양일권 149,000원",
+            "서울특별시 마포구 한강난지로 162(상암동) 난지한강공원",
+            TimetableSupportStatus.NOT_SUPPORTED,
+            List.of(),
+            List.of(
+                AdminFestivalCommand.ReservationScheduleCommand.of(
+                    "1차",
+                    LocalDateTime.of(2026, 3, 4, 18, 0)
+                ),
+                AdminFestivalCommand.ReservationScheduleCommand.of(
+                    "2차",
+                    LocalDateTime.of(2026, 4, 23, 14, 0)
+                ),
+                AdminFestivalCommand.ReservationScheduleCommand.of(
+                    "휠체어석",
+                    LocalDateTime.of(2026, 4, 24, 16, 49)
+                )
+            ),
+            List.of()
+        );
+    }
+
+    private AdminConcertCommand concertUpdateCommand(long concertId) {
+        return AdminConcertCommand.of(
+            concertId,
+            "SUMMER SONIC 2026",
+            LocalDate.of(2026, 8, 15),
+            LocalDate.of(2026, 8, 15),
+            "KSPO DOME",
+            "전체 관람가",
+            "180분",
+            "132,000원",
+            "서울특별시 송파구 올림픽로 424",
+            List.of(),
+            List.of(),
+            List.of(
+                AdminConcertCommand.ReservationScheduleCommand.of(
+                    "1차",
+                    LocalDateTime.of(2026, 6, 1, 20, 0)
+                ),
+                AdminConcertCommand.ReservationScheduleCommand.of(
+                    "2차",
+                    LocalDateTime.of(2026, 6, 15, 20, 0)
+                )
+            )
+        );
+    }
+}


### PR DESCRIPTION
## 🔊 Summaries
- 어드민에서 페스티벌/콘서트 수정 성공 후 상세 Redis 캐시를 삭제하도록 변경했습니다.
- 클라이언트 상세 조회에서 예매 일정이 이전 캐시에 남아 최신값이 반영되지 않던 문제를 해결했습니다.
- 수정 시 예약 일정 갱신과 캐시 무효화가 함께 동작하는 회귀 테스트를 추가했습니다.

## ✨ Notification 
- 클라이언트 상세 조회는 `performance:festivals:{id}`, `performance:concerts:{id}` 캐시를 사용하고 있어 수정 직후 stale 데이터가 내려갈 수 있었습니다.
- 이번 변경으로 어드민 수정 후에는 상세 조회가 즉시 최신 데이터로 재생성됩니다.
- 운영에 이미 남아 있는 기존 캐시는 TTL 만료 전까지 남아 있을 수 있어, 즉시 반영이 필요하면 관련 Redis 키 삭제가 필요할 수 있습니다.
