### PR TITLE
CSERVER-57 s3 file url 개선 - Phase 2 : Festival 예매처 응답 키 통일

### DIFF
--- a/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalReservationResponse.java
+++ b/src/main/java/org/sopt/confeti/api/performance/dto/response/FestivalReservationResponse.java
@@ -5,7 +5,7 @@ import org.sopt.confeti.api.performance.facade.dto.response.FestivalReservationD
 public record FestivalReservationResponse(
     long reservationId,
     String url,
-    TicketVendorResponse ticketVendorResponse
+    TicketVendorResponse ticketVendor
 ) {
 
     public static FestivalReservationResponse from(FestivalReservationDTO reservationDTO) {


### PR DESCRIPTION
Concert (CSERVER-54)와 동일한 응답 스키마 유지를 위해
FestivalReservationResponse 필드 ticketVendorResponse → ticketVendor 변경.

## 🔊 Summaries
<!-- 본인이 한 작업을 요약해주세요. -->
## 요약

  Festival 예매처 응답의 필드 키를 `ticketVendorResponse` → `ticketVendor`로 변경하여 Concert 응답(`ConcertReservationResponse.ticketVendor`)과 통일합니다. s3 file url 개선 시리즈(Phase 2)의 일관성 정정으로,
  클라이언트 측에서 Concert/Festival reservations를 단일 컴포넌트로 매핑할 수 있도록 합니다.

  ## 변경 사항

  - `FestivalReservationResponse` 필드명 `ticketVendorResponse` → `ticketVendor`
  - record 자동 생성 accessor도 함께 변경됨. 다른 사용처는 없어 추가 변경 불필요.

  ## 영향 (Breaking Change)

  `GET /performances/festivals/{festivalId}` 응답에서 `festival.reservations[]` 자식 필드명이 변경됩니다.

  - Before: `{ reservationId, url, ticketVendorResponse: { ticketVendorId, name, logoUrl } }`
  - After:  `{ reservationId, url, ticketVendor: { ticketVendorId, name, logoUrl } }`

  s3 file url 시리즈(CSERVER-47~56)가 아직 운영(main)에 미배포 상태이므로, 같은 배포 사이클에 함께 가는 변경입니다.

  ## 클라이언트 연동

  별도 PR로 `confeti-client` 측 Festival 타입을 새 키로 정정합니다.

  ## 검증

  - ✅ `./gradlew compileJava compileTestJava` BUILD SUCCESSFUL
  - ✅ `ticketVendorResponse` 잔재 grep 0건

## ✨ Notification 
<!-- 참고할 사항을 작성해주세요. -->
