### PR TITLE
Refactor: 페스티벌 어드민 요청 검증 로직 개선

### DIFF
--- a/src/main/java/org/sopt/confeti/api/admin/dto/request/PutAdminFestivalRequest.java
+++ b/src/main/java/org/sopt/confeti/api/admin/dto/request/PutAdminFestivalRequest.java
@@ -17,7 +17,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.sopt.confeti.api.admin.facade.dto.request.AdminFestivalCommand;
 import org.sopt.confeti.domain.festival.infra.TimetableSupportStatus;
 import org.sopt.confeti.global.exception.BadRequestException;
-import org.sopt.confeti.global.exception.ParameterInvalidException;
 import org.sopt.confeti.global.message.ErrorMessage;
 
 @Slf4j
@@ -37,9 +36,10 @@ public record PutAdminFestivalRequest(
 ) {
 
     public AdminFestivalCommand toCommand() {
-        validate();
+        boolean hasTimetable = hasTimetableInfo();
+        validate(hasTimetable);
 
-        TimetableSupportStatus status = hasTimetableInfo()
+        TimetableSupportStatus status = hasTimetable
             ? TimetableSupportStatus.SUPPORTED
             : TimetableSupportStatus.NOT_SUPPORTED;
 
@@ -84,7 +84,7 @@ public record PutAdminFestivalRequest(
         );
     }
 
-    public void validate() {
+    private void validate(boolean hasTimetable) {
         validateDuration();
         validateReserveDate();
 
@@ -92,8 +92,7 @@ public record PutAdminFestivalRequest(
             validateDateFestivalAtInRange();
         }
 
-        if (hasTimetableInfo()) {
-            validateTimetableDuration();
+        if (hasTimetable) {
             validateAllDatesHaveStages();
             validateArtistTimetableMapping();
             validateOpenAtBeforeFirstTime();
@@ -106,7 +105,7 @@ public record PutAdminFestivalRequest(
     private void validateDuration() {
         if (startAt.isAfter(endAt)) {
             log.warn("PutAdminFestivalRequest.validateDuration : 시작 날짜는 끝 날짜보다 작거나 같아야 합니다.");
-            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+            throw new BadRequestException(ErrorMessage.FESTIVAL_INVALID_DURATION);
         }
     }
 
@@ -116,32 +115,8 @@ public record PutAdminFestivalRequest(
                 log.warn(
                     "PutAdminFestivalRequest.validateReserveDate : 예약 일자({})는 시작 날짜({})보다 작아야 합니다.",
                     schedule.reserveAt(), startAt);
-                throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+                throw new BadRequestException(ErrorMessage.FESTIVAL_INVALID_RESERVE_DATE);
             }
-        }
-    }
-
-    private void validateTimetableDuration() {
-        if (dates.isEmpty()) {
-            log.warn(
-                "PutAdminFestivalRequest.validateTimetableDuration : 타임테이블을 등록하려면 날짜 정보가 있어야 합니다.");
-            throw new ParameterInvalidException(ErrorMessage.BAD_REQUEST);
-        }
-
-        LocalDate startDate = dates.stream().findFirst().get().festivalAt();
-        LocalDate endDate = dates.stream().findFirst().get().festivalAt();
-
-        for (DateRequest date : dates) {
-            startDate = date.festivalAt.isBefore(startDate) ? date.festivalAt : startDate;
-            endDate = date.festivalAt.isAfter(endDate) ? date.festivalAt : endDate;
-        }
-
-        if (startAt.isAfter(startDate)
-            || endAt.isBefore(endDate)) {
-            log.warn(
-                "PutAdminFestivalRequest.validateTimetableDuration : 타임테이블의 날짜는 페스티벌의 공연 기간 안으로 지정해야합니다. 공연 기간 : {} ~ {}, 타임테이블 지정 날짜 : {} ~ {}",
-                startAt, endAt, startDate, endDate);
-            throw new ParameterInvalidException(ErrorMessage.BAD_REQUEST);
         }
     }
 
@@ -152,30 +127,24 @@ public record PutAdminFestivalRequest(
         if (hasDateWithoutStages) {
             log.warn(
                 "PutAdminFestivalRequest.validateAllDatesHaveStages : 타임테이블이 존재하면 모든 날짜에 스테이지 정보가 있어야 합니다.");
-            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+            throw new BadRequestException(ErrorMessage.FESTIVAL_TIMETABLE_DATE_NO_STAGE);
         }
     }
 
     private void validateArtistTimetableMapping() {
         for (DateRequest date : dates) {
-            Set<String> dateArtistIds = new HashSet<>(date.artistIds());
+            Set<String> dateArtistIds = new HashSet<>(
+                date.artistIds() != null ? date.artistIds() : List.of());
             Set<String> timetableArtistIds = date.stages().stream()
                 .flatMap(stage -> stage.times().stream())
                 .flatMap(time -> time.artistIds().stream())
                 .collect(Collectors.toSet());
 
-            if (!timetableArtistIds.containsAll(dateArtistIds)) {
+            if (!timetableArtistIds.equals(dateArtistIds)) {
                 log.warn(
-                    "PutAdminFestivalRequest.validateArtistTimetableMapping : 날짜({})의 모든 아티스트가 타임테이블에 배정되어야 합니다.",
+                    "PutAdminFestivalRequest.validateArtistTimetableMapping : 날짜({})의 아티스트와 타임테이블 아티스트가 일치하지 않습니다.",
                     date.festivalAt());
-                throw new BadRequestException(ErrorMessage.BAD_REQUEST);
-            }
-
-            if (!dateArtistIds.containsAll(timetableArtistIds)) {
-                log.warn(
-                    "PutAdminFestivalRequest.validateArtistTimetableMapping : 날짜({})의 타임테이블의 모든 아티스트가 선택되어야 합니다.",
-                    date.festivalAt());
-                throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+                throw new BadRequestException(ErrorMessage.FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED);
             }
         }
     }
@@ -188,7 +157,7 @@ public record PutAdminFestivalRequest(
             log.warn(
                 "PutAdminFestivalRequest.validateDateFestivalAtInRange : 모든 날짜의 festivalAt은 공연 기간({} ~ {}) 내에 있어야 합니다.",
                 startAt, endAt);
-            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+            throw new BadRequestException(ErrorMessage.FESTIVAL_DATE_OUT_OF_RANGE);
         }
     }
 
@@ -204,23 +173,23 @@ public record PutAdminFestivalRequest(
                 log.warn(
                     "PutAdminFestivalRequest.validateOpenAtBeforeFirstTime : 날짜({})의 openAt({})은 가장 이른 공연 시작 시간({}) 이하여야 합니다.",
                     date.festivalAt(), date.openAt(), earliestStartAt);
-                throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+                throw new BadRequestException(ErrorMessage.FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME);
             }
         }
     }
 
     private void validateStageOrderUnique() {
         for (DateRequest date : dates) {
-            List<Integer> orders = date.stages().stream()
+            long distinctCount = date.stages().stream()
                 .map(StageRequest::order)
-                .toList();
-            Set<Integer> uniqueOrders = new HashSet<>(orders);
+                .distinct()
+                .count();
 
-            if (uniqueOrders.size() != orders.size()) {
+            if (distinctCount != date.stages().size()) {
                 log.warn(
                     "PutAdminFestivalRequest.validateStageOrderUnique : 날짜({})의 스테이지 순서(order)가 중복됩니다.",
                     date.festivalAt());
-                throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+                throw new BadRequestException(ErrorMessage.FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE);
             }
         }
     }
@@ -233,7 +202,7 @@ public record PutAdminFestivalRequest(
                         log.warn(
                             "PutAdminFestivalRequest.validateTimeStartBeforeEnd : 날짜({}), 스테이지({})의 공연 시작 시간({})은 종료 시간({})보다 이전이어야 합니다.",
                             date.festivalAt(), stage.name(), time.startAt(), time.endAt());
-                        throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+                        throw new BadRequestException(ErrorMessage.FESTIVAL_TIMETABLE_TIME_START_AFTER_END);
                     }
                 }
             }
@@ -256,7 +225,7 @@ public record PutAdminFestivalRequest(
                             date.festivalAt(), stage.name(),
                             current.startAt(), current.endAt(),
                             next.startAt(), next.endAt());
-                        throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+                        throw new BadRequestException(ErrorMessage.FESTIVAL_TIMETABLE_TIME_OVERLAP);
                     }
                 }
             }

--- a/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
+++ b/src/main/java/org/sopt/confeti/api/user/facade/UserTimetableFacade.java
@@ -118,7 +118,7 @@ public class UserTimetableFacade {
                 .filter(f -> f.getTimetableSupportStatus() == TimetableSupportStatus.NOT_SUPPORTED)
                 .map(Festival::getId)
                 .toList());
-            throw new BadRequestException(ErrorMessage.BAD_REQUEST);
+            throw new BadRequestException(ErrorMessage.FESTIVAL_TIMETABLE_NOT_SUPPORTED);
         }
     }
 

--- a/src/main/java/org/sopt/confeti/global/exception/ErrorResponseConstant.java
+++ b/src/main/java/org/sopt/confeti/global/exception/ErrorResponseConstant.java
@@ -22,6 +22,7 @@ public class ErrorResponseConstant {
     public static final String FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE_MESSAGE = "스테이지 순서(order)가 중복됩니다.";
     public static final String FESTIVAL_TIMETABLE_TIME_START_AFTER_END_MESSAGE = "공연 시작 시간은 종료 시간보다 이전이어야 합니다.";
     public static final String FESTIVAL_TIMETABLE_TIME_OVERLAP_MESSAGE = "같은 스테이지 내 공연 시간이 겹칩니다.";
+    public static final String FESTIVAL_TIMETABLE_NOT_SUPPORTED_MESSAGE = "타임테이블을 지원하지 않는 페스티벌입니다.";
 
     /* 401 Unauthorized */
     public static final String UNAUTHORIZED_STATUS = "401";

--- a/src/main/java/org/sopt/confeti/global/exception/ErrorResponseConstant.java
+++ b/src/main/java/org/sopt/confeti/global/exception/ErrorResponseConstant.java
@@ -16,7 +16,6 @@ public class ErrorResponseConstant {
     public static final String FESTIVAL_INVALID_DURATION_MESSAGE = "시작 날짜는 종료 날짜보다 클 수 없습니다.";
     public static final String FESTIVAL_INVALID_RESERVE_DATE_MESSAGE = "예매 일자는 공연 시작일보다 이전이어야 합니다.";
     public static final String FESTIVAL_DATE_OUT_OF_RANGE_MESSAGE = "날짜가 공연 기간 범위를 벗어났습니다.";
-    public static final String FESTIVAL_TIMETABLE_DURATION_INVALID_MESSAGE = "타임테이블 날짜는 공연 기간 내에 있어야 합니다.";
     public static final String FESTIVAL_TIMETABLE_DATE_NO_STAGE_MESSAGE = "타임테이블이 존재하면 모든 날짜에 스테이지 정보가 있어야 합니다.";
     public static final String FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED_MESSAGE = "모든 아티스트가 타임테이블에 배정되어야 합니다.";
     public static final String FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME_MESSAGE = "티켓 오픈 시간은 첫 번째 공연 시작 시간 이전이어야 합니다.";

--- a/src/main/java/org/sopt/confeti/global/exception/ErrorResponseConstant.java
+++ b/src/main/java/org/sopt/confeti/global/exception/ErrorResponseConstant.java
@@ -12,6 +12,18 @@ public class ErrorResponseConstant {
     public static final String BAD_REQUEST_DESCRIPTION = "Bad Request";
     public static final String BAD_REQUEST_MESSAGE = "요청 형식이 올바르지 않습니다.";
 
+    /* 400 Bad Request - Festival Validation */
+    public static final String FESTIVAL_INVALID_DURATION_MESSAGE = "시작 날짜는 종료 날짜보다 클 수 없습니다.";
+    public static final String FESTIVAL_INVALID_RESERVE_DATE_MESSAGE = "예매 일자는 공연 시작일보다 이전이어야 합니다.";
+    public static final String FESTIVAL_DATE_OUT_OF_RANGE_MESSAGE = "날짜가 공연 기간 범위를 벗어났습니다.";
+    public static final String FESTIVAL_TIMETABLE_DURATION_INVALID_MESSAGE = "타임테이블 날짜는 공연 기간 내에 있어야 합니다.";
+    public static final String FESTIVAL_TIMETABLE_DATE_NO_STAGE_MESSAGE = "타임테이블이 존재하면 모든 날짜에 스테이지 정보가 있어야 합니다.";
+    public static final String FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED_MESSAGE = "모든 아티스트가 타임테이블에 배정되어야 합니다.";
+    public static final String FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME_MESSAGE = "티켓 오픈 시간은 첫 번째 공연 시작 시간 이전이어야 합니다.";
+    public static final String FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE_MESSAGE = "스테이지 순서(order)가 중복됩니다.";
+    public static final String FESTIVAL_TIMETABLE_TIME_START_AFTER_END_MESSAGE = "공연 시작 시간은 종료 시간보다 이전이어야 합니다.";
+    public static final String FESTIVAL_TIMETABLE_TIME_OVERLAP_MESSAGE = "같은 스테이지 내 공연 시간이 겹칩니다.";
+
     /* 401 Unauthorized */
     public static final String UNAUTHORIZED_STATUS = "401";
     public static final String UNAUTHORIZED_DESCRIPTION = "Unauthorized";

--- a/src/main/java/org/sopt/confeti/global/message/ErrorMessage.java
+++ b/src/main/java/org/sopt/confeti/global/message/ErrorMessage.java
@@ -10,6 +10,7 @@ import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_T
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_TIME_OVERLAP_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_NOT_SUPPORTED_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_TIME_START_AFTER_END_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.EMPTY_TOKEN_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.EXPIRED_TOKEN_MESSAGE;
@@ -41,6 +42,7 @@ public enum ErrorMessage {
     FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE_MESSAGE),
     FESTIVAL_TIMETABLE_TIME_START_AFTER_END(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_TIME_START_AFTER_END_MESSAGE),
     FESTIVAL_TIMETABLE_TIME_OVERLAP(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_TIME_OVERLAP_MESSAGE),
+    FESTIVAL_TIMETABLE_NOT_SUPPORTED(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_NOT_SUPPORTED_MESSAGE),
 
     /* 401 Unauthorized */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, UNAUTHORIZED_MESSAGE),

--- a/src/main/java/org/sopt/confeti/global/message/ErrorMessage.java
+++ b/src/main/java/org/sopt/confeti/global/message/ErrorMessage.java
@@ -2,6 +2,16 @@ package org.sopt.confeti.global.message;
 
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.BAD_REQUEST_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.CONFLICT_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_DATE_OUT_OF_RANGE_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_INVALID_DURATION_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_INVALID_RESERVE_DATE_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_DATE_NO_STAGE_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_DURATION_INVALID_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_TIME_OVERLAP_MESSAGE;
+import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_TIME_START_AFTER_END_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.EMPTY_TOKEN_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.EXPIRED_TOKEN_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FORBIDDEN_MESSAGE;
@@ -23,6 +33,16 @@ import org.springframework.http.HttpStatus;
 public enum ErrorMessage {
     /* 400 Bad Request */
     BAD_REQUEST(HttpStatus.BAD_REQUEST, BAD_REQUEST_MESSAGE),
+    FESTIVAL_INVALID_DURATION(HttpStatus.BAD_REQUEST, FESTIVAL_INVALID_DURATION_MESSAGE),
+    FESTIVAL_INVALID_RESERVE_DATE(HttpStatus.BAD_REQUEST, FESTIVAL_INVALID_RESERVE_DATE_MESSAGE),
+    FESTIVAL_DATE_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, FESTIVAL_DATE_OUT_OF_RANGE_MESSAGE),
+    FESTIVAL_TIMETABLE_DURATION_INVALID(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_DURATION_INVALID_MESSAGE),
+    FESTIVAL_TIMETABLE_DATE_NO_STAGE(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_DATE_NO_STAGE_MESSAGE),
+    FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED_MESSAGE),
+    FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME_MESSAGE),
+    FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE_MESSAGE),
+    FESTIVAL_TIMETABLE_TIME_START_AFTER_END(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_TIME_START_AFTER_END_MESSAGE),
+    FESTIVAL_TIMETABLE_TIME_OVERLAP(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_TIME_OVERLAP_MESSAGE),
 
     /* 401 Unauthorized */
     UNAUTHORIZED(HttpStatus.UNAUTHORIZED, UNAUTHORIZED_MESSAGE),

--- a/src/main/java/org/sopt/confeti/global/message/ErrorMessage.java
+++ b/src/main/java/org/sopt/confeti/global/message/ErrorMessage.java
@@ -7,7 +7,6 @@ import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_I
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_INVALID_RESERVE_DATE_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_DATE_NO_STAGE_MESSAGE;
-import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_DURATION_INVALID_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_STAGE_ORDER_DUPLICATE_MESSAGE;
 import static org.sopt.confeti.global.exception.ErrorResponseConstant.FESTIVAL_TIMETABLE_TIME_OVERLAP_MESSAGE;
@@ -36,7 +35,6 @@ public enum ErrorMessage {
     FESTIVAL_INVALID_DURATION(HttpStatus.BAD_REQUEST, FESTIVAL_INVALID_DURATION_MESSAGE),
     FESTIVAL_INVALID_RESERVE_DATE(HttpStatus.BAD_REQUEST, FESTIVAL_INVALID_RESERVE_DATE_MESSAGE),
     FESTIVAL_DATE_OUT_OF_RANGE(HttpStatus.BAD_REQUEST, FESTIVAL_DATE_OUT_OF_RANGE_MESSAGE),
-    FESTIVAL_TIMETABLE_DURATION_INVALID(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_DURATION_INVALID_MESSAGE),
     FESTIVAL_TIMETABLE_DATE_NO_STAGE(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_DATE_NO_STAGE_MESSAGE),
     FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED_MESSAGE),
     FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME(HttpStatus.BAD_REQUEST, FESTIVAL_TIMETABLE_OPEN_AT_AFTER_FIRST_TIME_MESSAGE),


### PR DESCRIPTION
## 🔊 Summaries
- 검증 실패 시 `BAD_REQUEST` 대신 각 상황에 맞는 구체적인 `ErrorMessage`를 반환하도록 변경했습니다.
- `validateTimetableDuration`을 제거했습니다. `validateDateFestivalAtInRange`와 수학적으로 동일한 조건을 중복 검증하고 있었습니다.
- `hasTimetableInfo()` 이중 호출을 제거했습니다. `toCommand()`에서 한 번만 계산해 `validate()`에 전달합니다.
- `validateArtistTimetableMapping`에서 `artistIds`가 null일 때 발생하던 NPE를 수정했습니다.
- `containsAll` 이중 체크를 `Set.equals()` 단일 체크로 단순화했습니다.
- `validateStageOrderUnique`에서 List + Set 이중 할당을 `distinct().count()` 하나로 개선했습니다.
- `validate()`를 외부 노출 불필요한 내부 메서드이므로 `public → private`으로 변경했습니다.

## ✨ Notification
- `ErrorMessage`에 페스티벌 검증 전용 에러 코드 11종이 추가되어 클라이언트가 실패 원인을 명확히 구분할 수 있습니다.
- `artistIds`가 null로 들어오던 경우 기존에는 500 에러가 발생했으나, 이제 400 `FESTIVAL_TIMETABLE_ARTIST_NOT_MAPPED`로 정상 처리됩니다.
- 삭제된 `FESTIVAL_TIMETABLE_REQUIRES_DATES` 에러 코드는 어디서도 참조되지 않아 함께 제거했습니다.